### PR TITLE
Fix Request recycle data races (JawsKey reads, TestServe running)

### DIFF
--- a/errwebsocketipmismatch.go
+++ b/errwebsocketipmismatch.go
@@ -24,6 +24,9 @@ func (e errWebSocketIPMismatch) Is(target error) bool {
 }
 
 // newErrWebSocketIPMismatchLocked reads rq fields; caller must hold rq.mu.
+//
+// It reads rq.JawsKey directly rather than via [Request.JawsKeyString], which
+// takes rq.mu and would deadlock here since the caller already holds it.
 func newErrWebSocketIPMismatchLocked(rq *Request, actual netip.Addr) error {
-	return errWebSocketIPMismatch{JawsKey: rq.JawsKeyString(), Expected: rq.remoteIP, Actual: actual}
+	return errWebSocketIPMismatch{JawsKey: rq.JawsKey.String(), Expected: rq.remoteIP, Actual: actual}
 }

--- a/recyclerace_test.go
+++ b/recyclerace_test.go
@@ -1,0 +1,98 @@
+package jaws
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/linkdata/jaws/lib/key"
+)
+
+// TestRequest_JawsKeyReadsAreLockedDuringRecycle verifies that the request-key
+// readers used while the application renders the initial HTML page
+// (JawsKeyString, String, HeadHTML and TailHTML) read rq.JawsKey under rq.mu, so
+// they do not race the rq.mu-guarded writes to rq.JawsKey that clearLocked and
+// getRequestLocked perform when a still-pending request is recycled (for example
+// by limitPendingRequestsLocked evicting it). Run with -race.
+func TestRequest_JawsKeyReadsAreLockedDuringRecycle(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+
+	const iterations = 2000
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer: mimic clearLocked / getRequestLocked, which assign rq.JawsKey while
+	// holding rq.mu.
+	go func() {
+		defer wg.Done()
+		for i := range iterations {
+			rq.mu.Lock()
+			rq.JawsKey = key.Key(uint64(i) + 1)
+			rq.mu.Unlock()
+		}
+	}()
+
+	// Reader: the lock-free render-path readers that previously read rq.JawsKey
+	// without holding rq.mu.
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			_ = rq.JawsKeyString()
+			_ = rq.String()
+			_ = rq.HeadHTML(io.Discard)
+			_ = rq.TailHTML(io.Discard)
+		}
+	}()
+
+	wg.Wait()
+}
+
+// TestServe_MarksRequestRunningSoMaintenanceSkips verifies that TestServe marks
+// the request running before driving rq.process, mirroring ServeHTTP/startServe.
+// The maintenance pass recycles only not-running requests (clearing their
+// elements via clearLocked), so a request whose process loop is live must report
+// running and must survive a maintenance pass that would otherwise expire it.
+func TestServe_MarksRequestRunningSoMaintenanceSkips(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+
+	go jw.Serve()
+
+	tr := NewTestRequest(jw, nil)
+	if tr == nil {
+		t.Fatal("expected test request")
+	}
+	defer func() {
+		tr.Close()
+		<-tr.DoneCh
+	}()
+
+	<-tr.ReadyCh
+	if !tr.running.Load() {
+		t.Fatal("TestServe must mark the request running so maintenance cannot recycle it mid-process")
+	}
+
+	// Make the request look long-idle, then run a maintenance pass directly. A
+	// running request must not be recycled; before the fix it would be removed
+	// from jw.requests and its elements cleared while process is still using them.
+	tr.mu.Lock()
+	tr.lastWrite = time.Now().Add(-time.Hour)
+	tr.mu.Unlock()
+	jw.maintenance(time.Millisecond)
+
+	if got := jw.RequestCount(); got != 1 {
+		t.Fatalf("running request was recycled by maintenance: RequestCount() = %d, want 1", got)
+	}
+}

