### PR TITLE
Enforce WebSocket origin checks

### DIFF
--- a/jaws/session_test.go
+++ b/jaws/session_test.go
@@ -310,7 +310,7 @@ func TestSession_Delete(t *testing.T) {
 		return nil
 	})
 
-	conn, resp, err := websocket.Dial(ts.ctx, ts.Url(), nil)
+	conn, resp, err := ts.Dial()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- validate the Origin header before accepting JaWS WebSocket connections
- ensure test helpers send a same-origin header and cover rejection paths for missing or mismatched origins

## Testing
- GOPROXY=direct GOSUMDB=off go test -v -cover ./...


------
https://chatgpt.com/codex/tasks/task_b_68d0ddf11610832cb055aed1c25478b4