### PR TITLE
Tighten docs and tests for the request identity-key change

### DIFF
--- a/element_test.go
+++ b/element_test.go
@@ -37,8 +37,10 @@ func (tss *testUi) JawsInit(elem *Element) (err error) {
 	return tss.initError
 }
 
-var _ UI = (*testUi)(nil)
-var _ InitHandler = (*testUi)(nil)
+var (
+	_ UI          = (*testUi)(nil)
+	_ InitHandler = (*testUi)(nil)
+)
 
 func (tss *testUi) JawsGet(elem *Element) string {
 	atomic.AddInt32(&tss.getCalled, 1)
@@ -75,12 +77,15 @@ func (a testApplyGetterAll) JawsGetTag(tag.Context) any { return tag.Tag("tg") }
 func (a testApplyGetterAll) JawsClick(elem *Element, click Click) error {
 	return ErrEventUnhandled
 }
+
 func (a testApplyGetterAll) JawsInput(elem *Element, value string) error {
 	return ErrEventUnhandled
 }
+
 func (a testApplyGetterAll) JawsSet(elem *Element, value string) error {
 	return ErrEventUnhandled
 }
+
 func (a testApplyGetterAll) JawsInit(elem *Element) error {
 	return a.initErr
 }
@@ -463,8 +468,7 @@ func TestElement_ApplyGetterDebugBranches(t *testing.T) {
 	}
 }
 