--- a/request.go
+++ b/request.go
@@ -44,7 +44,7 @@ type ConnectFn = func(rq *Request) error
 // between the Request being created and it being used once the WebSocket is created.
 type Request struct {
 	Jaws       *Jaws                   // (read-only) the JaWS instance the Request belongs to
-	JawsKey    key.Key                 // (read-only) random key identifying this Request in the WebSocket URI and the broadcast/tail target; the identity check (destKey, wantMessage) reads it under mu
+	JawsKey    key.Key                 // (read-only) random key identifying this Request in the WebSocket URI and the broadcast/tail target; read under mu by the identity check (destKey, wantMessage) and the render path (JawsKeyString, HeadHTML)
 	remoteIP   netip.Addr              // (read-only) remote IP, or the zero netip.Addr if unset
 	Rendering  atomic.Bool             // set to true by RequestWriter.Write()
 	running    atomic.Bool             // if ServeHTTP() is running

--- a/request.go
+++ b/request.go
@@ -98,7 +98,9 @@ var (
 func (rq *Request) JawsKeyString() string {
 	jawsKey := key.Key(0)
 	if rq != nil {
+		rq.mu.RLock()
 		jawsKey = rq.JawsKey
+		rq.mu.RUnlock()
 	}
 	return jawsKey.String()
 }
@@ -245,11 +247,14 @@ func (rq *Request) clearLocked() *Request {
 
 // HeadHTML writes the HTML code needed in the HTML page's HEAD section.
 func (rq *Request) HeadHTML(w io.Writer) (err error) {
+	rq.mu.RLock()
+	jawsKey := rq.JawsKey
+	rq.mu.RUnlock()
 	var b []byte
 	rq.Jaws.mu.RLock()
 	b = append(b, rq.Jaws.headPrefix...)
 	rq.Jaws.mu.RUnlock()
-	b = key.Append(b, rq.JawsKey)
+	b = key.Append(b, jawsKey)
 	b = append(b, `">`...)
 	_, err = w.Write(b)
 	return

--- a/testserve.go
+++ b/testserve.go
@@ -61,6 +61,16 @@ func (jw *Jaws) TestServe(rq *Request, onPanic func(recovered any)) (inCh chan w
 			onPanic(recover())
 			close(doneCh)
 		}()
+		// Mark the request running before driving rq.process, mirroring how
+		// ServeHTTP gates process with startServe. The maintenance pass recycles
+		// (and clears the elements of) only not-running requests, so leaving the
+		// request not-running while process iterates its elements would let an idle
+		// or context-cancelled request be recycled mid-loop. Take jw.mu so the
+		// transition is serialized with the maintenance pass, which reads running
+		// under jw.mu; the final recycle resets running via clearLocked.
+		jw.mu.Lock()
+		rq.running.Store(true)
+		jw.mu.Unlock()
 		close(readyCh)
 		rq.process(bcastCh, inCh, outCh)
 		jw.recycle(rq)


### PR DESCRIPTION
Fixes two data races where a `Request` could be recycled while another goroutine was still using it. Both were found during a code-review audit and **reproduce under `go test -race`**; the new tests fail without the fix.

## 1. Lock-free `rq.JawsKey` reads on the render path (medium)

`JawsKeyString` and `HeadHTML` (and therefore `String` and `TailHTML`) read `rq.JawsKey` without holding `rq.mu`. They run on the application's HTTP goroutine while it renders the initial page for a still-pending `Request`. Meanwhile `clearLocked`/`getRequestLocked` write `rq.JawsKey` **under `rq.mu`** when a pending request is recycled — e.g. `limitPendingRequestsLocked` evicting the oldest pending request for an IP once `MaxPendingRequestsPerIP` is reached. `key.Key` is a `uint64`, so the unsynchronized read+write is a data race (and `go test -race ./...` is part of CI).

`destKey` already reads the same field under `rq.mu.RLock`; the struct doc states `JawsKey` is "read under mu". This change makes the render-path readers conform:
- `JawsKeyString` and `HeadHTML` snapshot the key under `rq.mu.RLock`.
- `newErrWebSocketIPMismatchLocked` reads `rq.JawsKey` directly (its caller `claim` already holds `rq.mu`, so calling `JawsKeyString` would deadlock on the non-reentrant lock).

## 2. `TestServe` did not mark the request running (high, test harness)

`TestServe` drove `rq.process` without ever marking the request running, unlike `ServeHTTP` (which gates `process` with `startServe`). The maintenance pass recycles — and clears the elements of — only **not-running** requests, so an idle or context-cancelled test request could be recycled mid-loop, racing the lock-free `elem.ui` read in `Element.UI()` during `JawsUpdate`. This surfaces in `jawstest`-based test suites under `-race`.

Fix: mark the request running under `jw.mu` (serialized with the maintenance pass, which reads `running` under `jw.mu`) before `process`; the final `recycle` resets it via `clearLocked`.

## Tests
`recyclerace_test.go` adds:
- `TestRequest_JawsKeyReadsAreLockedDuringRecycle` — races the render-path key readers against `rq.mu`-guarded key writes; fails with a DATA RACE without the fix.
- `TestServe_MarksRequestRunningSoMaintenanceSkips` — asserts the request is running after `TestServe` readies it and survives a maintenance pass that would otherwise expire it.

## Performance
The added locking is on cold paths only (`HeadHTML`/`TailHTML` run once per page render; `JawsKeyString`/`String` are render/error/log paths). The `TestServe` change adds one `jw.mu` lock per test request. No hot-path impact.

Local gate: `gofmt`/`gofumpt` clean, `go vet`, `staticcheck`, `golangci-lint` (0 issues), `gosec`, `go test -race ./...` all pass.