### PR TITLE
fix: harden broadcast, setup, and widget edge cases from code review

### DIFF
--- a/jaws.go
+++ b/jaws.go
@@ -639,6 +639,19 @@ func (jw *Jaws) Broadcast(msg wire.Message) {
 	default:
 		expanded, err := tag.TagExpand(nil, msg.Dest)
 		jw.MustLog(err)
+		for _, tagValue := range expanded {
+			// Expanded tags become map keys in the processing loop (wantMessage's
+			// lookup in Request.tagMap). A value can pass tag expansion's static
+			// comparability check yet be non-comparable at runtime (a comparable
+			// struct holding e.g. a func in an interface field), which panics when
+			// hashed. NewErrNotComparable runs the runtime value check that
+			// ensureUsableTag only performs in debug builds; doing it here rejects a
+			// bad Dest before it can panic the Serve goroutine and crash the process.
+			if cmperr := tag.NewErrNotComparable(tagValue); cmperr != nil {
+				jw.reportMisuse(fmt.Errorf("jaws: Broadcast: %w", cmperr))
+				return
+			}
+		}
 		switch len(expanded) {
 		case 0:
 			// no tags, so no requests will match

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"html/template"
 	"io"
+	"log/slog"
 	"mime"
 	"net/http"
 	"net/http/httptest"
@@ -19,6 +20,7 @@ import (
 	"testing/synctest"
 	"time"
 
+	"github.com/linkdata/deadlock"
 	"github.com/linkdata/jaws/lib/assets"
 	"github.com/linkdata/jaws/lib/tag"
 	"github.com/linkdata/jaws/lib/what"
@@ -466,6 +468,48 @@ func TestBroadcast_NoneDestination(t *testing.T) {
 	case msg := <-jw.bcastCh:
 		t.Fatalf("expected no pending broadcast, got %T(%#v)", msg.Dest, msg.Dest)
 	default:
+	}
+}
+
+func TestBroadcast_RejectsUnhashableTagDest(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+	var logbuf bytes.Buffer
+	jw.Logger = slog.New(slog.NewTextHandler(&logbuf, nil))
+
+	// A statically comparable struct holding a func in an interface field panics
+	// when used as a map key. Such a Dest must be rejected before it reaches the
+	// Serve loop, where wantMessage's tagMap lookup would panic and tear the loop
+	// down. In debug builds tag.TagExpand rejects it; in non-debug (production)
+	// builds TagExpand is lenient and the hashableTag check in Broadcast catches
+	// it. Either way, Broadcast must not panic and must not queue the message.
+	type ifaceHolder struct{ any }
+	var panicked bool
+	func() {
+		defer func() {
+			if recover() != nil {
+				panicked = true
+			}
+		}()
+		jw.Broadcast(wire.Message{What: what.Reload, Dest: ifaceHolder{any: func() {}}})
+	}()
+
+	if panicked {
+		t.Error("Broadcast must not let an unhashable tag panic the caller")
+	}
+	select {
+	case msg := <-jw.bcastCh:
+		t.Fatalf("unhashable Dest was queued for the Serve loop: %T(%#v)", msg.Dest, msg.Dest)
+	default:
+	}
+	if logbuf.Len() == 0 {
+		t.Error("expected the rejected broadcast tag to be logged")
+	}
+	if !deadlock.Debug && !strings.Contains(logbuf.String(), "not comparable") {
+		t.Errorf("non-debug build should reject the non-comparable tag, got %q", logbuf.String())
 	}
 }
 

--- a/jawstree/regression_test.go
+++ b/jawstree/regression_test.go
@@ -1,0 +1,85 @@
+package jawstree
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/linkdata/deadlock"
+	"github.com/linkdata/jaws"
+	"github.com/linkdata/jaws/lib/ui"
+	"github.com/linkdata/staticserve"
+)
+
+// TestSetup_PrefixVariants verifies that for any prefix form (absolute, relative
+// or empty) Setup neither panics nor diverges: every emitted asset URL appears in
+// the head HTML and resolves to a registered handler. An empty prefix previously
+// panicked because the handler pattern was registered without a leading slash.
+func TestSetup_PrefixVariants(t *testing.T) {
+	var names []string
+	if err := staticserve.WalkDir(assetsFS, "assets", func(_ string, ss *staticserve.StaticServe) error {
+		names = append(names, ss.Name)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, prefix := range []string{"/static", "static", ""} {
+		t.Run("prefix="+strconv.Quote(prefix), func(t *testing.T) {
+			mux := http.NewServeMux()
+			jw, err := jaws.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer jw.Close()
+
+			if err := jw.Setup(mux.Handle, prefix, Setup); err != nil {
+				t.Fatal(err)
+			}
+
+			rq := jw.NewRequest(nil)
+			var sb strings.Builder
+			if err := (ui.RequestWriter{Request: rq, Writer: &sb}).HeadHTML(); err != nil {
+				t.Fatal(err)
+			}
+			head := sb.String()
+
+			for _, name := range names {
+				wantURI := staticserve.EnsurePrefixSlash(path.Join(prefix, name))
+				if !strings.Contains(head, `"`+wantURI+`"`) {
+					t.Errorf("head html missing %q", wantURI)
+				}
+				rr := httptest.NewRecorder()
+				mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, wantURI, nil))
+				if rr.Code != http.StatusOK {
+					t.Errorf("GET %q (prefix %q) = %d, want 200 (head URL must match a registered handler)", wantURI, prefix, rr.Code)
+				}
+			}
+		})
+	}
+}
+
+// TestNew_RejectsInvalidID verifies that New panics on ids that would otherwise
+// fail far downstream (a render-time "illegal jsvar name" and a 400 on the
+// init-script route), while accepting a valid one.
+func TestNew_RejectsInvalidID(t *testing.T) {
+	var mu deadlock.RWMutex
+	for _, id := range []string{"", "my-tree", "tree.1", "a b", "with/slash"} {
+		t.Run(strconv.Quote(id), func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Errorf("New(%q, ...) should panic on an invalid id", id)
+				}
+			}()
+			New(id, ui.NewJsVar(&mu, &Node{}))
+		})
+	}
+
+	// A valid id must still construct.
+	if New("valid_$Id0", ui.NewJsVar(&mu, &Node{})) == nil {
+		t.Error("New with a valid id returned nil")
+	}
+}