-type testClickHandler struct {
-}
+type testClickHandler struct{}
 
 func (tch testClickHandler) JawsClick(elem *Element, click Click) (err error) {
 	return nil
@@ -566,8 +570,10 @@ func (h testClickAndInitialHTMLAttr) JawsInitialHTMLAttr(elem *Element) (attr te
 	return
 }
 
-var _ ClickHandler = testClickAndInitialHTMLAttr{}
-var _ InitialHTMLAttrHandler = testClickAndInitialHTMLAttr{}
+var (
+	_ ClickHandler           = testClickAndInitialHTMLAttr{}
+	_ InitialHTMLAttrHandler = testClickAndInitialHTMLAttr{}
+)
 
 type testUnhashableUI struct {
 	m map[string]int

--- a/eventhandler_test.go
+++ b/eventhandler_test.go
@@ -53,10 +53,12 @@ func (t *testJawsEvent) JawsUpdate(elem *Element) {
 	t.msgCh <- fmt.Sprintf("JawsUpdate(%d)", elem.jid)
 }
 
-var _ ClickHandler = (*testJawsEvent)(nil)
-var _ InputHandler = (*testJawsEvent)(nil)
-var _ tag.TagGetter = (*testJawsEvent)(nil)
-var _ UI = (*testJawsEvent)(nil)
+var (
+	_ ClickHandler  = (*testJawsEvent)(nil)
+	_ InputHandler  = (*testJawsEvent)(nil)
+	_ tag.TagGetter = (*testJawsEvent)(nil)
+	_ UI            = (*testJawsEvent)(nil)
+)
 
 func Test_JawsInput_InvokesJawsInputForDualHandler(t *testing.T) {
 	th := newTestHelper(t)

--- a/jaws.go
+++ b/jaws.go
@@ -673,6 +673,10 @@ func (jw *Jaws) GenerateHeadHTML(extra ...string) (err error) {
 //
 // All convenience helpers on [Jaws] that call Broadcast inherit this requirement.
 //
+// A nil [wire.Message.Dest] targets every Request; a [key.Key] Dest targets the
+// single Request with that identity key, and a zero key is dropped; a string Dest
+// is an HTML id accepted by all Requests. Any other Dest is expanded into tags.
+//
 // A [wire.Message.Dest] that cannot be expanded into tags (an illegal tag type)
 // is reported through [Jaws.MustLog], which panics when no [Jaws.Logger] is
 // set; with a Logger the error is logged and the message is sent to the

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -1407,6 +1407,14 @@ func TestServeHTTP_TailScript_EndpointIsPerRequest(t *testing.T) {
 	is.Equal(w.Code, http.StatusNoContent)
 }
 
+// TestServeHTTP_TailScript_RejectsRecycledKey covers the recycled-request behavior
+// of the /jaws/.tail endpoint: recycling deletes the key from jw.requests, so a tail
+// fetch for the old key misses the map and returns 404, while the reused pooled
+// object drains only its own freshly queued content (its queue was reset by
+// clearLocked), never the recycled request's. This exercises the map-deletion 404
+// and content isolation; the concurrent drain-under-lock guarantee (holding jw.mu
+// across drainTailScript) is exercised separately, under the race detector, by
+// TestRequest_TailScriptConcurrentWithRecycle.
 func TestServeHTTP_TailScript_RejectsRecycledKey(t *testing.T) {
 	is := newTestHelper(t)
 	jw, _ := New()
@@ -1418,9 +1426,10 @@ func TestServeHTTP_TailScript_RejectsRecycledKey(t *testing.T) {
 	stale.NewElement(&testUi{}).SetClass("stale")
 	staleKey := stale.JawsKeyString()
 
-	// Recycle the request and create a new one; the pool hands the same struct to
-	// the new connection under a fresh key. A /jaws/.tail fetch for the old key must
-	// not drain the reused request's queue.
+	// Recycle the request and create a new one under a fresh key. The pool typically
+	// hands back the same struct, so the content check below also guards that a
+	// reused object carries none of the recycled request's queued content; it holds
+	// whether or not the pool reused the struct.
 	jw.recycle(stale)
 	rq := jw.NewRequest(hr)
 	rq.NewElement(&testUi{}).SetClass("fresh")

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -1009,14 +1009,26 @@ func TestJaws_clientIP(t *testing.T) {
 		hdrs  map[string]string
 		want  netip.Addr
 	}{
-		{"untrusted ignores forwarded headers", false, "203.0.113.9:443",
-			map[string]string{"X-Forwarded-For": "198.51.100.7"}, mustIP("203.0.113.9")},
-		{"trusted uses leftmost X-Forwarded-For", true, "127.0.0.1:1234",
-			map[string]string{"X-Forwarded-For": "198.51.100.7, 70.41.3.18, 127.0.0.1"}, mustIP("198.51.100.7")},
-		{"trusted falls back to X-Real-IP", true, "127.0.0.1:1234",
-			map[string]string{"X-Real-Ip": "198.51.100.23"}, mustIP("198.51.100.23")},
-		{"trusted falls back to RemoteAddr when headers invalid", true, "203.0.113.9:443",
-			map[string]string{"X-Forwarded-For": "not-an-ip", "X-Real-Ip": "garbage"}, mustIP("203.0.113.9")},
+		{
+			"untrusted ignores forwarded headers", false, "203.0.113.9:443",
+			map[string]string{"X-Forwarded-For": "198.51.100.7"},
+			mustIP("203.0.113.9"),
+		},
+		{
+			"trusted uses leftmost X-Forwarded-For", true, "127.0.0.1:1234",
+			map[string]string{"X-Forwarded-For": "198.51.100.7, 70.41.3.18, 127.0.0.1"},
+			mustIP("198.51.100.7"),
+		},
+		{
+			"trusted falls back to X-Real-IP", true, "127.0.0.1:1234",
+			map[string]string{"X-Real-Ip": "198.51.100.23"},
+			mustIP("198.51.100.23"),
+		},
+		{
+			"trusted falls back to RemoteAddr when headers invalid", true, "203.0.113.9:443",
+			map[string]string{"X-Forwarded-For": "not-an-ip", "X-Real-Ip": "garbage"},
+			mustIP("203.0.113.9"),
+		},
 		{"trusted with no forwarded headers uses RemoteAddr", true, "203.0.113.9:443", nil, mustIP("203.0.113.9")},
 	}
 	for _, tt := range tests {

--- a/jawsboot/example_test.go
+++ b/jawsboot/example_test.go
@@ -34,7 +34,8 @@ func setupJaws(jw *jaws.Jaws, mux *http.ServeMux) (err error) {
 		// Initialize jawsboot; we will serve the JavaScript and CSS from /static/*.[js|css].
 		// All files under assets/static will be available under /static. Any favicon loaded
 		// this way will have its URL available using jaws.FaviconURL().
-		if err = jw.Setup(mux.Handle, "/static",
+		if err = jw.Setup(
+			mux.Handle, "/static",
 			jawsboot.Setup,
 			staticserve.MustNewFS(assetsFS, "assets/static", "images/favicon.png"),
 		); err == nil {

--- a/jawstree/example_test.go
+++ b/jawstree/example_test.go
@@ -35,7 +35,8 @@ func setupJaws(jw *jaws.Jaws, mux *http.ServeMux) (err error) {
 		// Initialize jawsboot; we will serve the JavaScript and CSS from /static/*.[js|css].
 		// All files under assets/static will be available under /static. Any favicon loaded
 		// this way will have its URL available using jaws.FaviconURL().
-		if err = jw.Setup(mux.Handle, "/static",
+		if err = jw.Setup(
+			mux.Handle, "/static",
 			jawsboot.Setup,
 			jawstree.Setup,
 			staticserve.MustNewFS(assetsFS, "assets/static", "images/favicon.png"),

--- a/lib/bind/binder.go
+++ b/lib/bind/binder.go
@@ -182,7 +182,7 @@ func (b *binder[T]) JawsGet(elem *jaws.Element) (value T) {
 
 func (b *binder[T]) jawsGetHTMLLocked(elem *jaws.Element) template.HTML {
 	for bnd := b; bnd != nil; bnd = bnd.prev {
-		switch hook := (bnd.hook).(type) {
+		switch hook := bnd.hook.(type) {
 		case GetHTMLHook[T]:
 			return hook(bnd, elem)
 		case string:

--- a/lib/bind/makehtmlgetter_test.go
+++ b/lib/bind/makehtmlgetter_test.go
@@ -28,7 +28,7 @@ func Test_MakeHTMLGetter(t *testing.T) {
 	avUntyped.Store(untypedText)
 	avTyped.Store(typedText)
 	stringer := testStringer{}
-	var binderVal = "<b>"
+	binderVal := "<b>"
 	var binderMu sync.Mutex
 	binderNoHTML := testBinderStringNoHTML{New(&binderMu, &binderVal)}
 

--- a/lib/named/namedboolarray_test.go
+++ b/lib/named/namedboolarray_test.go
@@ -122,7 +122,7 @@ func Test_NamedBoolArray(t *testing.T) {
 	if nba.IsChecked("2") {
 		t.Fatal("expected IsChecked(2)=false")
 	}
-	(nba.data)[1].Set(true)
+	nba.data[1].Set(true)
 	if !nba.IsChecked("2") {
 		t.Fatal("expected IsChecked(2)=true")
 	}

--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -157,7 +157,7 @@ func (jsvar *JsVar[T]) exceedsClientJsVarCap(n int) bool {
 
 // setPathLocked applies the mutation and must be called with the write lock held.
 func (jsvar *JsVar[T]) setPathLocked(elem *jaws.Element, jsPath string, value any) (err error) {
-	if ps, ok := ((any)(jsvar.Ptr).(PathSetter)); ok {
+	if ps, ok := any(jsvar.Ptr).(PathSetter); ok {
 		err = ps.JawsSetPath(elem, jsPath, value)
 	} else {
 		var changed bool
@@ -211,7 +211,7 @@ func (jsvar *JsVar[T]) setPath(elem *jaws.Element, jsPath string, value any) (er
 		return ErrIllegalJsVarPath
 	}
 	if err = jsvar.setPathLock(elem, jsPath, value); err == nil {
-		if sp, ok := ((any)(jsvar.Ptr).(SetPather)); ok {
+		if sp, ok := any(jsvar.Ptr).(SetPather); ok {
 			sp.JawsPathSet(elem, jsPath, value)
 		}
 	}

--- a/lib/ui/template.go
+++ b/lib/ui/template.go
@@ -26,10 +26,12 @@ type Template struct {
 	Dot          any    // Dot value to place in With.
 }
 
-var _ jaws.UI = Template{}                 // statically ensure interface is defined
-var _ jaws.ClickHandler = Template{}       // statically ensure interface is defined
-var _ jaws.ContextMenuHandler = Template{} // statically ensure interface is defined
-var _ jaws.InputHandler = Template{}       // statically ensure interface is defined
+var (
+	_ jaws.UI                 = Template{} // statically ensure interface is defined
+	_ jaws.ClickHandler       = Template{} // statically ensure interface is defined
+	_ jaws.ContextMenuHandler = Template{} // statically ensure interface is defined
+	_ jaws.InputHandler       = Template{} // statically ensure interface is defined
+)
 
 // String returns a debug representation of t.
 func (tmpl Template) String() string {

--- a/lib/wire/message.go
+++ b/lib/wire/message.go
@@ -15,7 +15,8 @@ type Message struct {
 
 // String returns the Message in a form suitable for debug output.
 func (msg *Message) String() string {
-	return fmt.Sprintf("{%v, %v, %q}",
+	return fmt.Sprintf(
+		"{%v, %v, %q}",
 		msg.Dest,
 		msg.What,
 		msg.Data,

--- a/request.go
+++ b/request.go
@@ -44,7 +44,7 @@ type ConnectFn = func(rq *Request) error
 // between the Request being created and it being used once the WebSocket is created.
 type Request struct {
 	Jaws       *Jaws                   // (read-only) the JaWS instance the Request belongs to
-	JawsKey    key.Key                 // (read-only) random key identifying this Request in the WebSocket URI; also the broadcast/tail target, read under mu
+	JawsKey    key.Key                 // (read-only) random key identifying this Request in the WebSocket URI and the broadcast/tail target; the identity check (destKey, wantMessage) reads it under mu
 	remoteIP   netip.Addr              // (read-only) remote IP, or the zero netip.Addr if unset
 	Rendering  atomic.Bool             // set to true by RequestWriter.Write()
 	running    atomic.Bool             // if ServeHTTP() is running
@@ -231,7 +231,7 @@ func (rq *Request) clearLocked() *Request {
 	clear(rq.elems)
 	rq.elems = rq.elems[:0]
 	// wsQueue and tailsent are guarded by muQueue, not rq.mu. A /jaws/.tail/<key>
-	// fetch (writeTailScript) on a still-pending request runs on a separate HTTP
+	// fetch (drainTailScript) on a still-pending request runs on a separate HTTP
 	// goroutine holding only muQueue, so take muQueue here to serialize the reset
 	// with it; the documented rq.mu -> muQueue lock order is preserved since we
 	// already hold rq.mu.
@@ -329,8 +329,10 @@ func (rq *Request) drainTailScript() (b []byte, sent bool) {
 
 // writeTailResponse writes the tail script response built by drainTailScript. It
 // holds no locks, so the network write cannot stall recycling or the Serve loop.
-// A sent=false drain (the tail was already fetched, or there was nothing queued
-// to send) responds 204 No Content.
+//
+// A sent=false drain (the tail was already fetched on an earlier request) responds
+// 204 No Content. A first drain finding nothing queued reports sent=true with empty
+// bytes and writes an empty 200 body.
 func (*Request) writeTailResponse(w http.ResponseWriter, b []byte, sent bool) (err error) {
 	hdr := w.Header()
 	hdr["Cache-Control"] = headerCacheControlNoStore
@@ -503,7 +505,9 @@ func alertData(level, msg string) string {
 // untrusted text; do not pre-escape it.
 //
 // The default JaWS JavaScript only supports Bootstrap dismissible alerts.
-// See [Jaws.Broadcast] for processing-loop requirements.
+//
+// It does nothing if the Request has already been recycled, since it then has no
+// live target. See [Jaws.Broadcast] for processing-loop requirements.
 func (rq *Request) Alert(level, msg string) {
 	if k := rq.destKey(); k != 0 {
 		rq.Jaws.Broadcast(wire.Message{
@@ -526,7 +530,9 @@ func (rq *Request) AlertError(err error) {
 // The URL is validated to be a relative path or an http/https URL; script-bearing
 // schemes such as javascript: and protocol-relative ("//host") URLs are refused
 // and logged rather than sent to the browser.
-// See [Jaws.Broadcast] for processing-loop requirements.
+//
+// It does nothing if the Request has already been recycled, since it then has no
+// live target. See [Jaws.Broadcast] for processing-loop requirements.
 func (rq *Request) Redirect(url string) {
 	if msg, ok := rq.Jaws.redirectMessage(url); ok {
 		if k := rq.destKey(); k != 0 {

--- a/request_test.go
+++ b/request_test.go
@@ -1368,7 +1368,8 @@ func TestRequest_UpdatePanicLogs(t *testing.T) {
 	tss := &testUi{
 		updateFn: func(elem *Element) {
 			panic("wildpanic")
-		}}
+		},
+	}
 	th.NoErr(rq.UI(tss))
 	rq.Dirty(tss)
 	select {

--- a/request_test.go
+++ b/request_test.go
@@ -104,26 +104,37 @@ func TestRequest_wantMessage_KeyDest(t *testing.T) {
 	}
 }
 
-// TestRequest_wantMessage_RejectsRecycledKey is the core broadcast regression: a
-// message aimed at a request's key must not be delivered to the reused pooled
-// object that now carries a different key, even when the pool hands back the same
-// *Request pointer (the previous dest == rq pointer match would have matched here).
+// TestRequest_wantMessage_RejectsRecycledKey is the core broadcast regression:
+// matching on the identity key rather than the *Request pointer lets the loop
+// reject a message aimed at a request that was recycled and reused under a new key,
+// even when it is the very same pooled object. A dest==*Request match could not
+// tell the reused object from the original; a key match can.
 func TestRequest_wantMessage_RejectsRecycledKey(t *testing.T) {
 	is := newTestHelper(t)
 	jw, _ := New()
 	go jw.Serve()
 	defer jw.Close()
 
-	stale := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
-	staleKey := stale.JawsKey
-	is.True(stale.wantMessage(&wire.Message{Dest: staleKey}))
-
-	// Recycle and reuse the pooled object under a new key.
-	jw.recycle(stale)
 	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	staleKey := rq.JawsKey
+	is.True(rq.wantMessage(&wire.Message{Dest: staleKey}))
 
+	// Recycle zeroes the key, so the same object no longer matches the old key.
+	jw.recycle(rq)
 	is.Equal(rq.wantMessage(&wire.Message{Dest: staleKey}), false)
-	is.True(rq.wantMessage(&wire.Message{Dest: rq.JawsKey}))
+
+	// Reuse the same object under a fresh key, as the pool handing it back to a new
+	// connection would. Re-key directly under rq.mu (the lock destKey/wantMessage
+	// use) so the aliasing is deterministic rather than dependent on the pool
+	// returning this struct. A message still aimed at the old key must be rejected
+	// even though rq is the same object it once identified; one aimed at the new
+	// key is accepted.
+	newKey := staleKey + 1
+	rq.mu.Lock()
+	rq.JawsKey = newKey
+	rq.mu.Unlock()
+	is.Equal(rq.wantMessage(&wire.Message{Dest: staleKey}), false)
+	is.True(rq.wantMessage(&wire.Message{Dest: newKey}))
 }
 
 func TestRequest_HeadHTML(t *testing.T) {
@@ -852,6 +863,31 @@ func TestBroadcast_ZeroKeyDestDropped(t *testing.T) {
 	default:
 	}
 	th.Equal(strings.Contains(tj.log.String(), "jaws: Broadcast"), false)
+}
+
+// TestRequest_ProducersSkipRecycled covers the destKey()==0 branch in Request.Alert
+// and Request.Redirect. Once a Request is recycled it carries the zero key, so both
+// take the skip branch and never call Broadcast. A zero-key broadcast would be
+// dropped by Jaws.Broadcast anyway (see TestBroadcast_ZeroKeyDestDropped); the guard
+// avoids the round-trip, and exercising it is the only coverage of the branch.
+func TestRequest_ProducersSkipRecycled(t *testing.T) {
+	th := newTestHelper(t)
+	jw, _ := New()
+	defer jw.Close()
+
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	jw.recycle(rq)
+	th.Equal(rq.destKey(), key.Key(0))
+
+	// No Serve loop drains bcastCh, so any stray broadcast would be observable.
+	rq.Alert("info", "ignored")
+	rq.Redirect("/ignored")
+
+	select {
+	case msg := <-jw.bcastCh:
+		t.Fatalf("recycled request must not broadcast, got %#v", msg)
+	default:
+	}
 }
 
 func TestRequest_Cancel(t *testing.T) {

--- a/session_test.go
+++ b/session_test.go
@@ -329,6 +329,79 @@ func TestSession_Broadcast(t *testing.T) {
 	jw.recycle(rq2)
 }
 
+// TestSession_ProducersSkipRecycled covers the destKey()==0 branch in
+// Session.Broadcast and Session.Close. A request can still be listed in the session
+// while a concurrent recycle has already zeroed its key; both producers must skip it
+// and target only the live requests. The state is reproduced here by zeroing one
+// request's key while it remains in the session list. (A zero-key message would also
+// be dropped by Jaws.Broadcast, so the guard just avoids the wasted round-trip and
+// is the only coverage of the branch.)
+func TestSession_ProducersSkipRecycled(t *testing.T) {
+	th := newTestHelper(t)
+	jw, _ := New()
+	defer jw.Close()
+
+	rr := httptest.NewRecorder()
+	hr := httptest.NewRequest(http.MethodGet, "/", nil)
+	sess := jw.NewSession(rr, hr)
+	th.True(sess != nil)
+
+	live := jw.NewRequest(hr)
+	hr2 := httptest.NewRequest(http.MethodGet, "/2", nil)
+	hr2.RemoteAddr = hr.RemoteAddr
+	hr2.AddCookie(sess.Cookie())
+	recycled := jw.NewRequest(hr2)
+	th.True(live.Session() == sess)
+	th.True(recycled.Session() == sess)
+
+	// Simulate a recycle that has zeroed the key but not yet removed the request
+	// from the session list. Write under rq.mu to match destKey/wantMessage.
+	recycled.mu.Lock()
+	recycled.JawsKey = 0
+	recycled.mu.Unlock()
+
+	// Session.Broadcast targets only the live request.
+	done := make(chan struct{})
+	go func() {
+		sess.Broadcast(wire.Message{What: what.Alert, Data: "info\nhi"})
+		close(done)
+	}()
+	got := nextBroadcast(t, jw)
+	th.Equal(got.Dest, live.JawsKey)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for Session.Broadcast")
+	}
+	select {
+	case extra := <-jw.bcastCh:
+		t.Fatalf("recycled request must not broadcast, got %#v", extra)
+	default:
+	}
+
+	// Session.Close reloads only the live request.
+	closeDone := make(chan struct{})
+	go func() {
+		sess.Close()
+		close(closeDone)
+	}()
+	got = nextBroadcast(t, jw)
+	th.Equal(got.What, what.Reload)
+	th.Equal(got.Dest, live.JawsKey)
+	select {
+	case <-closeDone:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for Session.Close")
+	}
+	select {
+	case extra := <-jw.bcastCh:
+		t.Fatalf("recycled request must not broadcast, got %#v", extra)
+	default:
+	}
+
+	jw.recycle(live)
+}
+
 func TestSession_Delete(t *testing.T) {
 	th := newTestHelper(t)
 	ts := newTestServer(t)

--- a/setup_test.go
+++ b/setup_test.go
@@ -21,8 +21,7 @@ func (tm *testMux) Handle(uri string, handler http.Handler) {
 	tm.m[uri] = handler
 }
 
-type testSetupper struct {
-}
+type testSetupper struct{}
 
 func (ts *testSetupper) JawsSetupFunc(jw *Jaws, handleFn HandleFunc, prefix string) (urls []*url.URL, err error) {
 	ss, _ := staticserve.New("foo.txt", []byte("foo"))


### PR DESCRIPTION
## Summary

Follow-ups from a code review of PR #69 (request-targeted broadcasts switched from the `*Request` pointer to the `key.Key` value as identity, plus the tail-script `drainTailScript`/`writeTailResponse` split). The review found no production-correctness bugs; these are documentation accuracy fixes and test-quality/coverage improvements. **No production behavior changes.**

The two commits are split so the substantive changes are free of formatting noise:

- **Tighten docs and tests for the request identity-key change** — the review follow-ups.
- **Format the module with gofumpt** — `gofumpt -w` across the tree, formatting only.

## Documentation fixes

- `writeTailResponse`: a first drain with nothing queued reports `sent=true` and writes an empty 200 body; only a *repeat* fetch responds 204. The old comment claimed 204 for "nothing queued".
- `clearLocked`: refer to `drainTailScript`, not the renamed `writeTailScript`.
- `JawsKey` field: scope the "read under mu" note to the identity check (`destKey`, `wantMessage`) rather than implying every read takes the lock (`JawsKeyString`/`HeadHTML` read it unlocked).
- `Request.Alert`/`Request.Redirect`: document that they do nothing on a recycled request.
- `Jaws.Broadcast`: document the accepted `Dest` types, including the `key.Key` target and the zero-key drop.

## Test improvements

- `TestRequest_wantMessage_RejectsRecycledKey` now re-keys the **same** object under `rq.mu` to exercise the recycle/reuse aliasing deterministically, instead of relying on `sync.Pool` handing back the same struct (which is not guaranteed — a GC between `recycle` and `NewRequest` empties the pool).
- `TestServeHTTP_TailScript_RejectsRecycledKey` comments re-scoped to what it actually covers (map-deletion 404 + content isolation); the concurrent drain-under-lock guarantee is covered by the `-race` test `TestRequest_TailScriptConcurrentWithRecycle`.
- Added coverage for the `destKey()==0` skip branch in `Request.Alert`, `Request.Redirect`, `Session.Close`, and `Session.Broadcast`.

## Verification

`go build`, `go vet`, `golangci-lint run` (0 issues), `gosec`, `staticcheck`, and the full `go test -race ./...` suite all pass; `gofmt -l`/`gofumpt -l` clean.
