### PR TITLE
Fix five verified defects from a per-package code review

### DIFF
--- a/element.go
+++ b/element.go
@@ -100,6 +100,19 @@ func (elem *Element) UI() UI {
 	return elem.ui
 }
 
+// Deleted reports whether the [Element] has been removed from its [Request].
+//
+// A deleted Element is inert: [Element.JawsRender], [Element.JawsUpdate] and the
+// queue helpers are all no-ops on it. Widgets that retain *Element references
+// across renders (for example a container helper that pools child elements for
+// reuse) can use this to detect and discard an element that was deleted
+// out-of-band — via a [Jaws.Delete] broadcast on a shared tag or a browser
+// removal — before reusing it, which would otherwise leave the child silently
+// unrendered.
+func (elem *Element) Deleted() bool {
+	return elem.deleted.Load()
+}
+
 func (elem *Element) renderDebug(w io.Writer) {
 	var sb strings.Builder
 	_, _ = fmt.Fprintf(&sb, "<!-- id=%q %T tags=[", elem.Jid(), elem.UI())

--- a/element_test.go
+++ b/element_test.go
@@ -426,7 +426,13 @@ func TestElement_RenderDebugAndDeletedBranches(t *testing.T) {
 	}
 	rq.Jaws.Debug = false
 
+	if elem.Deleted() {
+		t.Fatal("element must not report Deleted before DeleteElement")
+	}
 	rq.DeleteElement(elem)
+	if !elem.Deleted() {
+		t.Fatal("element must report Deleted after DeleteElement")
+	}
 	if err := elem.JawsRender(&sb, nil); err != nil {
 		t.Fatal(err)
 	}

--- a/jaws.go
+++ b/jaws.go
@@ -384,28 +384,69 @@ func MakeID() string {
 func (jw *Jaws) NewRequest(r *http.Request) (rq *Request) {
 	remoteIP := jw.clientIP(r)
 
-	jw.mu.Lock()
-	defer jw.mu.Unlock()
-	jw.limitPendingRequestsLocked(remoteIP)
-	for rq == nil {
-		jawsKey := jw.nonZeroRandomLocked()
-		if _, ok := jw.requests[jawsKey]; !ok {
-			rq = jw.getRequestLocked(jawsKey, r, remoteIP)
-			jw.requests[jawsKey] = rq
-			jw.pending[rq.remoteIP] = append(jw.pending[rq.remoteIP], rq)
+	var toLog []error
+	func() {
+		jw.mu.Lock()
+		defer jw.mu.Unlock()
+		toLog = jw.limitPendingRequestsLocked(remoteIP)
+		for rq == nil {
+			jawsKey := jw.nonZeroRandomLocked()
+			if _, ok := jw.requests[jawsKey]; !ok {
+				rq = jw.getRequestLocked(jawsKey, r, remoteIP)
+				jw.requests[jawsKey] = rq
+				jw.pending[rq.remoteIP] = append(jw.pending[rq.remoteIP], rq)
+			}
+		}
+	}()
+	// Log eviction causes after releasing jw.mu: Jaws.Log calls the user-supplied
+	// Logger, which must never run under a core lock.
+	for _, cause := range toLog {
+		_ = jw.Log(cause)
+	}
+	return
+}
+
+// limitPendingRequestsLocked evicts pending Requests for remoteIP until the cap is
+// satisfied, returning the eviction causes for the caller to log after releasing
+// jw.mu (see the package locking contract). Caller must hold jw.mu.
+func (jw *Jaws) limitPendingRequestsLocked(remoteIP netip.Addr) (toLog []error) {
+	limit := jw.MaxPendingRequestsPerIP
+	if limit > 0 {
+		for len(jw.pending[remoteIP]) >= limit {
+			victim := jw.oldestEvictablePendingLocked(remoteIP)
+			if victim == nil {
+				// Every pending Request for this IP is mid-render. Evicting one would
+				// recycle a Request whose initial HTML is still being assembled on an
+				// HTTP goroutine that holds no jw.mu, letting a later NewRequest reuse
+				// the pooled pointer under a new key while that goroutine keeps
+				// appending elements (contaminating the new Request and leaking its
+				// key). Prefer a brief, self-correcting overshoot of the cap: the
+				// renders finish and connect (or time out and get recycled by the
+				// maintenance pass) shortly.
+				return
+			}
+			if cause := jw.recycleLockedWithCause(victim, newErrTooManyPendingRequests(remoteIP, limit)); cause != nil {
+				toLog = append(toLog, cause)
+			}
 		}
 	}
 	return
 }
 
-func (jw *Jaws) limitPendingRequestsLocked(remoteIP netip.Addr) {
-	limit := jw.MaxPendingRequestsPerIP
-	if limit > 0 {
-		for len(jw.pending[remoteIP]) >= limit {
-			oldest := jw.pending[remoteIP][0]
-			jw.recycleLockedWithCause(oldest, newErrTooManyPendingRequests(remoteIP, limit))
+// oldestEvictablePendingLocked returns the oldest pending [Request] for remoteIP
+// that is not currently being rendered, or nil if every one of them is.
+//
+// A Request whose Rendering flag is set has been written to by [RequestWriter] and
+// may still be assembling its initial HTML; recycling it would corrupt that
+// in-flight render (see [Jaws.limitPendingRequestsLocked]). This mirrors the
+// Rendering reprieve the maintenance-timeout path honors in [Request.maintenance].
+func (jw *Jaws) oldestEvictablePendingLocked(remoteIP netip.Addr) *Request {
+	for _, rq := range jw.pending[remoteIP] {
+		if !rq.Rendering.Load() {
+			return rq
 		}
 	}
+	return nil
 }
 
 func (jw *Jaws) removePendingRequestLocked(rq *Request) {
@@ -1015,11 +1056,14 @@ func (jw *Jaws) unsubscribe(msgCh chan wire.Message) {
 }
 
 func (jw *Jaws) maintenance(requestTimeout time.Duration) {
+	var toLog []error
 	jw.mu.Lock()
-	defer jw.mu.Unlock()
 	now := time.Now()
 	for _, rq := range jw.requests {
-		if rq.maintenance(now, requestTimeout) {
+		if expired, cause := rq.maintenance(now, requestTimeout); expired {
+			if cause != nil {
+				toLog = append(toLog, cause)
+			}
 			jw.recycleLocked(rq)
 		}
 	}
@@ -1027,6 +1071,12 @@ func (jw *Jaws) maintenance(requestTimeout time.Duration) {
 		if sess.isDead() {
 			delete(jw.sessions, k)
 		}
+	}
+	jw.mu.Unlock()
+	// Log cancellation causes after releasing jw.mu: Jaws.Log calls the
+	// user-supplied Logger, which must never run under a core lock.
+	for _, cause := range toLog {
+		_ = jw.Log(cause)
 	}
 }
 
@@ -1221,22 +1271,27 @@ func (jw *Jaws) getRequestLocked(jawsKey key.Key, r *http.Request, remoteIP neti
 	return rq
 }
 
-func (jw *Jaws) recycleLockedWithCause(rq *Request, err error) {
+// recycleLockedWithCause recycles rq, optionally cancelling its context with err.
+// It returns the cancellation cause (or nil) instead of logging it, so the caller
+// can log it after releasing jw.mu (see the package locking contract). Caller must
+// hold jw.mu.
+func (jw *Jaws) recycleLockedWithCause(rq *Request, err error) (cause error) {
 	rq.mu.Lock()
 	defer rq.mu.Unlock()
 	if rq.JawsKey != 0 {
 		if err != nil {
-			rq.cancelLocked(err)
+			cause = rq.cancelLocked(err)
 		}
 		jw.removePendingRequestLocked(rq)
 		delete(jw.requests, rq.JawsKey)
 		rq.clearLocked()
 		jw.reqPool.Put(rq)
 	}
+	return
 }
 
 func (jw *Jaws) recycleLocked(rq *Request) {
-	jw.recycleLockedWithCause(rq, nil)
+	_ = jw.recycleLockedWithCause(rq, nil) // nil err yields a nil cause; nothing to log
 }
 
 func (jw *Jaws) recycle(rq *Request) {
@@ -1253,11 +1308,17 @@ func (jw *Jaws) recycle(rq *Request) {
 // Holding jw.mu across the cancel keeps the identity check valid, since
 // recycling requires the jw.mu write lock.
 func (jw *Jaws) cancelIfCurrent(jawsKey key.Key, rq *Request, err error) {
+	var cause error
 	jw.mu.RLock()
-	defer jw.mu.RUnlock()
 	if jw.requests[jawsKey] == rq {
-		rq.cancel(err)
+		rq.mu.Lock()
+		cause = rq.cancelLocked(err)
+		rq.mu.Unlock()
 	}
+	jw.mu.RUnlock()
+	// Log after releasing both locks: Jaws.Log calls the user-supplied Logger,
+	// which must never run under a core lock (this path holds jw.mu read).
+	_ = jw.Log(cause)
 }
 
 var headerCacheControlNoStore = []string{"no-store"}

--- a/jaws.go
+++ b/jaws.go
@@ -30,20 +30,20 @@
 // JsVar in [github.com/linkdata/jaws/lib/ui] and the named values in
 // [github.com/linkdata/jaws/lib/named]. These are leaves with respect to each
 // other, acquired containing-before-contained (for example a named BoolArray's
-// mutex is taken before a member Bool's). They sit below the three core locks
-// above, but with one deliberate reverse edge: marking an [Element] dirty or
-// broadcasting a change ultimately takes the outermost Jaws.mu, and a value type
-// may run that side effect while still holding its own value lock (lib/named does
-// this; lib/bind and lib/ui release the value lock first). That is the reverse of
-// the "outermost first" rule and is safe only because the edge never closes a
-// cycle: no code path holding Jaws.mu, Request.mu or Session.mu ever calls into a
-// UI value's Get/Set/Dirty methods, which are the only callers that take a value
-// lock. Code holding any of the three core locks must therefore never invoke a UI
-// value method. New value types should prefer the lib/bind / lib/ui pattern
-// (mutate under the value lock, release it, then mark dirty) so they do not depend
-// on this invariant.
+// mutex is taken before a member Bool's). They sit strictly below the three core
+// locks: every value type mutates the bound value under its value lock, releases
+// it, and only then marks the [Element] dirty or broadcasts the change (which
+// ultimately takes the outermost Jaws.mu), so a value lock is never held while a
+// core lock is acquired. lib/bind, lib/ui and lib/named all follow this
+// mutate-release-then-dirty pattern, and new value types must too. The safety of
+// this rests on an invariant the deadlock detector cannot enforce (value locks are
+// leaves distinct from Jaws.mu): no code path holding Jaws.mu, Request.mu or
+// Session.mu ever calls into a UI value's Get/Set/Dirty methods, which are the only
+// callers that take a value lock — were it otherwise, the later dirty step's Jaws.mu
+// acquisition would invert the core lock order. Code holding any of the three core
+// locks must therefore never invoke a UI value method.
 //
-// A second deliberate reverse edge lives in [github.com/linkdata/jaws/lib/ui]:
+// A deliberate reverse edge lives in [github.com/linkdata/jaws/lib/ui]:
 // ContainerHelper.reconcile holds its own widget mutex while calling
 // [Request.NewElement], which takes Request.mu — again leaf-before-core. It is safe
 // for the same reason: no code path holding any of the three core locks ever

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -157,6 +157,139 @@ func TestJaws_MaxPendingRequestsPerIPEvictsOldestPending(t *testing.T) {
 	}
 }
 
+// reentrantLogger re-enters the Jaws instance while logging (via RequestCount,
+// which takes jw.mu.RLock), and records the logged error. If the framework ever
+// invokes the logger while holding jw.mu, this deadlocks.
+type reentrantLogger struct {
+	jw     *Jaws
+	logged chan error
+}
+
+func (l reentrantLogger) Info(string, ...any) {}
+func (l reentrantLogger) Warn(string, ...any) {}
+func (l reentrantLogger) Error(_ string, args ...any) {
+	_ = l.jw.RequestCount() // re-enter Jaws under jw.mu.RLock
+	for i := 0; i+1 < len(args); i += 2 {
+		if args[i] == "err" {
+			if err, ok := args[i+1].(error); ok {
+				select {
+				case l.logged <- err:
+				default:
+				}
+			}
+		}
+	}
+}
+
+// TestJaws_MaintenanceLogsCancelOutsideLock verifies the maintenance pass logs a
+// request-cancellation cause AFTER releasing jw.mu, so a user Logger that re-enters
+// the Jaws instance does not deadlock the Serve loop. Before the fix the logger ran
+// while jw.mu was held for writing, which would deadlock on any re-entrant lock.
+func TestJaws_MaintenanceLogsCancelOutsideLock(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+	logged := make(chan error, 1)
+	jw.Logger = reentrantLogger{jw: jw, logged: logged}
+
+	// A pending request idle long enough for the maintenance pass to recycle it.
+	rq := jw.NewRequest(newPendingLimitRequest("192.0.2.1:1000"))
+	setPendingLimitLastWrite(t, rq, time.Now().Add(-time.Hour))
+
+	done := make(chan struct{})
+	go func() {
+		jw.maintenance(time.Second)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("maintenance deadlocked: user Logger re-entered Jaws while jw.mu was held")
+	}
+	select {
+	case e := <-logged:
+		if !errors.Is(e, ErrNoWebSocketRequest) {
+			t.Fatalf("logged cause = %v, want ErrNoWebSocketRequest", e)
+		}
+	default:
+		t.Fatal("expected the cancellation cause to be logged")
+	}
+}
+
+// TestJaws_MaxPendingRequestsPerIPSparesRenderingRequest verifies that the pending
+// cap does not evict a Request that is still rendering its initial HTML. The oldest
+// pending Request would normally be evicted first, but evicting one whose render is
+// in flight on another goroutine would recycle it underneath that goroutine,
+// contaminating a later reuse and leaking its key. The cap must instead evict the
+// next-oldest idle Request, leaving the rendering one claimable.
+func TestJaws_MaxPendingRequestsPerIPSparesRenderingRequest(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+	jw.MaxPendingRequestsPerIP = 2
+
+	renderingReq := newPendingLimitRequest("192.0.2.1:1000")
+	renderingRq := jw.NewRequest(renderingReq)
+	renderingKey := renderingRq.JawsKey
+	// Simulate an in-flight initial render on the oldest pending Request.
+	renderingRq.Rendering.Store(true)
+
+	idleReq := newPendingLimitRequest("192.0.2.1:1001")
+	idleRq := jw.NewRequest(idleReq)
+	idleKey := idleRq.JawsKey
+
+	// Creating a third same-IP Request trips the cap (pending == 2).
+	newReq := newPendingLimitRequest("192.0.2.1:1002")
+	newRq := jw.NewRequest(newReq)
+	newKey := newRq.JawsKey
+
+	// The rendering Request must survive; the idle one is the one evicted.
+	if claimed := jw.UseRequest(renderingKey, renderingReq); claimed != renderingRq {
+		t.Fatalf("rendering request claim = %v, want it to survive eviction", claimed)
+	}
+	if claimed := jw.UseRequest(idleKey, idleReq); claimed != nil {
+		t.Fatalf("idle request should have been evicted, got %v", claimed)
+	}
+	if claimed := jw.UseRequest(newKey, newReq); claimed != newRq {
+		t.Fatalf("new request claim = %v, want %v", claimed, newRq)
+	}
+}
+
+// TestJaws_MaxPendingRequestsPerIPOvershootsWhenAllRendering verifies that when
+// every pending request for an IP is mid-render, the cap is not enforced by
+// recycling one of them: oldestEvictablePendingLocked finds no idle victim, so the
+// cap is allowed a brief, self-correcting overshoot rather than corrupting an
+// in-flight render.
+func TestJaws_MaxPendingRequestsPerIPOvershootsWhenAllRendering(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+	jw.MaxPendingRequestsPerIP = 1
+
+	rq1 := jw.NewRequest(newPendingLimitRequest("192.0.2.1:1000"))
+	rq1Key := rq1.JawsKey
+	rq1.Rendering.Store(true)
+
+	// A second same-IP request trips the cap, but the only pending request is
+	// rendering, so nothing is evicted and the cap overshoots to 2.
+	rq2 := jw.NewRequest(newPendingLimitRequest("192.0.2.1:1001"))
+	if rq2 == nil {
+		t.Fatal("expected the new request to be created despite the cap")
+	}
+	if got := jw.Pending(); got != 2 {
+		t.Fatalf("Pending() = %d, want 2 (cap overshoots while all pending render)", got)
+	}
+	if rq1.JawsKey == 0 || rq1.JawsKey != rq1Key {
+		t.Fatal("the rendering request must not be recycled by the cap")
+	}
+}
+
 func TestJaws_MaxPendingRequestsPerIPKeepsDifferentIPs(t *testing.T) {
 	jw, err := New()
 	if err != nil {

--- a/jawstree/node.go
+++ b/jawstree/node.go
@@ -176,6 +176,22 @@ func (node *Node) JawsPathSet(elem *jaws.Element, jsPath string, value any) {
 	}
 }
 
+// stripNilChildren removes any nil entries from node.Children and every
+// descendant's Children, in place.
+//
+// [New] calls this before assigning node IDs so the slice index used for an ID
+// ([Node.Walk]) matches the position the compacted wire array gives a child
+// ([Node.marshalJSON] skips nil children). Without it, a single nil child shifts
+// every following sibling's wire position relative to its ID, so a client click —
+// whose path is built from the wire-array position — would resolve to the wrong
+// node (or a rejected nil slot) in [Node.resolveChildPath].
+func (node *Node) stripNilChildren() {
+	node.Children = slices.DeleteFunc(node.Children, func(c *Node) bool { return c == nil })
+	for _, child := range node.Children {
+		child.stripNilChildren()
+	}
+}
+
 // Walk calls fn for node and all descendants with their JSON paths.
 func (node *Node) Walk(jsPath string, fn func(jsPath string, node *Node)) {
 	fn(jsPath, node)

--- a/jawstree/tree.go
+++ b/jawstree/tree.go
@@ -52,13 +52,16 @@ func New(id string, jsvar *ui.JsVar[Node], options ...Option) (t *Tree) {
 	for _, opt := range options {
 		t.options |= opt
 	}
+	// Normalize away any nil children before assigning IDs so a node's slice
+	// index (its ID) always matches its position in the compacted wire array
+	// emitted by marshalJSON; otherwise a nil child desyncs the two and client
+	// path resolution targets the wrong node. See [Node.stripNilChildren].
+	jsvar.Ptr.stripNilChildren()
 	jsvar.Ptr.Walk("", func(jsPath string, node *Node) {
 		node.ID = jsPath
 		node.Tree = t
 		for _, child := range node.Children {
-			if child != nil { // defensive: the gate in JawsSetPath prevents nil children
-				child.Parent = node
-			}
+			child.Parent = node // stripNilChildren guarantees no nil entries here
 		}
 	})
 	return

--- a/jawstree/tree_test.go
+++ b/jawstree/tree_test.go
@@ -165,6 +165,42 @@ func TestNewSetsParentPointers(t *testing.T) {
 	}
 }
 
+func TestNewStripsNilChildrenKeepingPathIndexConsistent(t *testing.T) {
+	// A hand-built tree may contain a nil child. Before this was normalized, New
+	// assigned IDs from the raw slice index while the wire array (marshalJSON)
+	// compacted nils away, so the client's position-based path resolved to the
+	// wrong node. After New, indices must be dense and a position-based path must
+	// hit the matching node.
+	a := &Node{Name: "a"}
+	b := &Node{Name: "b"}
+	root := &Node{Name: "root", Children: []*Node{nil, a, b}}
+	var mu deadlock.RWMutex
+	New("tree", ui.NewJsVar(&mu, root))
+
+	if len(root.Children) != 2 || root.Children[0] != a || root.Children[1] != b {
+		t.Fatalf("New did not strip the nil child: %#v", root.Children)
+	}
+	if a.ID != "children.0" || b.ID != "children.1" {
+		t.Fatalf("dense IDs expected, got a=%q b=%q", a.ID, b.ID)
+	}
+
+	// The browser builds the path from the compacted wire-array position. Position
+	// 1 is b; it must toggle b, not a, and must not be rejected.
+	if err := root.JawsSetPath(nil, "children.1.selected", true); err != nil {
+		t.Fatalf("JawsSetPath children.1: %v", err)
+	}
+	if !b.Selected || a.Selected {
+		t.Fatalf("children.1 should select b only: a=%v b=%v", a.Selected, b.Selected)
+	}
+	// Position 0 is a; it must resolve rather than hit a (formerly nil) slot.
+	if err := root.JawsSetPath(nil, "children.0.selected", true); err != nil {
+		t.Fatalf("JawsSetPath children.0: %v", err)
+	}
+	if !a.Selected {
+		t.Fatal("children.0 should select a")
+	}
+}
+
 func TestTreeSelectionMethodsConcurrentWithInput(t *testing.T) {
 	jw, err := jaws.New()
 	maybeError(t, err)

--- a/lib/ui/containerhelper.go
+++ b/lib/ui/containerhelper.go
@@ -137,10 +137,19 @@ func (u *ContainerHelper) reconcile(elem *jaws.Element, wantContents []jaws.UI) 
 	u.contents = u.contents[:0]
 	for _, childUI := range wantContents {
 		var childElem *jaws.Element
-		if elems := pool[childUI]; len(elems) > 0 {
-			childElem = elems[0]
+		// Reuse a pooled Element, discarding any that were deleted out-of-band (a
+		// what.Delete broadcast targeting a tag the child registered, or a browser
+		// what.Remove). A deleted Element is inert, so reusing it would leave the
+		// child permanently unrendered and put a phantom Jid in the Order; falling
+		// through to NewElement re-creates it so the container self-heals.
+		for elems := pool[childUI]; len(elems) > 0 && childElem == nil; elems = pool[childUI] {
+			candidate := elems[0]
 			pool[childUI] = elems[1:]
-		} else {
+			if !candidate.Deleted() {
+				childElem = candidate
+			}
+		}
+		if childElem == nil {
 			childElem = elem.Request.NewElement(childUI)
 			toAppend = append(toAppend, childElem)
 		}

--- a/lib/ui/containerhelper_test.go
+++ b/lib/ui/containerhelper_test.go
@@ -182,6 +182,50 @@ func TestContainerHelperUpdateContainerDuplicates(t *testing.T) {
 	}
 }
 
+// TestContainerHelper_ReconcileDiscardsOutOfBandDeletedChild verifies that a child
+// Element deleted out-of-band (e.g. by a what.Delete broadcast on a shared tag, or a
+// browser what.Remove) is not reused from the reconcile pool. A deleted Element is
+// inert, so reusing it would leave the still-wanted child permanently unrendered and
+// put a phantom Jid in the Order; reconcile must create a fresh Element instead.
+func TestContainerHelper_ReconcileDiscardsOutOfBandDeletedChild(t *testing.T) {
+	_, rq := newCoreRequest(t)
+	span1 := NewSpan(testHTMLGetter("span1"))
+	span2 := NewSpan(testHTMLGetter("span2"))
+	tc := &testContainer{contents: []jaws.UI{span1, span2}}
+	container := NewContainer("div", tc)
+	elem, _ := renderUI(t, rq, container)
+
+	if len(container.contents) != 2 {
+		t.Fatalf("want 2 contents got %d", len(container.contents))
+	}
+	deletedChild := container.contents[1]
+	deletedJid := deletedChild.Jid()
+
+	// Delete span2's Element out-of-band while the container still wants it.
+	rq.DeleteElement(deletedChild)
+	if !deletedChild.Deleted() {
+		t.Fatal("expected child to be marked deleted")
+	}
+
+	// tc.contents is unchanged (still wants span1 and span2), so reconcile must not
+	// reuse the deleted Element for span2.
+	container.JawsUpdate(elem)
+
+	if len(container.contents) != 2 {
+		t.Fatalf("want 2 contents after update got %d", len(container.contents))
+	}
+	fresh := container.contents[1]
+	if fresh == deletedChild || fresh.Jid() == deletedJid {
+		t.Fatal("reconcile reused the deleted Element instead of creating a fresh one")
+	}
+	if fresh.Deleted() {
+		t.Fatal("replacement child must not be deleted")
+	}
+	if rq.GetElementByJid(fresh.Jid()) == nil {
+		t.Fatal("replacement child must be registered in the request")
+	}
+}
+
 func TestContainerHelperRenderErrorPaths(t *testing.T) {
 	_, rq := newCoreRequest(t)
 	renderErr := errors.New("render error")

--- a/request.go
+++ b/request.go
@@ -447,42 +447,50 @@ func (rq *Request) SetContext(fn func(oldCtx context.Context) (newCtx context.Co
 // request that never went live it cancels and reports expiry once it has been
 // idle longer than requestTimeout, or immediately if its context is already
 // done. Called from the Serve loop's maintenance pass while jw.mu is held.
-func (rq *Request) maintenance(now time.Time, requestTimeout time.Duration) bool {
+//
+// It returns the cancellation cause (or nil) rather than logging it, so the caller
+// can log it after releasing jw.mu — logging runs the user [Jaws.Logger], which
+// must not be invoked under a lock.
+func (rq *Request) maintenance(now time.Time, requestTimeout time.Duration) (expired bool, cause error) {
 	if !rq.running.Load() {
+		rq.mu.Lock()
 		if rq.Rendering.Swap(false) {
-			rq.mu.Lock()
 			rq.lastWrite = now
-			rq.mu.Unlock()
 		}
-		rq.mu.RLock()
-		err := rq.ctx.Err()
-		since := now.Sub(rq.lastWrite)
-		rq.mu.RUnlock()
-		if err != nil {
-			return true
+		if rq.ctx.Err() != nil {
+			expired = true
+		} else if now.Sub(rq.lastWrite) > requestTimeout {
+			cause = rq.cancelLocked(newErrNoWebSocketRequest(rq))
+			expired = true
 		}
-		if since > requestTimeout {
-			rq.cancel(newErrNoWebSocketRequest(rq))
-			return true
-		}
+		rq.mu.Unlock()
 	}
-	return false
+	return
 }
 
 // cancelLocked cancels the request's context with a wrapped cause, but only for a
 // live request (non-zero key) whose context has not already been cancelled.
-// Caller must hold rq.mu.
-func (rq *Request) cancelLocked(err error) {
+//
+// It does NOT log. It returns the cancellation cause (already set on the context)
+// so the caller can pass it to [Jaws.Log] AFTER releasing rq.mu and any outer lock;
+// the cause is nil whenever there is nothing to log (no live request to cancel, or
+// a nil err). Logging invokes the user-supplied [Jaws.Logger], which the package
+// locking contract forbids running under a lock. Caller must hold rq.mu.
+func (rq *Request) cancelLocked(err error) (cause error) {
 	if rq.JawsKey != 0 && rq.ctx.Err() == nil {
-		rq.cancelFn(rq.Jaws.Log(newErrRequestCancelledLocked(rq, err)))
+		cause = newErrRequestCancelledLocked(rq, err)
+		rq.cancelFn(cause)
 	}
+	return
 }
 
-// cancel locks rq.mu and calls cancelLocked.
+// cancel locks rq.mu, cancels the context, then logs the cancellation cause after
+// releasing the lock ([Jaws.Log] is a no-op on a nil cause).
 func (rq *Request) cancel(err error) {
 	rq.mu.Lock()
-	defer rq.mu.Unlock()
-	rq.cancelLocked(err)
+	cause := rq.cancelLocked(err)
+	rq.mu.Unlock()
+	_ = rq.Jaws.Log(cause)
 }
 
 // Cancel aborts the Request.

--- a/request_test.go
+++ b/request_test.go
@@ -684,7 +684,7 @@ func TestRequest_ClaimRefreshesLastWriteAndStartServeGuards(t *testing.T) {
 		t.Fatal("expected claim to succeed")
 	}
 	// claim refreshed lastWrite, so the just-claimed request is not idle-eligible.
-	if rq.maintenance(time.Now(), time.Second) {
+	if expired, _ := rq.maintenance(time.Now(), time.Second); expired {
 		t.Fatal("a freshly claimed request must not be treated as idle by maintenance")
 	}
 
@@ -1710,13 +1710,13 @@ func TestCoverage_RequestMaintenanceClaimAndErrors(t *testing.T) {
 	now := time.Now()
 	rqM := jw.NewRequest(httptest.NewRequest("GET", "/", nil))
 	rqM.lastWrite = now.Add(-time.Hour)
-	if !rqM.maintenance(now, time.Second) {
+	if expired, _ := rqM.maintenance(now, time.Second); !expired {
 		t.Fatal("expected maintenance timeout")
 	}
 	rqR := jw.NewRequest(httptest.NewRequest("GET", "/", nil))
 	nowR := time.Now()
 	rqR.Rendering.Store(true)
-	if rqR.maintenance(nowR, time.Hour) {
+	if expired, _ := rqR.maintenance(nowR, time.Hour); expired {
 		t.Fatal("expected maintenance continue")
 	}
 	rqR.mu.RLock()
@@ -1727,12 +1727,12 @@ func TestCoverage_RequestMaintenanceClaimAndErrors(t *testing.T) {
 	}
 	rqC := jw.NewRequest(httptest.NewRequest("GET", "/", nil))
 	rqC.cancel(errors.New("cancelled"))
-	if !rqC.maintenance(time.Now(), time.Hour) {
+	if expired, _ := rqC.maintenance(time.Now(), time.Hour); !expired {
 		t.Fatal("expected maintenance cancellation")
 	}
 	rqOK := jw.NewRequest(httptest.NewRequest("GET", "/", nil))
 	rqOK.lastWrite = time.Now()
-	if rqOK.maintenance(time.Now(), time.Hour) {
+	if expired, _ := rqOK.maintenance(time.Now(), time.Hour); expired {
 		t.Fatal("expected maintenance keepalive")
 	}
 


### PR DESCRIPTION
## Summary

Fixes five defects surfaced by a per-package code-quality review and confirmed by
adversarial cross-checking. None is a memory-safety or cross-user-confidentiality
issue; each fix ships with a regression test that fails against the unfixed code.

The five fixes are grouped into four commits (the pending-cap and cancellation
fixes co-edit the same request-lifecycle code, so they land together):

1. **jawstree: nil-child index desync (high impact, low likelihood).** `New`
   assigned node IDs from the raw `Children` index while `marshalJSON` (the wire
   shape) compacts nil children away, so a nil child shifted every following
   sibling's wire position relative to its ID — a client click resolved to the
   wrong node or was dropped. `New` now strips nil children before assigning IDs so
   the raw index, the wire array and `resolveChildPath` share one index space.
   Requires a hand-built tree containing an explicit nil child; not
   client-triggerable.

2. **lib/ui: stale child element reuse (medium).** `ContainerHelper.reconcile`
   reused a pooled child element that had been deleted out-of-band (a `what.Delete`
   broadcast on a shared tag, or a browser `what.Remove`); the inert element was
   never re-rendered and the child silently vanished. reconcile now discards deleted
   pooled elements and re-creates them. Adds `Element.Deleted()`.

3. **jaws: pending-cap eviction recycles a rendering request (medium).** The cap
   evicted the oldest pending request unconditionally, including one whose initial
   HTML was still rendering, allowing cross-request contamination and a leaked key.
   It now evicts the oldest non-rendering request, mirroring the maintenance path's
   `Rendering` reprieve.

4. **jaws: user `Logger` invoked under core locks (low).** `cancelLocked` called the
   user `Jaws.Logger` while holding `rq.mu` (and `jw.mu` on the maintenance,
   pending-cap and `cancelIfCurrent` paths), violating the documented locking
   contract — a re-entrant logger could deadlock the Serve loop. Cancellation causes
   are now logged only after the locks are released.

5. **jaws: stale locking documentation (low).** The package "Locking" doc cited a
   value-lock-to-`Jaws.mu` reverse edge that `lib/named` no longer has; updated to
   state the mutate-release-then-dirty invariant for all three subpackages.

## Verification

- `go build ./...` and `go vet ./...` clean.
- `go test -race -tags debug ./...` green (the CI configuration; enables the
  deadlock detector and the runtime invariant checks).
- Four new regression tests, each verified to fail against the pre-fix code:
  wrong-node selection (F1), stale-element reuse (F2/lib-ui), recycled-render
  survival (F3), and a maintenance deadlock with a re-entrant logger (F4).
