### PR TITLE
Scope minesweeper per-cell dirtying to one cell, not the whole board

### DIFF
--- a/.agents/skills/jaws/SKILL.md
+++ b/.agents/skills/jaws/SKILL.md
@@ -31,6 +31,7 @@ JaWS is an immediate-mode, server-driven UI framework, not an MVC framework.
 - Dirty only affected dependency tags after mutations, and include any derived-field dependencies that changed.
 - Avoid synthetic tags (coordinates, ad-hoc strings, wrappers) when a stable underlying data pointer exists.
 - For collection elements, register each element with both its item-level tag (the item's pointer) and a shared group tag (for example `&g.items`). Mutations can then dirty a single item, several items, or the whole group from the same tag namespace, without changing what each element listens to.
+- Keep an item's own `JawsGetTag` scoped to the item, never returning the shared group tag. Element *registration* (what an element listens to) and dirty-target *expansion* (what `Request.Dirty(x)` resolves to) are different things. If an item type implements `tag.TagGetter` and its `JawsGetTag` returns `[]any{item, &group}`, then `Request.Dirty(item)` tag-expands to include `&group` and re-renders **every** element registered under it — silently defeating per-item dirtying even though you passed a single item. Return only the item's own identity from `JawsGetTag`, and attach the shared group tag separately at construction (for example pass `&group` as an extra tag param to the item's widget). The element then listens to both, but `Dirty(item)` stays scoped to that one item while `Dirty(&group)` still refreshes the whole group.
 
 ## Hard framework constraints
 
@@ -184,5 +185,6 @@ Guideline:
 - Fake binders or fake tags created only to satisfy an API shape.
 - Hidden mutations in getter paths.
 - Broad `Dirty(...)` calls used to mask incorrect dependency targeting.
+- Returning a shared/group tag from an item's `JawsGetTag` (bundling it into the item's own dirty identity), which makes a single-item `Dirty` fan out to the whole group.
 - Passing explicit template click handlers when dot-owned `JawsClick` already covers behavior.
 - Adding custom browser JavaScript for state that can be expressed through JaWS events and server updates.

--- a/examples/minesweeper/assets/ui/index.html
+++ b/examples/minesweeper/assets/ui/index.html
@@ -26,7 +26,7 @@
 				{{range .Board}}
 				<tr>
 					{{range .}}
-					<td>{{$.Button . `class="cell"`}}</td>
+					<td>{{$.Button . .BoardTag `class="cell"`}}</td>
 					{{end}}
 				</tr>
 				{{end}}

--- a/examples/minesweeper/main.go
+++ b/examples/minesweeper/main.go
@@ -160,9 +160,24 @@ func (c *Cell) syncPresentation(elem *jaws.Element, view cellView) {
 	}
 }
 
-// JawsGetTag exposes the cell and board tags used for dirtying.
+// JawsGetTag returns the cell's per-cell dirty identity.
+//
+// It deliberately returns ONLY the cell, not the shared board tag. Because *Cell
+// is a [tag.TagGetter], returning the board tag here would make Request.Dirty(c)
+// tag-expand to include it, so dirtying one cell would re-render every cell. The
+// shared board tag is registered separately via [Cell.BoardTag] (passed to the
+// cell's Button), so the element listens to both while a single-cell dirty stays
+// scoped to just that cell. Board-wide refreshes dirty &g.cells directly.
 func (c *Cell) JawsGetTag(_ tag.Context) any {
-	return []any{c, &c.game.cells}
+	return c
+}
+
+// BoardTag returns the shared board dirty tag registered on every cell element, so
+// board-wide refreshes (reset, loss, win) can re-render the whole board at once. It
+// is kept separate from [Cell.JawsGetTag] so per-cell dirtying stays scoped; see it
+// for why.
+func (c *Cell) BoardTag() any {
+	return &c.game.cells
 }
 
 // JawsGetHTML renders the cell contents.