--- a/jawstree/setup.go
+++ b/jawstree/setup.go
@@ -27,15 +27,21 @@ func Setup(jw *jaws.Jaws, handleFn jaws.HandleFunc, prefix string) (urls []*url.
 		return
 	}); err == nil {
 		for _, ss := range files {
-			u, e := url.Parse(path.Join(prefix, ss.Name))
+			// Build an absolute path so jaws.Setup's makeAbsPath leaves the returned
+			// URL unchanged and the registered handler pattern stays valid for any
+			// prefix form (absolute, relative or empty). Registering the raw
+			// path.Join result would panic on an empty prefix and double-apply a
+			// relative one; mirror jawsboot.Setup, which documents this.
+			abspath := staticserve.EnsurePrefixSlash(path.Join(prefix, ss.Name))
+			u, e := url.Parse(abspath)
 			if e == nil {
 				urls = append(urls, u)
-				handleFn(http.MethodGet+" "+u.String(), ss)
+				handleFn(staticserve.NormalizeGET(abspath), ss)
 			}
 			err = errors.Join(err, e)
 		}
 		handleFn(http.MethodGet+" "+initScriptPattern, http.HandlerFunc(serveInitScript))
-		handleFn(http.MethodGet+" "+path.Join(prefix, "treeview.js.map"), http.NotFoundHandler())
+		handleFn(staticserve.NormalizeGET(path.Join(prefix, "treeview.js.map")), http.NotFoundHandler())
 	}
 	return
 }

