### PR TITLE
Improve documentation for core APIs

### DIFF
--- a/jaws/handler.go
+++ b/jaws/handler.go
@@ -2,7 +2,12 @@ package jaws
 
 import "net/http"
 
-// Handler implements ServeHTTP with a jaws.Template
+// Handler is an http.Handler that renders a template for every request.
+//
+// It wires the incoming HTTP request through the JaWS rendering pipeline by
+// creating a Request, instantiating the configured Template and streaming the
+// resulting HTML to the caller. Applications typically obtain a Handler via the
+// Jaws.Handler helper.
 type Handler struct {
 	*Jaws
 	Template
@@ -12,7 +17,11 @@ func (h Handler) ServeHTTP(wr http.ResponseWriter, r *http.Request) {
 	_ = h.Log(h.NewRequest(r).NewElement(h.Template).JawsRender(wr, nil))
 }
 
-// Handler returns a http.Handler using a jaws.Template
+// Handler returns an http.Handler that renders the named template.
+//
+// The returned handler can be registered directly with a router. Each request
+// results in the template being looked up through the configured Template
+// lookupers and rendered with dot as the template data.
 func (jw *Jaws) Handler(name string, dot any) http.Handler {
 	return Handler{Jaws: jw, Template: Template{Name: name, Dot: dot}}
 }

--- a/jaws/jaws.go
+++ b/jaws/jaws.go
@@ -38,8 +38,19 @@ const (
 	DefaultUpdateInterval = time.Millisecond * 100 // Default browser update interval
 )
 
+// Jid is the identifier type used for HTML elements managed by JaWS.
+//
+// It is provided as a convenience alias to the value defined in the jid
+// subpackage so applications do not have to import that package directly
+// when working with element IDs.
 type Jid = jid.Jid // convenience alias
 
+// Jaws holds the server-side state and configuration for a JaWS instance.
+//
+// A single Jaws value coordinates template lookup, session handling and the
+// request lifecycle that keeps the browser and backend synchronized via
+// WebSockets. The zero value is not ready for use; construct instances with
+// New to ensure the helper goroutines and static assets are prepared.
 type Jaws struct {
 	CookieName   string          // Name for session cookies, defaults to "jaws"
 	Logger       Logger          // Optional logger to use
@@ -65,6 +76,11 @@ type Jaws struct {
 	dirtOrder    int
 }
 
+// New allocates a JaWS instance with the default configuration.
+//
+// The returned Jaws value is ready for use: static assets are embedded,
+// internal goroutines are configured and the request pool is primed. Call
+// Close when the instance is no longer needed to free associated resources.
 func New() (jw *Jaws, err error) {
 	var serveJS, serveCSS *staticserve.StaticServe
 	if serveJS, err = staticserve.New("/jaws/.jaws.js", JavascriptText); err == nil {

--- a/jaws/template.go
+++ b/jaws/template.go
@@ -12,6 +12,12 @@ import (
 	"github.com/linkdata/jaws/what"
 )
 
+// Template references a Go html/template to be rendered through JaWS.
+//
+// The Name field identifies the template to execute and Dot contains the data
+// that will be exposed to the template through the With structure constructed
+// during rendering. Additional tag bindings and event handlers can be supplied
+// at render time through the RequestWriter.Template helper.
 type Template struct {
 	Name string // Template name to be looked up using jaws.LookupTemplate()
 	Dot  any    // Dot value to place in With structure
@@ -120,6 +126,10 @@ func (t Template) JawsEvent(e *Element, wht what.What, val string) error {
 	return callEventHandlers(t.Dot, e, wht, val)
 }
 
+// NewTemplate constructs a Template with the provided name and data value.
+//
+// It is a small helper that makes it convenient to use Template values with
+// other JaWS helpers without having to fill the struct fields manually.
 func NewTemplate(name string, dot any) Template {
 	return Template{Name: name, Dot: dot}
 }


### PR DESCRIPTION
## Summary
- document the Jid alias, Jaws type, and New constructor to clarify their responsibilities
- expand the Handler and Handler helper comments to describe how HTTP requests flow through JaWS
- document the Template type and NewTemplate helper for easier discovery in API docs

## Testing
- GOPROXY=direct GOSUMDB=off go test -v -cover ./...


------
https://chatgpt.com/codex/tasks/task_b_68d0efe4a8ec832c9d379234dff6e0d6