### PR TITLE
Reject non-canonical child indices in jawstree path resolution

### DIFF
--- a/jawstree/node.go
+++ b/jawstree/node.go
@@ -135,6 +135,12 @@ func (node *Node) JawsSetPath(elem *jaws.Element, jsPath string, value any) (err
 // index must be within the current Children range; out-of-range, malformed, or
 // nil-targeting segments are rejected, so a client can neither grow the slice nor
 // address a node that does not exist.
+//
+// Indices must be in canonical decimal form (no leading '+', '-' or zeros) so the
+// index a client sends round-trips to the same string [Node.Walk] emits as the
+// node ID. A non-canonical but in-range index would mutate the server node yet be
+// echoed verbatim as the [Node.JawsPathSet] broadcast "id", which no peer's
+// rendered node matches, diverging peer state from the server.
 func (node *Node) resolveChildPath(nodePath string) (*Node, error) {
 	cur := node
 	for nodePath != "" {
@@ -147,6 +153,9 @@ func (node *Node) resolveChildPath(nodePath string) (*Node, error) {
 		idx, err := strconv.Atoi(idxStr)
 		if err != nil || idx < 0 || idx >= len(cur.Children) || cur.Children[idx] == nil {
 			return nil, fmt.Errorf("%w: child index %q out of range", ErrPathRejected, idxStr)
+		}
+		if strconv.Itoa(idx) != idxStr {
+			return nil, fmt.Errorf("%w: non-canonical child index %q", ErrPathRejected, idxStr)
 		}
 		cur = cur.Children[idx]
 	}

--- a/jawstree/node_test.go
+++ b/jawstree/node_test.go
@@ -124,6 +124,8 @@ func TestNode_JawsSetPath_Gate(t *testing.T) {
 			"children.99.selected",           // far out of range
 			"children.-1.selected",           // negative
 			"children.x.selected",            // non-numeric
+			"children.+0.selected",           // non-canonical: leading '+' (Atoi accepts it)
+			"children.00.selected",           // non-canonical: leading zero
 			"children.0.children.0.selected", // child has no children
 			"bogus.selected",                 // path segment is not "children"
 		} {


### PR DESCRIPTION
> Draft until earlier PRs' CodeRabbit reviews free the hourly budget; CI runs meanwhile.

Found during a code-review audit.

## Bug
`resolveChildPath` parses each child index with `strconv.Atoi`, which accepts a leading `+` and leading zeros (`Atoi("+0") == 0`, `Atoi("00") == 0`). A WebSocket frame for `children.+0.selected` (or `children.00.selected`) therefore resolved to an in-range node and mutated its `Selected` flag on the server, while `Node.JawsPathSet` broadcasts the caller-supplied path **verbatim** as the JSON `id`. Authoritative node IDs are the canonical form `Node.Walk` produces via `strconv.Itoa` (`children.0`), so peers' `selectNodeById("children.+0")` matched no DOM node: the server and the originating client updated, but **all other clients sharing the Tree silently diverged**.

This is a malformed-input robustness gap, not reachable through normal UI use — the trusted client only ever emits canonical indices. The index still resolved in-range to a real node, so there is no out-of-bounds access or slice growth.

## Fix
Require each index to round-trip through `strconv.Itoa`, rejecting non-canonical forms (`+0`, `00`, `-0`, …) with `ErrPathRejected`. `setPath` only broadcasts when the set succeeds, so the server now neither mutates nor broadcasts on such input, keeping the broadcast `id` canonical and peers convergent.

## Tests
`children.+0.selected` and `children.00.selected` are added to the existing path-rejection table in `TestNode_JawsSetPath_Gate`. Both index 0 (in range for the test tree), so they exercise the new canonical check specifically; both fail (`got <nil>`) without the fix.

## Performance
One `strconv.Itoa` + string compare per path segment on the client-set path (not a hot broadcast/render path). Negligible.

Local gate: `gofmt`/`gofumpt` clean, `go vet`, `staticcheck`, `golangci-lint` (0 issues), `gosec`, `go test -race ./...` all pass.