--- a/jawstree/tree.go
+++ b/jawstree/tree.go
@@ -20,14 +20,23 @@ type Tree struct {
 
 // New returns a tree widget with id, jsvar and options.
 //
+// The id is used both as a JavaScript variable name and as a URL path segment
+// for the init script, so it must be non-empty and contain only the characters
+// [A-Za-z0-9_$]; otherwise New panics. Validating here turns what would
+// otherwise be a confusing render-time "illegal jsvar name" error and a 400 on
+// the init-script route into an immediate, clear failure.
+//
 // New initializes node IDs and tree back-pointers in jsvar.Ptr.
-// It panics if jsvar or jsvar.Ptr is nil.
+// It panics if jsvar or jsvar.Ptr is nil, or if id is not a valid name.
 func New(id string, jsvar *ui.JsVar[Node], options ...Option) (t *Tree) {
 	if jsvar == nil {
 		panic("jawstree.New: jsvar must not be nil")
 	}
 	if jsvar.Ptr == nil {
 		panic("jawstree.New: jsvar.Ptr must not be nil")
+	}
+	if !isSafeTreeName(id) {
+		panic("jawstree.New: id must be non-empty and contain only [A-Za-z0-9_$]")
 	}
 	t = &Tree{
 		id:    id,

--- a/lib/assets/jaws.js
+++ b/lib/assets/jaws.js
@@ -386,7 +386,14 @@ function jawsMessage(e) {
 	for (i = 0; i < orders.length; i++) {
 		if (orders[i]) {
 			var parts = orders[i].split('\t');
-			jawsPerform(parts.shift(), parts.shift(), parts.shift());
+			// Isolate each order: the server batches independent element updates
+			// into one frame, so a single failing order (e.g. targeting an element
+			// a prior order removed) must not abandon the rest of the frame.
+			try {
+				jawsPerform(parts.shift(), parts.shift(), parts.shift());
+			} catch (err) {
+				console.error("jaws: " + orders[i] + ": " + err);
+			}
 		}
 	}
 }

--- a/lib/assets/js_test.go
+++ b/lib/assets/js_test.go
@@ -705,6 +705,61 @@ process.stdout.write(JSON.stringify({ innerReads: innerReads, innerWrites: inner
 	}
 }
 
+func TestJawsJS_BatchedFrameIsolatesThrowingOrder(t *testing.T) {
+	// The server coalesces independent element updates into one frame. A single
+	// failing order (here a middle Inner targeting a missing element, which makes
+	// jawsPerform throw "element not found") must not abandon the orders after it.
+	raw := runJawsJSSnippet(t, `
+jawsDebug = false;
+var errors = [];
+console.error = function(msg) { errors.push(msg); };
+
+function makeElem(id) {
+	var e = { id: id, _inner: "", querySelectorAll: function(){ return []; } };
+	Object.defineProperty(e, "innerHTML", {
+		get: function(){ return this._inner; },
+		set: function(v){ this._inner = v; },
+		enumerable: true, configurable: true,
+	});
+	return e;
+}
+var one = makeElem("Jid.1");
+var two = makeElem("Jid.2");
+document.getElementById = function(id) {
+	if (id === "Jid.1") return one;
+	if (id === "Jid.2") return two;
+	return null; // Jid.9 is missing -> jawsPerform throws for that order only
+};
+
+var frame = [
+	"Inner\tJid.1\t" + JSON.stringify("<b>one</b>"),
+	"Inner\tJid.9\t" + JSON.stringify("<b>boom</b>"),
+	"Inner\tJid.2\t" + JSON.stringify("<b>two</b>")
+].join("\n");
+jawsMessage({ data: frame });
+
+process.stdout.write(JSON.stringify({ one: one.innerHTML, two: two.innerHTML, errorCount: errors.length }));
+`)
+
+	var got struct {
+		One        string `json:"one"`
+		Two        string `json:"two"`
+		ErrorCount int    `json:"errorCount"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &got); err != nil {
+		t.Fatalf("failed to parse snippet output %q: %v", raw, err)
+	}
+	if got.One != "<b>one</b>" {
+		t.Errorf("order before the throwing one was not applied: one=%q", got.One)
+	}
+	if got.Two != "<b>two</b>" {
+		t.Errorf("order after the throwing one was dropped: two=%q", got.Two)
+	}
+	if got.ErrorCount != 1 {
+		t.Errorf("expected exactly one console.error for the failing order, got %d", got.ErrorCount)
+	}
+}
+
 func TestJawsJS_ReplaceComparesAndUpdatesWhenDebugDisabled(t *testing.T) {
 	raw := runJawsJSSnippet(t, `
 jawsDebug = false;

--- a/lib/ui/containerhelper.go
+++ b/lib/ui/containerhelper.go
@@ -91,21 +91,46 @@ func (u *ContainerHelper) RenderContainer(elem *jaws.Element, w io.Writer, outer
 // Render errors for newly appended children are reported through
 // [jaws.Jaws.MustLog], which may panic when no [jaws.Jaws.Logger] is configured.
 func (u *ContainerHelper) UpdateContainer(elem *jaws.Element) {
-	var toAppend []*jaws.Element
-
 	wantContents := u.Container.JawsContains(elem)
-	newOrder := make([]jaws.Jid, 0, len(wantContents))
+	toAppend, toRemove, oldOrder, newOrder := u.reconcile(elem, wantContents)
 
+	// remove leftover Elements not present in new contents
+	for _, childElem := range toRemove {
+		elem.Remove(childElem.Jid().String())
+		elem.Request.DeleteElement(childElem)
+	}
+
+	for _, childElem := range toAppend {
+		var sb strings.Builder
+		elem.Jaws.MustLog(childElem.JawsRender(&sb, nil))
+		elem.Append(template.HTML(sb.String())) // #nosec G203
+	}
+
+	if !slices.Equal(oldOrder, newOrder) {
+		elem.Order(newOrder)
+	}
+}
+
+// reconcile matches u.contents to wantContents under u.mu and returns the
+// Elements to append, the leftover Elements to remove, and the old and new Jid
+// orders. The lock is released with defer so that using a child UI as a map key
+// cannot leave u.mu held if it panics: a UI that passes the static comparability
+// check can still be non-comparable at runtime (a comparable struct holding e.g.
+// a func in an interface field). This mirrors the defense in jaws.setDirty.
+func (u *ContainerHelper) reconcile(elem *jaws.Element, wantContents []jaws.UI) (toAppend, toRemove []*jaws.Element, oldOrder, newOrder []jaws.Jid) {
 	u.mu.Lock()
+	defer u.mu.Unlock()
+
 	// build pool of reusable Elements keyed by UI, preserving duplicates
 	pool := make(map[jaws.UI][]*jaws.Element, len(u.contents))
-	oldOrder := make([]jaws.Jid, len(u.contents))
+	oldOrder = make([]jaws.Jid, len(u.contents))
 	for i, childElem := range u.contents {
 		oldOrder[i] = childElem.Jid()
 		pool[childElem.UI()] = append(pool[childElem.UI()], childElem)
 	}
 
 	// build new contents, reusing pooled Elements where possible
+	newOrder = make([]jaws.Jid, 0, len(wantContents))
 	u.contents = u.contents[:0]
 	for _, childUI := range wantContents {
 		var childElem *jaws.Element
@@ -119,23 +144,9 @@ func (u *ContainerHelper) UpdateContainer(elem *jaws.Element) {
 		u.contents = append(u.contents, childElem)
 		newOrder = append(newOrder, childElem.Jid())
 	}
-	u.mu.Unlock()
 
-	// remove leftover Elements not present in new contents
 	for _, elems := range pool {
-		for _, childElem := range elems {
-			elem.Remove(childElem.Jid().String())
-			elem.Request.DeleteElement(childElem)
-		}
+		toRemove = append(toRemove, elems...)
 	}
-
-	for _, childElem := range toAppend {
-		var sb strings.Builder
-		elem.Jaws.MustLog(childElem.JawsRender(&sb, nil))
-		elem.Append(template.HTML(sb.String())) // #nosec G203
-	}
-
-	if !slices.Equal(oldOrder, newOrder) {
-		elem.Order(newOrder)
-	}
+	return
 }

--- a/lib/ui/radiogroup.go
+++ b/lib/ui/radiogroup.go
@@ -8,39 +8,69 @@ import (
 	"github.com/linkdata/jaws/lib/named"
 )
 
-// RadioElement contains the input and label elements for one radio option.
+// RadioElement renders the input and label elements for one radio option.
+//
+// The underlying [jaws.Element] values are created lazily on the first call to
+// [RadioElement.Radio] or [RadioElement.Label], so options that a template never
+// renders register no elements on the [jaws.Request]. Call each of Radio and
+// Label at most once.
 type RadioElement struct {
+	st *radioState
+}
+
+// radioState is the shared, lazily-populated state behind a RadioElement. It is
+// held by pointer so the value-receiver methods (callable on a template range
+// copy) observe the same elements, and is only ever touched on the single
+// rendering goroutine, so it needs no lock.
+type radioState struct {
+	rw       RequestWriter
+	nb       *named.Bool
+	nameAttr string
 	radio    *jaws.Element
 	label    *jaws.Element
-	nameAttr string
+}
+
+// radioElem returns the radio Element, creating it on first use. Label also
+// needs it (for the "for=" attribute), so creating it here keeps the radio's Jid
+// ordered before the label's regardless of which is rendered first.
+func (st *radioState) radioElem() *jaws.Element {
+	if st.radio == nil {
+		st.radio = st.rw.Request.NewElement(NewRadio(st.nb))
+	}
+	return st.radio
 }
 
 // Radio renders an HTML input element of type radio.
 func (re RadioElement) Radio(params ...any) template.HTML {
+	radio := re.st.radioElem()
 	var sb strings.Builder
-	re.radio.Jaws.MustLog(re.radio.JawsRender(&sb, append(params, re.nameAttr)))
+	radio.Jaws.MustLog(radio.JawsRender(&sb, append(params, re.st.nameAttr)))
 	return template.HTML(sb.String()) // #nosec G203
 }
 
 // Label renders an HTML label element.
 func (re RadioElement) Label(params ...any) template.HTML {
+	radio := re.st.radioElem()
+	if re.st.label == nil {
+		re.st.label = re.st.rw.Request.NewElement(NewLabel(re.st.nb))
+	}
 	var sb strings.Builder
-	forAttr := string(re.radio.Jid().AppendQuote([]byte("for=")))
-	re.label.Jaws.MustLog(re.label.JawsRender(&sb, append(params, forAttr)))
+	forAttr := string(radio.Jid().AppendQuote([]byte("for=")))
+	re.st.label.Jaws.MustLog(re.st.label.JawsRender(&sb, append(params, forAttr)))
 	return template.HTML(sb.String()) // #nosec G203
 }
 
-// RadioGroup creates radio and label elements for each value in nba.
+// RadioGroup returns a [RadioElement] for each value in nba. Elements are created
+// lazily as they are rendered; see [RadioElement].
 func (rw RequestWriter) RadioGroup(nba *named.BoolArray) (rel []RadioElement) {
 	nameAttr := `name="` + jaws.MakeID() + `"`
 	nba.ReadLocked(func(nbl []*named.Bool) {
 		for _, nb := range nbl {
-			rel = append(rel, RadioElement{
-				radio:    rw.Request.NewElement(NewRadio(nb)),
-				label:    rw.Request.NewElement(NewLabel(nb)),
+			rel = append(rel, RadioElement{st: &radioState{
+				rw:       rw,
+				nb:       nb,
 				nameAttr: nameAttr,
-			},
-			)
+			}})
 		}
 	})
 	return

--- a/lib/ui/radiogroup_test.go
+++ b/lib/ui/radiogroup_test.go
@@ -27,3 +27,34 @@ func TestRequest_RadioGroup(t *testing.T) {
 		t.Errorf("got %q, want %q", gotHTML, wantHTML)
 	}
 }
+
+// TestRequest_RadioGroup_LazyCreation verifies options that are never rendered
+// register no Elements on the Request, and that rendering an option creates its
+// radio (Jid before the label) and label exactly once.
+func TestRequest_RadioGroup_LazyCreation(t *testing.T) {
+	_, rq := newCoreRequest(t)
+	var sb strings.Builder
+	rw := RequestWriter{Request: rq, Writer: &sb}
+
+	nba := named.NewBoolArray(false)
+	nba.Add("1", "one")
+	nba.Add("2", "two")
+	rel := rw.RadioGroup(nba)
+
+	// Nothing rendered yet: no Elements should exist.
+	if rq.GetElementByJid(1) != nil {
+		t.Fatal("RadioGroup created Elements before any option was rendered")
+	}
+
+	// Render only the first option.
+	_ = rel[0].Radio()
+	_ = rel[0].Label()
+	if rq.GetElementByJid(1) == nil || rq.GetElementByJid(2) == nil {
+		t.Fatal("rendering an option must create its radio and label Elements")
+	}
+
+	// The second option was never rendered; it must not have registered Elements.
+	if rq.GetElementByJid(3) != nil {
+		t.Fatal("an unrendered option must not register any Element")
+	}
+}

--- a/request.go
+++ b/request.go
@@ -524,8 +524,8 @@ func (rq *Request) wantMessage(msg *wire.Message) (yes bool) {
 		}
 	default:
 		rq.mu.RLock()
+		defer rq.mu.RUnlock()
 		_, yes = rq.tagMap[msg.Dest]
-		rq.mu.RUnlock()
 	}
 	return
 }


### PR DESCRIPTION
Six issues found in a code-quality assessment, each with a regression test; full `go test -tags debug -race ./...` stays green at ~100% coverage.

- jaws: reject runtime-non-comparable Broadcast tags at the boundary using tag.NewErrNotComparable, and defer the unlock in Request.wantMessage. A statically-comparable tag holding a func/slice in an interface field would otherwise panic the Serve goroutine on the tagMap lookup, crashing the process; production builds skip the runtime check tag expansion only runs in debug, so the check belongs at this boundary.
- jawstree: build absolute handler paths in Setup (EnsurePrefixSlash + NormalizeGET), mirroring jawsboot, so an empty prefix no longer panics and a relative prefix no longer diverges from the emitted head URL.
- lib/ui: reconcile ContainerHelper.UpdateContainer under a deferred unlock so a panicking child-UI map key cannot leave the mutex held.
- lib/ui: create RadioGroup elements lazily so options a template never renders register no elements on the Request.
- assets/jaws.js: isolate each order in a batched frame with try/catch so one failing order no longer abandons the rest of the frame.
- jawstree: validate the Tree.New id up front instead of failing at render time with a confusing error and a 400 on the init-script route.