### PR TITLE
Share one DefaultAuth per Jaws so the fail-open warning logs once

### DIFF
--- a/contracts.go
+++ b/contracts.go
@@ -144,3 +144,16 @@ func (da *DefaultAuth) IsAdmin() bool {
 	})
 	return true
 }
+
+// DefaultAuth returns the shared fail-open [DefaultAuth] used for templates when
+// [Jaws.MakeAuth] is nil.
+//
+// It is created on first use and reused, so the embedded [sync.Once] warning in
+// [DefaultAuth.IsAdmin] fires at most once per [Jaws] rather than once per
+// template render. The value of [Jaws.Logger] in effect at first use is captured.
+func (jw *Jaws) DefaultAuth() *DefaultAuth {
+	jw.defaultAuthOnce.Do(func() {
+		jw.defaultAuthVal = &DefaultAuth{Logger: jw.Logger}
+	})
+	return jw.defaultAuthVal
+}

--- a/contracts_test.go
+++ b/contracts_test.go
@@ -112,6 +112,23 @@ func Test_defaultAuth(t *testing.T) {
 	}
 }
 
+func TestJaws_DefaultAuthReturnsSharedInstance(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+	// A shared instance keeps the embedded sync.Once effective across renders so
+	// the fail-open warning is logged once per Jaws, not once per template render.
+	a := jw.DefaultAuth()
+	if a == nil {
+		t.Fatal("DefaultAuth returned nil")
+	}
+	if jw.DefaultAuth() != a {
+		t.Fatal("DefaultAuth must return the same shared instance")
+	}
+}
+
 func Test_InitialHTMLAttrHandler_IgnoredByDispatch(t *testing.T) {
 	if err := callEventHandler(testJawsInitialHTMLAttr{}, nil, what.Input, "ignored"); err != ErrEventUnhandled {
 		t.Fatalf("expected ErrEventUnhandled, got %v", err)

--- a/jaws.go
+++ b/jaws.go
@@ -162,6 +162,8 @@ type Jaws struct {
 	unsubCh                 chan chan wire.Message
 	updateTicker            *time.Ticker
 	serving                 atomic.Bool
+	defaultAuthOnce         sync.Once    // guards lazy creation of defaultAuthVal
+	defaultAuthVal          *DefaultAuth // shared fail-open Auth; see [Jaws.DefaultAuth]
 	reqPool                 sync.Pool
 	serveJS                 *staticserve.StaticServe
 	serveCSS                *staticserve.StaticServe

--- a/lib/ui/template.go
+++ b/lib/ui/template.go
@@ -48,7 +48,9 @@ func (tmpl Template) auth(elem *jaws.Element) (auth jaws.Auth) {
 	if f := elem.Request.Jaws.MakeAuth; f != nil {
 		auth = f(elem.Request)
 	} else {
-		auth = &jaws.DefaultAuth{Logger: elem.Request.Jaws.Logger}
+		// Reuse the instance's shared DefaultAuth so its one-time fail-open warning
+		// is logged once per Jaws, not once per render.
+		auth = elem.Request.Jaws.DefaultAuth()
 	}
 	return
 }

--- a/lib/ui/template_handler_test.go
+++ b/lib/ui/template_handler_test.go
@@ -65,6 +65,48 @@ func (l *templateLogger) Error(_ string, args ...any) {
 	}
 }
 
+// warnCountLogger counts Warn calls whose message contains substr.
+type warnCountLogger struct {
+	substr string
+	count  int
+}
+
+func (l *warnCountLogger) Info(string, ...any) {}
+func (l *warnCountLogger) Warn(msg string, _ ...any) {
+	if strings.Contains(msg, l.substr) {
+		l.count++
+	}
+}
+func (l *warnCountLogger) Error(string, ...any) {}
+
+// TestTemplate_DefaultAuthWarnsOncePerJawsAcrossRenders verifies that with
+// MakeAuth unset, rendering a template that consults .Auth.IsAdmin logs the
+// fail-open warning only once per Jaws instance across many renders. The reused
+// jaws.Jaws.DefaultAuth keeps its sync.Once effective; a fresh DefaultAuth
+// allocated per render (the previous behavior) re-warns on every render.
+func TestTemplate_DefaultAuthWarnsOncePerJawsAcrossRenders(t *testing.T) {
+	jw, rq := newCoreRequest(t)
+	logger := &warnCountLogger{substr: "DefaultAuth.IsAdmin returns true"}
+	jw.Logger = logger
+	// MakeAuth is deliberately left nil so templates receive the DefaultAuth.
+
+	_ = jw.AddTemplateLookuper(template.Must(template.New("authtmpl").Parse(
+		`{{if $.Auth.IsAdmin}}<span>admin</span>{{end}}`,
+	)))
+
+	for range 3 {
+		var sb bytes.Buffer
+		rw := RequestWriter{Request: rq, Writer: &sb}
+		if err := rw.Template("div", "authtmpl", tag.Tag("dot")); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if logger.count != 1 {
+		t.Fatalf("fail-open warning logged %d times across 3 renders, want 1", logger.count)
+	}
+}
+
 func TestTemplate_RenderUpdateEventAndHelpers(t *testing.T) {
 	jw, rq := newCoreRequest(t)
 	jw.MakeAuth = func(*jaws.Request) jaws.Auth { return templateAuth{} }


### PR DESCRIPTION
> Draft until earlier PRs' CodeRabbit reviews free the hourly budget; CI runs meanwhile.

Found during a code-review audit.

## Bug
`DefaultAuth.IsAdmin` logs a one-time fail-open warning guarded by an embedded `sync.Once`, and its doc says "one-time warning". But `Template.auth` (lib/ui) allocated a **fresh** `&jaws.DefaultAuth{...}` on every render when `Jaws.MakeAuth` is nil. Each fresh value has its own zero `Once`, so the warning was re-emitted on every template execution that consults `.Auth.IsAdmin` — log spam proportional to render volume, contradicting the doc. (`IsAdmin` still always returns `true`, so there is no correctness/security change from the bug itself; the fail-open risk is separately documented.)

## Fix
Cache a single `DefaultAuth` per `Jaws`, created on first use and exposed via the new `Jaws.DefaultAuth()`; `Template.auth` uses it. The embedded `Once` is now scoped to the `Jaws` instance, so the warning fires at most once per instance.

## Tests
- `lib/ui`: `TestTemplate_DefaultAuthWarnsOncePerJawsAcrossRenders` renders an `.Auth.IsAdmin` template three times with `MakeAuth` unset and asserts the warning logs **once** (it logged **three** times before the fix).
- `jaws`: `TestJaws_DefaultAuthReturnsSharedInstance` asserts `DefaultAuth()` returns one shared instance.

## Performance
Strictly fewer allocations on the render path: one shared `DefaultAuth` instead of one per render when `MakeAuth` is nil. No new locking on the hot path (`sync.Once` fast path after first use).

Local gate: `gofmt` clean on changed files, `go vet`, `staticcheck`, `golangci-lint` (0 issues), `gosec`, `go test -race ./...` all pass.