--- a/examples/minesweeper/main_benchmark_test.go
+++ b/examples/minesweeper/main_benchmark_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/linkdata/jaws"
+	jawstag "github.com/linkdata/jaws/lib/tag"
+	"github.com/linkdata/jaws/lib/ui"
+)
+
+var dirtyFanoutSink int
+
+// BenchmarkSingleCellDirtyFanout measures the per-event work a single-cell action
+// triggers: how many element re-renders a flag toggle's dirty set resolves to after
+// tag expansion. It renders a full default board (100 cell elements registered under
+// both their per-cell tag and the shared board tag), then resolves the dirty tags
+// the way the framework's update step does (expand, then look up elements per tag).
+//
+// This is the cost the fix targets: before, a single-cell dirty expanded to the
+// shared board tag and resolved to all 100 cells; after, it resolves to one. Run
+// with -benchmem and compare before/after with benchstat.
+func BenchmarkSingleCellDirtyFanout(b *testing.B) {
+	jw, err := jaws.New()
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer jw.Close()
+
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	if rq == nil {
+		b.Fatal("expected a request")
+	}
+
+	g := newGame(10, 10, 15)
+	for _, row := range g.Board() {
+		for _, cell := range row {
+			elem := rq.NewElement(ui.NewButton(cell))
+			var sb strings.Builder
+			if err := elem.JawsRender(&sb, []any{cell.BoardTag(), `class="cell"`}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+
+	cell := g.cells[0][0]
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Mirror the framework's dirty dispatch: expand the toggle's tags and
+		// resolve each to its registered elements (Request.GetElements is the same
+		// tagMap lookup makeUpdateList performs). The sum is the number of element
+		// re-renders the toggle would drive.
+		expanded, err := jawstag.TagExpand(nil, g.toggleFlag(cell))
+		if err != nil {
+			b.Fatal(err)
+		}
+		n := 0
+		for _, tg := range expanded {
+			n += len(rq.GetElements(tg))
+		}
+		dirtyFanoutSink = n
+	}
+}

--- a/examples/minesweeper/main_test.go
+++ b/examples/minesweeper/main_test.go
@@ -111,8 +111,11 @@ func TestCellButtonUsesCellTagsAndHandlers(t *testing.T) {
 	cell := g.cells[0][0]
 	elem := rq.NewElement(ui.NewButton(cell))
 
+	// Mirror the template, which passes the shared board tag alongside the cell
+	// (see index.html: {{$.Button . .BoardTag ...}}). The cell's own JawsGetTag
+	// returns only the cell, so the board tag must be supplied as a render param.
 	var body bytes.Buffer
-	if err := elem.JawsRender(&body, []any{`class="cell"`}); err != nil {
+	if err := elem.JawsRender(&body, []any{cell.BoardTag(), `class="cell"`}); err != nil {
 		t.Fatal(err)
 	}
 	if !elem.HasTag(cell) {
@@ -582,6 +585,47 @@ func TestGameClickCellPaths(t *testing.T) {
 		t.Fatal("expected remaining mine to be revealed on win")
 	}
 	assertTagSetEqual(t, winTags, &g.cells, &g.gameOver, &g.won, &g.revealed)
+}
+
+func containsTag(tags []any, want any) bool {
+	for _, tg := range tags {
+		if tg == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSingleCellDirtyStaysScopedToOneCell guards the per-cell dirty contract after
+// tag EXPANSION (what Request.Dirty actually does), not just the raw returned slice.
+// A single-cell action (flag toggle) must not expand to the shared &g.cells board
+// tag — otherwise every cell re-renders — while a board-wide refresh (reset) must.
+// *Cell is a tag.TagGetter, so a board tag returned from Cell.JawsGetTag would be
+// pulled in by expanding any single cell; this test fails if that regresses.
+func TestSingleCellDirtyStaysScopedToOneCell(t *testing.T) {
+	g := newGame(3, 3, 1)
+	cell := g.cells[0][0]
+
+	flagTags, err := jawstag.TagExpand(nil, g.toggleFlag(cell))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Expanded dirty set for a flag toggle is exactly the cell and the changed
+	// flag counter — no board tag.
+	assertTagSetEqual(t, flagTags, cell, &g.flags)
+
+	// A board-wide refresh must still expand to the shared board tag so every cell
+	// re-renders. Start the game first (the first click is guaranteed safe) so reset
+	// reports changed scalars and appends &g.cells.
+	g2 := newGame(3, 3, 1)
+	_ = g2.clickCell(g2.cells[0][0])
+	resetTags, err := jawstag.TagExpand(nil, g2.reset())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsTag(resetTags, &g2.cells) {
+		t.Fatalf("board reset did not target the shared board tag &g.cells: %#v", resetTags)
+	}
 }
 
 func TestRevealFromLockedAndRevealAllMines(t *testing.T) {


### PR DESCRIPTION
## Defect (second-pass per-package review)

`Cell.JawsGetTag` returned `[]any{c, &c.game.cells}`. Because `*Cell` is a `tag.TagGetter`, passing a single `*Cell` to `Request.Dirty` **tag-expands** to include `&g.cells` — the shared board tag registered on *every* cell element — so every single-cell reveal or flag toggle re-rendered the **entire board** on every connected client.

This silently defeated the per-cell dirty targeting the example builds on purpose (individual `*Cell` tags for normal reveals at `clickCell`, a single cell for `toggleFlag`; `&g.cells` reserved for the loss/win/reset "refresh board" paths) and nullified the no-spurious-dirty optimization documented around the `gameState` snapshot. As a usage reference, it also mis-taught the pattern: the returned `[]any` of individual `*Cell` pointers *looks* per-cell, but each cell also carries the board tag.

## Fix

Return only the cell from `JawsGetTag`, and register the shared board tag separately via a new `Cell.BoardTag()` passed to each cell's `Button` in the template (`{{$.Button . .BoardTag ...}}`). The element still listens to both tags, so board-wide refreshes (loss/win/reset) keep dirtying `&g.cells` and hit every cell, while `Dirty(cell)` now expands to just that cell.

## Benchmark (perf change ⇒ benchmark per AGENTS.md)

`BenchmarkSingleCellDirtyFanout` (new, kept as a regression guard) measures the element re-render set a flag toggle resolves to on the default 10×10 board (`benchstat`, n=10):

| metric | before | after | delta |
|---|---|---|---|
| sec/op | 3593n | 208n | −94% |
| B/op | 8024 | 208 | −97% |
| allocs/op | 37 | 10 | −73% |

## Tests

- `TestSingleCellDirtyStaysScopedToOneCell` (new) asserts the **post-expansion** dirty set for a single-cell flag toggle is exactly `{cell, &g.flags}` (no board tag), while a board reset still expands to `&g.cells`. It fails on the unpatched code.
- `TestCellButtonUsesCellTagsAndHandlers` now registers the board tag via a render param, mirroring the template, and still asserts the element listens to both tags.
- Existing raw-slice tag assertions (`clickCell`/`toggleFlag`/`reset`) are unchanged.

## Skill doc

`.agents/skills/jaws/SKILL.md` gains the underlying lesson: an item's `JawsGetTag` must stay scoped to the item and not return the shared group tag, because element *registration* and dirty-target *expansion* are distinct — bundling the group tag into the item's identity makes a single-item `Dirty` fan out to the whole group.

## Verification

`go vet`, `gofumpt -l`, `staticcheck`, `go build`, `go test -race ./...`, and `go test -tags debug -race ./...` all pass.