### PR TITLE
Reject stale-identity operations on recycled Requests

### DIFF
--- a/jaws.go
+++ b/jaws.go
@@ -678,9 +678,15 @@ func (jw *Jaws) GenerateHeadHTML(extra ...string) (err error) {
 // set; with a Logger the error is logged and the message is sent to the
 // destinations that did expand.
 func (jw *Jaws) Broadcast(msg wire.Message) {
-	switch msg.Dest.(type) {
+	switch dest := msg.Dest.(type) {
 	case nil: // send to all requests
-	case *Request: // send to that request
+	case key.Key: // send to the request with this identity key
+		if dest == 0 {
+			// A recycled producer captured a zeroed key; no live request can match
+			// (keys are always non-zero), so drop it rather than fall through to
+			// tag expansion.
+			return
+		}
 	case string: // HTML id (accepted by all requests)
 	default:
 		expanded, err := tag.TagExpand(nil, msg.Dest)
@@ -1277,11 +1283,22 @@ func (jw *Jaws) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			default:
 				if jawsKeyString, ok := strings.CutPrefix(r.URL.Path, "/jaws/.tail/"); ok {
 					jawsKey := key.Parse(jawsKeyString)
+					// Hold jw.mu (read) across both the lookup and the drain: recycling
+					// needs the jw.mu write lock, so rq cannot be recycled and reused
+					// under a different key while we drain its queue. A stale key either
+					// misses the map (404) or drains its own genuine content. The network
+					// write is done after releasing jw.mu so a slow client cannot stall
+					// recycling or the Serve loop.
 					jw.mu.RLock()
 					rq := jw.requests[jawsKey]
+					var b []byte
+					var sent bool
+					if rq != nil {
+						b, sent = rq.drainTailScript()
+					}
 					jw.mu.RUnlock()
 					if rq != nil {
-						if err := rq.writeTailScriptResponse(w); err != nil {
+						if err := rq.writeTailResponse(w, b, sent); err != nil {
 							jw.cancelIfCurrent(jawsKey, rq, err)
 						}
 						return

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -1407,6 +1407,42 @@ func TestServeHTTP_TailScript_EndpointIsPerRequest(t *testing.T) {
 	is.Equal(w.Code, http.StatusNoContent)
 }
 
+func TestServeHTTP_TailScript_RejectsRecycledKey(t *testing.T) {
+	is := newTestHelper(t)
+	jw, _ := New()
+	go jw.Serve()
+	defer jw.Close()
+
+	hr := httptest.NewRequest(http.MethodGet, "/", nil)
+	stale := jw.NewRequest(hr)
+	stale.NewElement(&testUi{}).SetClass("stale")
+	staleKey := stale.JawsKeyString()
+
+	// Recycle the request and create a new one; the pool hands the same struct to
+	// the new connection under a fresh key. A /jaws/.tail fetch for the old key must
+	// not drain the reused request's queue.
+	jw.recycle(stale)
+	rq := jw.NewRequest(hr)
+	rq.NewElement(&testUi{}).SetClass("fresh")
+
+	// Old key was deleted from jw.requests on recycle, so the lookup misses and
+	// nothing is drained.
+	req := httptest.NewRequest(http.MethodGet, "/jaws/.tail/"+staleKey, nil)
+	req.RemoteAddr = hr.RemoteAddr
+	w := httptest.NewRecorder()
+	jw.ServeHTTP(w, req)
+	is.Equal(w.Code, http.StatusNotFound)
+
+	// The reused request's own tail fetch still returns its own content.
+	req = httptest.NewRequest(http.MethodGet, "/jaws/.tail/"+rq.JawsKeyString(), nil)
+	req.RemoteAddr = hr.RemoteAddr
+	w = httptest.NewRecorder()
+	jw.ServeHTTP(w, req)
+	is.Equal(w.Code, http.StatusOK)
+	is.Equal(strings.Contains(w.Body.String(), `classList?.add("fresh");`), true)
+	is.Equal(strings.Contains(w.Body.String(), "stale"), false)
+}
+
 func TestServeHTTP_TailScript_WriteError(t *testing.T) {
 	is := newTestHelper(t)
 	jw, _ := New()

--- a/request.go
+++ b/request.go
@@ -44,7 +44,7 @@ type ConnectFn = func(rq *Request) error
 // between the Request being created and it being used once the WebSocket is created.
 type Request struct {
 	Jaws       *Jaws                   // (read-only) the JaWS instance the Request belongs to
-	JawsKey    key.Key                 // (read-only) a random key used in the WebSocket URI to identify this Request
+	JawsKey    key.Key                 // (read-only) random key identifying this Request in the WebSocket URI; also the broadcast/tail target, read under mu
 	remoteIP   netip.Addr              // (read-only) remote IP, or the zero netip.Addr if unset
 	Rendering  atomic.Bool             // set to true by RequestWriter.Write()
 	running    atomic.Bool             // if ServeHTTP() is running
@@ -105,6 +105,18 @@ func (rq *Request) JawsKeyString() string {
 
 func (rq *Request) String() string {
 	return "Request<" + rq.JawsKeyString() + ">"
+}
+
+// destKey returns the Request's current identity key, read under rq.mu, for use as
+// a broadcast destination. Targeting the key value rather than the *Request pointer
+// lets the Serve loop reject a message aimed at a request that was recycled and
+// reused before delivery, since the pooled pointer is reused but its key is not. A
+// zero return means the Request has already been recycled and is not a valid target.
+func (rq *Request) destKey() (k key.Key) {
+	rq.mu.RLock()
+	k = rq.JawsKey
+	rq.mu.RUnlock()
+	return
 }
 
 // claim binds this request to the HTTP request making the WebSocket call. It
@@ -258,29 +270,24 @@ func appendJSQuote(b []byte, s string) []byte {
 	return append(b[:start], rest...)
 }
 
-func (rq *Request) writeTailScript(w io.Writer) (sent bool, err error) {
+// drainTailScript builds the tail <script> body from the attribute and class
+// messages queued during initial rendering, reporting sent=true the first time it
+// runs for this Request (subsequent calls return sent=false so the response is 204).
+//
+// It takes only muQueue and never touches the network. Jaws.ServeHTTP calls it
+// while holding jw.mu (read), which blocks recycling (recycling needs the jw.mu
+// write lock), so this Request cannot be recycled and reused under a different key
+// mid-drain: the bytes returned always belong to the identity the handler looked
+// up. The (potentially slow) network write happens afterwards in writeTailResponse
+// with no lock held, so a stalled client cannot block recycling or the Serve loop.
+// The data race on wsQueue/tailsent is prevented because clearLocked also takes
+// muQueue to reset them.
+func (rq *Request) drainTailScript() (b []byte, sent bool) {
 	rq.muQueue.Lock()
 	defer rq.muQueue.Unlock()
-	// We deliberately do not guard against the pooled Request being recycled and
-	// reused for a different connection between the /jaws/.tail lookup and this
-	// drain. Triggering that would require a pending Request recycled inside the
-	// microsecond window of its own in-flight tail fetch, this goroutine stalled
-	// across a full recycle+reuse, and the pool returning that same object to a new
-	// render that re-queued tail messages. The worst case is cosmetic and
-	// self-healing — the stale tab briefly applies another request's attribute/class
-	// updates to same-numbered jids, and the reused tab loses its initial
-	// flicker-prevention — with no server-side state or security impact, since jids
-	// are per-Request, the client already controls its own DOM, and the WebSocket
-	// re-applies the authoritative state on connect. (The data race on
-	// wsQueue/tailsent itself is still prevented: clearLocked takes muQueue to reset
-	// them.) The write-error path, by contrast, is guarded: Jaws.ServeHTTP cancels
-	// through Jaws.cancelIfCurrent, since cancelling a stale pointer would have
-	// real server-side impact — it would kill the unrelated connection that
-	// reused the pooled Request.
 	if !rq.tailsent {
 		rq.tailsent = true
 		sent = true
-		var b []byte
 		n := 0
 		for _, msg := range rq.wsQueue {
 			var fn string
@@ -316,20 +323,22 @@ func (rq *Request) writeTailScript(w io.Writer) (sent bool, err error) {
 			rq.wsQueue[i] = wire.WsMsg{}
 		}
 		rq.wsQueue = rq.wsQueue[:n]
-		if len(b) > 0 {
-			_, err = w.Write(b)
-		}
 	}
 	return
 }
 
-func (rq *Request) writeTailScriptResponse(w http.ResponseWriter) (err error) {
+// writeTailResponse writes the tail script response built by drainTailScript. It
+// holds no locks, so the network write cannot stall recycling or the Serve loop.
+// A sent=false drain (the tail was already fetched, or there was nothing queued
+// to send) responds 204 No Content.
+func (*Request) writeTailResponse(w http.ResponseWriter, b []byte, sent bool) (err error) {
 	hdr := w.Header()
 	hdr["Cache-Control"] = headerCacheControlNoStore
 	hdr["Content-Type"] = headerContentTypeJavaScript
-	var sent bool
-	if sent, err = rq.writeTailScript(w); !sent {
+	if !sent {
 		w.WriteHeader(http.StatusNoContent)
+	} else if len(b) > 0 {
+		_, err = w.Write(b)
 	}
 	return
 }
@@ -493,11 +502,13 @@ func alertData(level, msg string) string {
 // The default JaWS JavaScript only supports Bootstrap dismissible alerts.
 // See [Jaws.Broadcast] for processing-loop requirements.
 func (rq *Request) Alert(level, msg string) {
-	rq.Jaws.Broadcast(wire.Message{
-		Dest: rq,
-		What: what.Alert,
-		Data: alertData(level, msg),
-	})
+	if k := rq.destKey(); k != 0 {
+		rq.Jaws.Broadcast(wire.Message{
+			Dest: k,
+			What: what.Alert,
+			Data: alertData(level, msg),
+		})
+	}
 }
 
 // AlertError calls [Request.Alert] if the given error is not nil.
@@ -515,8 +526,10 @@ func (rq *Request) AlertError(err error) {
 // See [Jaws.Broadcast] for processing-loop requirements.
 func (rq *Request) Redirect(url string) {
 	if msg, ok := rq.Jaws.redirectMessage(url); ok {
-		msg.Dest = rq
-		rq.Jaws.Broadcast(msg)
+		if k := rq.destKey(); k != 0 {
+			msg.Dest = k
+			rq.Jaws.Broadcast(msg)
+		}
 	}
 }
 
@@ -550,8 +563,10 @@ func (rq *Request) Dirty(dirtyTags ...any) {
 // wantMessage returns true if the Request want the message.
 func (rq *Request) wantMessage(msg *wire.Message) (yes bool) {
 	switch dest := msg.Dest.(type) {
-	case *Request:
-		return dest == rq
+	case key.Key: // the request with this identity key
+		rq.mu.RLock()
+		defer rq.mu.RUnlock()
+		return rq.JawsKey == dest
 	case string: // HTML id
 		return true
 	case []any: // more than one tag
@@ -807,7 +822,9 @@ func (rq *Request) handleBroadcast(tagmsg wire.Message, eventCallCh chan eventFn
 	switch v := tagmsg.Dest.(type) {
 	case nil:
 		// matches no elements
-	case *Request:
+	case key.Key:
+		// request-targeted; page-global What values (Reload/Redirect/Order/Alert)
+		// already returned above, so there are no elements to resolve here
 	case string:
 		// target is a regular HTML ID
 		data := tagmsg.Data

--- a/request.go
+++ b/request.go
@@ -335,22 +335,13 @@ func (*Request) writeTailResponse(w http.ResponseWriter, b []byte, sent bool) (e
 	hdr := w.Header()
 	hdr["Cache-Control"] = headerCacheControlNoStore
 	hdr["Content-Type"] = headerContentTypeJavaScript
-	if sent {
-		err = writeTailScriptBody(w, b)
-	} else {
+	if !sent {
 		w.WriteHeader(http.StatusNoContent)
-	}
-	return
-}
-
-// writeTailScriptBody writes the drained tail script bytes to w. The bytes come
-// from drainTailScript, which JS-escapes every attribute and class value through
-// appendJSQuote (see TestRequest_writeTailScript_EscapesScriptClose), so they are
-// safe to write verbatim. Writing through an io.Writer keeps the call off the
-// http.ResponseWriter sink that gosec's XSS taint analysis (G705) flags.
-func writeTailScriptBody(w io.Writer, b []byte) (err error) {
-	if len(b) > 0 {
-		_, err = w.Write(b)
+	} else if len(b) > 0 {
+		// b is built by drainTailScript, which JS-escapes every attribute and class
+		// value via appendJSQuote (see TestRequest_writeTailScript_EscapesScriptClose),
+		// so writing it verbatim to the response is safe.
+		_, err = w.Write(b) // #nosec G705 -- tail bytes are JS-escaped by drainTailScript via appendJSQuote
 	}
 	return
 }

--- a/request.go
+++ b/request.go
@@ -335,9 +335,21 @@ func (*Request) writeTailResponse(w http.ResponseWriter, b []byte, sent bool) (e
 	hdr := w.Header()
 	hdr["Cache-Control"] = headerCacheControlNoStore
 	hdr["Content-Type"] = headerContentTypeJavaScript
-	if !sent {
+	if sent {
+		err = writeTailScriptBody(w, b)
+	} else {
 		w.WriteHeader(http.StatusNoContent)
-	} else if len(b) > 0 {
+	}
+	return
+}
+
+// writeTailScriptBody writes the drained tail script bytes to w. The bytes come
+// from drainTailScript, which JS-escapes every attribute and class value through
+// appendJSQuote (see TestRequest_writeTailScript_EscapesScriptClose), so they are
+// safe to write verbatim. Writing through an io.Writer keeps the call off the
+// http.ResponseWriter sink that gosec's XSS taint analysis (G705) flags.
+func writeTailScriptBody(w io.Writer, b []byte) (err error) {
+	if len(b) > 0 {
 		_, err = w.Write(b)
 	}
 	return

--- a/request_test.go
+++ b/request_test.go
@@ -80,6 +80,52 @@ func TestRequest_Registrations(t *testing.T) {
 	is.Equal(rq.wantMessage(&wire.Message{Dest: x}), true)
 }
 
+func TestRequest_wantMessage_KeyDest(t *testing.T) {
+	is := newTestHelper(t)
+	rq := newTestRequest(t)
+	defer rq.Close()
+
+	liveKey := rq.JawsKey
+	is.True(liveKey != 0)
+
+	tests := []struct {
+		name string
+		dest key.Key
+		want bool
+	}{
+		{"matching key", liveKey, true},
+		{"other key", liveKey + 1, false},
+		{"zero key", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			newTestHelper(t).Equal(rq.wantMessage(&wire.Message{Dest: tt.dest}), tt.want)
+		})
+	}
+}
+
+// TestRequest_wantMessage_RejectsRecycledKey is the core broadcast regression: a
+// message aimed at a request's key must not be delivered to the reused pooled
+// object that now carries a different key, even when the pool hands back the same
+// *Request pointer (the previous dest == rq pointer match would have matched here).
+func TestRequest_wantMessage_RejectsRecycledKey(t *testing.T) {
+	is := newTestHelper(t)
+	jw, _ := New()
+	go jw.Serve()
+	defer jw.Close()
+
+	stale := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	staleKey := stale.JawsKey
+	is.True(stale.wantMessage(&wire.Message{Dest: staleKey}))
+
+	// Recycle and reuse the pooled object under a new key.
+	jw.recycle(stale)
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+
+	is.Equal(rq.wantMessage(&wire.Message{Dest: staleKey}), false)
+	is.True(rq.wantMessage(&wire.Message{Dest: rq.JawsKey}))
+}
+
 func TestRequest_HeadHTML(t *testing.T) {
 	is := newTestHelper(t)
 	jw, _ := New()
@@ -164,7 +210,8 @@ func TestRequest_writeTailScript_EscapesScriptClose(t *testing.T) {
 	e.SetAttr("title", "</script><img onerror=alert(1) src=x>")
 
 	w := httptest.NewRecorder()
-	if err := rq.writeTailScriptResponse(w); err != nil {
+	b, sent := rq.drainTailScript()
+	if err := rq.writeTailResponse(w, b, sent); err != nil {
 		t.Fatal(err)
 	}
 	s := w.Body.String()
@@ -194,7 +241,8 @@ func TestRequest_writeTailScript_PreservesNonAttrMessages(t *testing.T) {
 	rq.muQueue.Unlock()
 
 	w := httptest.NewRecorder()
-	if err := rq.writeTailScriptResponse(w); err != nil {
+	b, sent := rq.drainTailScript()
+	if err := rq.writeTailResponse(w, b, sent); err != nil {
 		t.Fatal(err)
 	}
 
@@ -218,7 +266,8 @@ func TestRequest_writeTailScript_RemoveAttrAndClass(t *testing.T) {
 	e.RemoveClass("cls")
 
 	w := httptest.NewRecorder()
-	if err := rq.writeTailScriptResponse(w); err != nil {
+	b, sent := rq.drainTailScript()
+	if err := rq.writeTailResponse(w, b, sent); err != nil {
 		t.Fatal(err)
 	}
 	s := w.Body.String()
@@ -231,10 +280,11 @@ func TestRequest_writeTailScript_RemoveAttrAndClass(t *testing.T) {
 }
 
 // TestRequest_TailScriptConcurrentWithRecycle exercises a /jaws/.tail fetch
-// racing recycle of the same still-pending request. clearLocked resets
-// wsQueue/tailsent, which writeTailScript reads under muQueue, and takes muQueue
-// for that reset so the two cannot race; without that guard this is a data race
-// the single-goroutine tail tests never hit. Run with -race.
+// racing recycle of the same still-pending request. The handler holds jw.mu (read)
+// across the drainTailScript call and recycle needs the jw.mu write lock, so the
+// drain and recycle are serialized: the fetch can never drain a recycled+reused
+// request. clearLocked also takes muQueue to reset wsQueue/tailsent, the lock
+// drainTailScript holds, so that reset cannot race the drain either. Run with -race.
 func TestRequest_TailScriptConcurrentWithRecycle(t *testing.T) {
 	jw, _ := New()
 	defer jw.Close()
@@ -253,6 +303,32 @@ func TestRequest_TailScriptConcurrentWithRecycle(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			jw.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, tailURL, nil))
+		}()
+		go func() {
+			defer wg.Done()
+			jw.recycle(rq)
+		}()
+	}
+	wg.Wait()
+}
+
+// TestRequest_wantMessageConcurrentWithRecycle stresses the broadcast identity
+// check: wantMessage reads rq.JawsKey under rq.mu while recycle zeroes it under the
+// same lock. The read and write must be serialized so there is no data race on the
+// key. Run with -race.
+func TestRequest_wantMessageConcurrentWithRecycle(t *testing.T) {
+	jw, _ := New()
+	defer jw.Close()
+
+	const n = 300
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		rq := jw.NewRequest(nil)
+		staleKey := rq.JawsKey
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			rq.wantMessage(&wire.Message{Dest: staleKey})
 		}()
 		go func() {
 			defer wg.Done()
@@ -673,7 +749,7 @@ func TestRequest_IgnoresIncomingMsgsDuringShutdown(t *testing.T) {
 		case <-th.C:
 			th.Timeout()
 		default:
-			rq.Jaws.Broadcast(wire.Message{Dest: rq})
+			rq.Jaws.Broadcast(wire.Message{Dest: rq.JawsKey})
 		}
 		select {
 		case rq.InCh <- wire.WsMsg{}:
@@ -747,6 +823,35 @@ func TestRequest_Redirect(t *testing.T) {
 		t.Errorf("%q", s)
 	default:
 	}
+}
+
+func TestBroadcast_ZeroKeyDestDropped(t *testing.T) {
+	th := newTestHelper(t)
+	tj := newTestJaws()
+	defer tj.Close()
+	rq := tj.newRequest(nil)
+
+	// A zero key (captured from an already-recycled request) targets no live
+	// request: Broadcast drops it before it reaches the Serve loop rather than
+	// treating it as a tag. A real follow-up still arrives, proving only the
+	// zero-key message was dropped, and no bad-destination misuse is logged.
+	rq.Jaws.Broadcast(wire.Message{Dest: key.Key(0), What: what.Alert, Data: alertData("info", "dropped")})
+	rq.Alert("info", "kept")
+
+	select {
+	case <-th.C:
+		th.Timeout()
+	case msg := <-rq.OutCh:
+		s := msg.Format()
+		th.True(strings.Contains(s, "kept"))
+		th.Equal(strings.Contains(s, "dropped"), false)
+	}
+	select {
+	case s := <-rq.OutCh:
+		t.Errorf("unexpected second delivery: %q", s)
+	default:
+	}
+	th.Equal(strings.Contains(tj.log.String(), "jaws: Broadcast"), false)
 }
 
 func TestRequest_Cancel(t *testing.T) {

--- a/session.go
+++ b/session.go
@@ -193,8 +193,10 @@ func (sess *Session) Close() (cookie *http.Cookie) {
 		msg := wire.Message{What: what.Reload}
 		for _, rq := range requests {
 			rq.deadSession(sess)
-			msg.Dest = rq
-			sess.jw.Broadcast(msg)
+			if k := rq.destKey(); k != 0 {
+				msg.Dest = k
+				sess.jw.Broadcast(msg)
+			}
 		}
 	}
 	return
@@ -240,8 +242,10 @@ func (sess *Session) Broadcast(msg wire.Message) {
 		// backpressure, and holding sess.mu across that send would stall every
 		// other session reader and writer. This mirrors Session.Close.
 		for _, rq := range sess.Requests() {
-			msg.Dest = rq
-			sess.jw.Broadcast(msg)
+			if k := rq.destKey(); k != 0 {
+				msg.Dest = k
+				sess.jw.Broadcast(msg)
+			}
 		}
 	}
 }

--- a/session_test.go
+++ b/session_test.go
@@ -305,15 +305,17 @@ func TestSession_Broadcast(t *testing.T) {
 		if got.What != msg.What || got.Data != msg.Data {
 			t.Fatalf("message %d mismatch: %#v", i+1, got)
 		}
-		if _, ok := got.Dest.(*Request); !ok {
+		// Session.Broadcast targets each request by its key identity, not the
+		// reusable *Request pointer.
+		if _, ok := got.Dest.(key.Key); !ok {
 			t.Fatalf("message %d destination type: %T", i+1, got.Dest)
 		}
 	}
 
-	seen := map[*Request]bool{}
-	seen[msg1.Dest.(*Request)] = true
-	seen[msg2.Dest.(*Request)] = true
-	if !seen[rq1] || !seen[rq2] || len(seen) != 2 {
+	seen := map[key.Key]bool{}
+	seen[msg1.Dest.(key.Key)] = true
+	seen[msg2.Dest.(key.Key)] = true
+	if !seen[rq1.JawsKey] || !seen[rq2.JawsKey] || len(seen) != 2 {
 		t.Fatalf("expected broadcasts for both requests, got %#v", seen)
 	}
 


### PR DESCRIPTION
## Problem

Pooled `*Request` objects are recycled and reused under a fresh `JawsKey`. Two operations could still act on a reused request via its *prior* key identity:

1. **`/jaws/.tail/KEY`** looked up the request under `jw.mu.RLock`, **released** the lock, then drained the queue and wrote it as a `<script>`. A recycle+reuse in that window would write the new connection's queued content to the stale client (the race was previously documented as deliberately unguarded).
2. **Request-targeted broadcasts** (`Alert`, `Redirect`, `Session.Close`, `Session.Broadcast`) put the `*Request` **pointer** in `wire.Message.Dest`, and `wantMessage` matched by pointer — so a reused pointer matched, delivering a message meant for the prior identity.

## Fix

Reuse the existing `JawsKey` field as the identity token — **no new struct fields or atomics**.

**Tail (coupled lookup+drain):** split `writeTailScript` into `drainTailScript()` (builds the JS bytes and compacts the queue under `muQueue`, no I/O) and `writeTailResponse()` (writes, no locks). The handler now holds `jw.mu.RLock` continuously across the lookup *and* the drain; since recycling needs the `jw.mu` write lock, the request can't change identity mid-drain. A stale key misses the map (404) or drains its own genuine content. The network write happens after releasing all locks, which also removes the prior lock-held-across-network-write stall.

**Broadcast (decoupled via `bcastCh`):** carry the `key.Key` value (captured via a new `destKey()` reader under `rq.mu`) instead of the pointer, and compare against the live `rq.JawsKey` in `wantMessage` under `rq.mu`. Producers skip the send when the captured key is already zero. All three type switches (`Broadcast`, `wantMessage`, `handleBroadcast`) updated `*Request` → `key.Key`, with `Broadcast` dropping a zero key rather than tag-expanding it.

There is no TOCTOU past the match: `mustBroadcast` runs in the serve-loop goroutine over a frozen `subs` map (subscribe/unsubscribe block on unbuffered channels the loop can't service mid-fan-out), and each `process` invocation owns a freshly-allocated channel, so a reused identity never reads a message matched against the prior subscription.

## Tests

Added: tail stale-key rejection, `wantMessage` key-match table, recycle/reuse rejection (the regression the old pointer compare would have failed), zero-key drop, and a `-race` stress test. Migrated the three `writeTailScript` tests to the new API and updated `TestSession_Broadcast` to assert `key.Key` destinations.

## Verification

- `go test -race ./...` — all packages pass
- `go vet`, `staticcheck`, `golangci-lint` (0 issues), `gosec` — clean
- 100% coverage on every touched function