### PR TITLE
Decode inbound lone-surrogate frames instead of dropping them

### DIFF
--- a/lib/wire/wsmsg.go
+++ b/lib/wire/wsmsg.go
@@ -2,6 +2,7 @@ package wire
 
 import (
 	"bytes"
+	"encoding/json"
 	"html"
 	"strconv"
 	"strings"
@@ -109,11 +110,13 @@ func (m *WsMsg) Format() string {
 // Parse parses an incoming text buffer into a message.
 //
 // The wire format mirrors [WsMsg.Append]. For commands other than [what.Set] and
-// [what.Call], if the Data field begins with a double quote it is decoded with
-// [strconv.Unquote] and the message is rejected if that fails; data that does not
-// begin with a double quote is taken verbatim. Set and Call data is always taken
-// verbatim. In all cases the resulting data is sanitized with
-// [strings.ToValidUTF8].
+// [what.Call], if the Data field begins with a double quote it is decoded as a JSON
+// string: [strconv.Unquote] handles the common case, with a fallback to a JSON
+// string decode for inputs it rejects but the browser's JSON.stringify can produce
+// (notably a lone UTF-16 surrogate, which the fallback maps to U+FFFD). The message
+// is rejected only if both decoders fail. Data that does not begin with a double
+// quote is taken verbatim, as is all Set and Call data. In all cases the resulting
+// data is sanitized with [strings.ToValidUTF8].
 func Parse(txt []byte) (WsMsg, bool) {
 	if len(txt) > 2 && txt[len(txt)-1] == '\n' {
 		if nl1 := bytes.IndexByte(txt, '\t'); nl1 >= 0 {
@@ -125,8 +128,21 @@ func Parse(txt []byte) (WsMsg, bool) {
 					if id := jid.ParseString(string(txt[nl1+1 : nl2])); id.IsValid() {
 						data := string(txt[nl2+1 : len(txt)-1])
 						if txt[nl2+1] == '"' && wht != what.Set && wht != what.Call {
-							var err error
-							if data, err = strconv.Unquote(data); err != nil {
+							// The browser encodes this data with JSON.stringify.
+							// strconv.Unquote decodes the common case cheaply and
+							// allocation-free, but its grammar is not a superset of
+							// JSON: it rejects the "\udXXX" lone-surrogate escapes
+							// JSON.stringify can emit. Fall back to a JSON string
+							// decode (which maps a lone surrogate to U+FFFD) so a
+							// legitimate event is decoded rather than silently dropped;
+							// the ToValidUTF8 below still sanitizes whatever survives.
+							// The fallback lives in jsonUnquoteString so the address it
+							// takes does not force data to the heap on every call.
+							if unq, err := strconv.Unquote(data); err == nil {
+								data = unq
+							} else if unq, ok := jsonUnquoteString(data); ok {
+								data = unq
+							} else {
 								return WsMsg{}, false
 							}
 						}
@@ -141,6 +157,15 @@ func Parse(txt []byte) (WsMsg, bool) {
 		}
 	}
 	return WsMsg{}, false
+}
+
+// jsonUnquoteString decodes s as a JSON string literal, returning ok=false if it
+// is not one. It exists as a separate function so that the address it must take of
+// its decode target does not force [Parse]'s data local to escape to the heap on
+// every call; see the fallback in Parse.
+func jsonUnquoteString(s string) (out string, ok bool) {
+	ok = json.Unmarshal([]byte(s), &out) == nil
+	return
 }
 
 // FillAlert replaces m with an escaped danger alert for err.

--- a/lib/wire/wsmsg_benchmark_test.go
+++ b/lib/wire/wsmsg_benchmark_test.go
@@ -1,0 +1,31 @@
+package wire
+
+import "testing"
+
+var parseBenchSink WsMsg
+
+// BenchmarkParse guards the inbound parse hot path (run on every WebSocket frame)
+// across the common command shapes, including the previously-dropped lone surrogate
+// that now decodes via the JSON fallback. The common quoted and unquoted paths must
+// stay allocation-light; only the rare surrogate case pays the JSON-decode cost.
+func BenchmarkParse(b *testing.B) {
+	frames := []struct {
+		name  string
+		frame []byte
+	}{
+		{"input_plain", []byte("Input\tJid.1\t\"hello world\"\n")},
+		{"input_escaped", []byte("Input\tJid.1\t\"a\\nb\\tc\"\n")},
+		{"input_surrogate", []byte("Input\tJid.1\t\"\\ud800\"\n")},
+		{"input_unquoted", []byte("Input\tJid.1\ttrue\n")},
+		{"set_verbatim", []byte("Set\tJid.1\tpath={\"a\":1}\n")},
+	}
+	for _, f := range frames {
+		b.Run(f.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				parseBenchSink, _ = Parse(f.frame)
+			}
+		})
+	}
+}

--- a/lib/wire/wsmsg_test.go
+++ b/lib/wire/wsmsg_test.go
@@ -170,6 +170,29 @@ func Test_wsParse_IncompleteFails(t *testing.T) {
 	}
 }
 
+// Test_wsParse_InboundLoneSurrogate covers an inbound frame whose JSON-quoted data
+// holds a lone UTF-16 surrogate. The browser's JSON.stringify emits such a value as
+// the literal escape "\udXXX" for Input/Click/ContextMenu/Remove payloads (it does
+// not throw on lone surrogates), but strconv.Unquote rejects "\udXXX", which would
+// silently drop the whole event frame before the ToValidUTF8 sanitizer runs. Parse
+// must instead decode it, replacing the surrogate with U+FFFD, and deliver the event.
+func Test_wsParse_InboundLoneSurrogate(t *testing.T) {
+	frame := "Input\tJid.1\t\"\\ud800\"\n" // data field is the 8-byte JSON string "\ud800"
+	msg, ok := Parse([]byte(frame))
+	if !ok {
+		t.Fatalf("Parse dropped a frame with a lone surrogate: %q", frame)
+	}
+	if msg.What != what.Input || msg.Jid != jid.Jid(1) {
+		t.Errorf("unexpected header: %+v", msg)
+	}
+	if !utf8.ValidString(msg.Data) {
+		t.Errorf("Data is not valid UTF-8: %q", msg.Data)
+	}
+	if msg.Data != "�" {
+		t.Errorf("got Data %q, want the replacement char %q", msg.Data, "�")
+	}
+}
+
 func Fuzz_wsParse(f *testing.F) {
 	f.Add([]byte("Update\t\t\"\"\n"))
 	f.Add([]byte("Click\t\t\"10 20 5 name\\tJid.1\"\n"))


### PR DESCRIPTION
## Defect (per-package code review)

`Parse` decoded the quoted `Data` of inbound `Input`/`Click`/`ContextMenu`/`Remove` frames with `strconv.Unquote`, returning failure (and `ReadLoop` then silently discarding the frame) when it errored — **before** the `strings.ToValidUTF8` sanitizer ran.

The browser encodes that data with `JSON.stringify`, whose string grammar is **not a subset** of `strconv.Unquote`'s: a lone UTF-16 surrogate is emitted as the literal escape `\udXXX` (ES2019 well-formed `JSON.stringify` does not throw on lone surrogates), and `strconv.Unquote` rejects `\udXXX` (`strconv/quote.go` calls `utf8.ValidRune`, false for U+D800–U+DFFF). Input `value` is a UTF-16 `DOMString` and can hold lone surrogates (emoji split, IME/paste, programmatic set), so a legitimate user event was **silently lost** rather than sanitized.

The package doc already noted the two grammars "overlap rather than nest" but only reasoned about the **outbound** `appendJSONQuote` direction; the inbound `JSON.stringify → Unquote` direction was unguarded.

## Fix

Fall back to a JSON string decode (which maps a lone surrogate to U+FFFD) when `strconv.Unquote` fails, so the event is delivered sanitized rather than dropped. The message is rejected only if **both** decoders fail; the common quoted path, the unquoted path and the verbatim Set/Call path are unchanged.

## How the implementation was chosen (benchmarked)

Three decoders were benchmarked (`benchstat -col /impl`, count=10): `strconv.Unquote` only, JSON only, and Unquote-with-JSON-fallback. Pure JSON regressed every inbound frame ~10× with 4–5 extra allocations; the fallback matches `strconv.Unquote` on the common path and pays the JSON cost only on the rare surrogate case.

The benchmark also exposed a subtle regression: inlining `json.Unmarshal([]byte(data), &data)` forced `Parse`'s `data` local to **escape to the heap on every call** (a uniform +1 alloc on all frames, including the unquoted and Set/Call paths that never decode). Moving the address-taken target into a small `jsonUnquoteString` helper keeps `data` on the stack.

`BenchmarkParse` (kept as a regression guard) confirms the common, unquoted and verbatim paths are **allocation-identical to `main`**; only the previously-dropped surrogate frame costs more:

| frame | before (main) | after |
|---|---|---|
| input_plain | 1 alloc | 1 alloc |
| input_unquoted | 1 alloc | 1 alloc |
| set_verbatim | 1 alloc | 1 alloc |
| input_surrogate | dropped | decoded (6 allocs) |

## Tests

- `Test_wsParse_InboundLoneSurrogate` feeds `Input\tJid.1\t"\ud800"\n` and asserts the event is delivered with `Data` = U+FFFD, not dropped. It fails on the unpatched code.
- `Fuzz_appendJSONQuote` / the existing outbound round-trip remain green (outbound path untouched).

## Verification

`go vet`, `gofumpt -l`, `staticcheck`, `go build`, `go test -race ./...`, and `go test -tags debug -race ./...` all pass.