### PR TITLE
Reject runtime-non-comparable tags in all builds

### DIFF
--- a/lib/tag/tag.go
+++ b/lib/tag/tag.go
@@ -7,7 +7,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/linkdata/deadlock"
 	"github.com/linkdata/jaws/lib/key"
 )
 
@@ -41,17 +40,35 @@ func ensureUsableTag(tag any) error {
 		if t := reflect.TypeOf(tag); t != nil && t.Comparable() {
 			// reflect.Type.Comparable reports STATIC comparability: a comparable
 			// struct or array can still hold a non-comparable value in an interface
-			// field and not be comparable at runtime. In debug builds also run the
-			// (more expensive) runtime value check via NewErrNotComparable so such
-			// tags are rejected at expansion time; production keeps only the cheap
-			// static check.
-			if deadlock.Debug && NewErrNotComparable(tag) != nil {
-				return NewErrNotUsableAsTag(tag)
+			// field, making it panic when compared or used as an rq.tagMap key. Only
+			// struct and array values can differ between static and runtime
+			// comparability (scalars, strings, pointers and channels are always
+			// comparable when their type is), so probe just those kinds with
+			// comparableAtRuntime and reject such tags here, rather than deferring a
+			// panic to appendUniqueTag's dedup or to rq.tagMap on the event goroutine.
+			switch t.Kind() {
+			case reflect.Struct, reflect.Array:
+				if !comparableAtRuntime(tag) {
+					return NewErrNotUsableAsTag(tag)
+				}
 			}
 			return nil
 		}
 	}
 	return NewErrNotUsableAsTag(tag)
+}
+
+// comparableAtRuntime reports whether tag can be compared with == without
+// panicking.
+//
+// A statically comparable struct or array can still hold a non-comparable value
+// (for example a func in an interface field); comparing such a value panics with
+// "comparing uncomparable type". This probe is allocation-free, unlike
+// [reflect.Value.Comparable], which allocates while walking the value.
+func comparableAtRuntime(tag any) (ok bool) {
+	defer func() { _ = recover() }()
+	other := tag
+	return tag == other
 }
 
 func appendUniqueTag(result []any, tag any) ([]any, error) {
@@ -197,12 +214,12 @@ func expand(depth int, ctx Context, tag any, result []any, active []any) ([]any,
 // comparable value. Primitive HTML/value types are rejected with
 // [ErrIllegalTagType] to catch common accidental tags.
 func TagExpand(ctx Context, tag any) (result []any, err error) {
-	// A value can pass the static comparability check in ensureUsableTag yet be
-	// non-comparable at runtime (a comparable struct holding e.g. a func in an
-	// interface field). Two such same-typed values reach appendUniqueTag's dedup,
-	// where existing == tag panics. recoverComparabilityPanic turns that specific
-	// runtime panic into [ErrNotUsableAsTag] and re-raises anything else. (Debug
-	// builds reject such tags in ensureUsableTag, so this fires only in production.)
+	// ensureUsableTag rejects tags that are not comparable at runtime, so the
+	// existing == tag dedup in appendUniqueTag does not panic on them. recover
+	// stays as a defense-in-depth net: should a non-comparable value ever reach
+	// that comparison, recoverComparabilityPanic turns the specific "comparing
+	// uncomparable type" runtime panic into [ErrNotUsableAsTag] and re-raises
+	// anything else.
 	defer func() {
 		if r := recover(); r != nil {
 			result, err = recoverComparabilityPanic(r, tag)

--- a/lib/tag/tag_benchmark_test.go
+++ b/lib/tag/tag_benchmark_test.go
@@ -84,6 +84,10 @@ func BenchmarkTagExpand(b *testing.B) {
 		tag  any
 	}{
 		{name: "SingleTag", tag: Tag("single")},
+		// StructTag exercises the struct-kind runtime comparability check that
+		// ensureUsableTag runs (scalar/pointer tags skip it); benchID is a small
+		// comparable struct value, not a pointer.
+		{name: "StructTag", tag: benchID{n: 1}},
 		{name: "FlatTags8", tag: flatTags8},
 		{name: "FlatAny16", tag: flatAny},
 		{name: "NestedAnyTree", tag: nestedAny},

--- a/lib/tag/tag_test.go
+++ b/lib/tag/tag_test.go
@@ -250,25 +250,22 @@ func TestTagExpand_TagGetterNonComparable(t *testing.T) {
 // TestTagExpand_RuntimeNonComparable covers the gap between static and runtime
 // comparability: a struct whose static type is comparable but that holds a
 // non-comparable value in an interface field (here a func) passes
-// reflect.Type.Comparable() yet panics on == / as a map key. In debug builds tag
-// expansion must reject it with ErrNotUsableAsTag rather than accepting it and
-// deferring a panic to jw.dirty / rq.tagMap on the event goroutine. The runtime
-// check is debug-gated for performance, so this only asserts under deadlock.Debug.
+// reflect.Type.Comparable() yet panics on == / as a map key. ensureUsableTag runs
+// the runtime comparability check for struct and array kinds in all builds, so tag
+// expansion must reject even a single such tag with ErrNotUsableAsTag rather than
+// accepting it and deferring a panic to jw.dirty / rq.tagMap on the event
+// goroutine.
 func TestTagExpand_RuntimeNonComparable(t *testing.T) {
-	if !deadlock.Debug {
-		t.Skip("runtime comparability check only runs under deadlock.Debug")
-	}
 	if _, err := TagExpand(nil, testRuntimeNonComparable{v: func() {}}); !errors.Is(err, ErrNotUsableAsTag) {
 		t.Fatalf("expected ErrNotUsableAsTag, got %v", err)
 	}
 }
 
-// TestTagExpand_MultiRuntimeNonComparable covers the multi-element case in all
-// builds: two same-typed runtime-non-comparable values in one expansion. In debug
-// builds ensureUsableTag rejects the first one; in production builds the dedup
-// existing == tag in appendUniqueTag panics, and TagExpand's recover converts it
-// to ErrNotUsableAsTag rather than crashing the caller. Either way it must not
-// panic and must report ErrNotUsableAsTag with no tags.
+// TestTagExpand_MultiRuntimeNonComparable covers the multi-element case: two
+// same-typed runtime-non-comparable values in one expansion. ensureUsableTag
+// rejects the first one with ErrNotUsableAsTag before the dedup existing == tag in
+// appendUniqueTag ever compares them; it must not panic and must report
+// ErrNotUsableAsTag with no tags.
 func TestTagExpand_MultiRuntimeNonComparable(t *testing.T) {
 	a := testRuntimeNonComparable{v: func() {}}
 	b := testRuntimeNonComparable{v: func() {}}


### PR DESCRIPTION
> Draft until PR #71's CodeRabbit review frees the hourly budget; CI runs meanwhile.

Found during a code-review audit.

## Bug
`ensureUsableTag` only ran the runtime comparability check under `deadlock.Debug`. In production it relied on `appendUniqueTag`'s `existing == tag` dedup (and `TagExpand`'s `recover`) to catch a value that is statically comparable but not comparable at runtime — e.g. `struct{ V any }{ V: func(){} }`. But that dedup loop never runs for a **single** tag, so a lone such tag passed `TagExpand` with `err == nil` and only panicked later — `hash of unhashable type` — when used as an `rq.tagMap` key on the render/event goroutine (holding `rq.mu`).

`TestTagExpand_RuntimeNonComparable` was skipped unless `deadlock.Debug`, so the production path was untested.

## Fix
Probe runtime comparability in `ensureUsableTag` for `Struct`/`Array` kinds (the only kinds where static and runtime comparability can differ) in **all builds**, rejecting with the stable `ErrNotUsableAsTag`. The probe is a `recover`-guarded `==` comparison rather than `reflect.Value.Comparable`, which allocates while walking the value.

## Performance
Common scalar/pointer/string tags skip the probe entirely (zero change). Only struct/array-*value* tags pay, and the probe is allocation-free:

```
name                  old             new
TagExpand/SingleTag   31.5n / 1 alloc  31.9n / 1 alloc   (~)
TagExpand/StructTag   35.5n / 1 alloc  39.6n / 1 alloc   (+11% time, 0 extra alloc)
```

For contrast, `reflect.Value.Comparable` measured **+352% time and +5 allocs/op** on `StructTag`; this PR deliberately avoids it. A `StructTag` benchmark case is added to guard the probed path.

## Tests
`TestTagExpand_RuntimeNonComparable` is unskipped so it asserts in all builds (it fails — `got <nil>` — without the fix). The now-unused `deadlock` import is dropped.

Local gate: `gofmt`/`gofumpt` clean, `go vet`, `staticcheck`, `golangci-lint` (0 issues), `gosec`, `go test -race ./...` all pass.