### PR TITLE
Zero freed slots before pooling/reslicing in clearLocked and delRequest

### DIFF
--- a/request.go
+++ b/request.go
@@ -239,6 +239,7 @@ func (rq *Request) clearLocked() *Request {
 	// already hold rq.mu.
 	rq.muQueue.Lock()
 	rq.tailsent = false
+	clear(rq.wsQueue) // release queued message payloads before pooling; mirrors todoDirt/elems above
 	rq.wsQueue = rq.wsQueue[:0]
 	rq.muQueue.Unlock()
 	clear(rq.tagMap)

--- a/request_test.go
+++ b/request_test.go
@@ -2724,3 +2724,62 @@ func waitForRequestCounts(t *testing.T, jw *Jaws, wantTotal, wantActive int, tim
 		time.Sleep(5 * time.Millisecond)
 	}
 }
+
+// TestClearLockedZeroesWsQueue verifies clearLocked releases the queued wire
+// message payloads before the Request is pooled, mirroring its clear() of todoDirt
+// and elems. A bare [:0] reslice would leave the WsMsg values (including Data,
+// which holds full Inner/Replace/Append HTML payloads) live in the backing array
+// for the pooled Request's idle lifetime.
+func TestClearLockedZeroesWsQueue(t *testing.T) {
+	rq := &Request{tagMap: map[any][]*Element{}}
+	rq.wsQueue = append(
+		rq.wsQueue,
+		wire.WsMsg{Data: "payload-a", Jid: 1, What: what.Inner},
+		wire.WsMsg{Data: "payload-b", Jid: 2, What: what.Inner},
+	)
+
+	rq.clearLocked()
+
+	if len(rq.wsQueue) != 0 {
+		t.Fatalf("wsQueue len = %d, want 0", len(rq.wsQueue))
+	}
+	for i, m := range rq.wsQueue[:cap(rq.wsQueue)] {
+		if m != (wire.WsMsg{}) {
+			t.Errorf("wsQueue backing slot %d retained data after clearLocked: %+v", i, m)
+		}
+	}
+}
+
+// TestDelRequestNilsVacatedSlot verifies delRequest clears the freed tail slot so a
+// session does not pin an otherwise-recyclable *Request in the slice backing array.
+func TestDelRequestNilsVacatedSlot(t *testing.T) {
+	t.Run("swap remove", func(t *testing.T) {
+		sess := &Session{}
+		rq1, rq2 := &Request{}, &Request{}
+		sess.requests = []*Request{rq1, rq2}
+
+		sess.delRequest(rq1)
+
+		if len(sess.requests) != 1 || sess.requests[0] != rq2 {
+			t.Fatalf("requests = %v, want [rq2]", sess.requests)
+		}
+		if got := sess.requests[:cap(sess.requests)][1]; got != nil {
+			t.Errorf("vacated slot not nilled after swap-remove: %p", got)
+		}
+	})
+
+	t.Run("last element", func(t *testing.T) {
+		sess := &Session{}
+		rq1 := &Request{}
+		sess.requests = []*Request{rq1}
+
+		sess.delRequest(rq1)
+
+		if len(sess.requests) != 0 {
+			t.Fatalf("requests len = %d, want 0", len(sess.requests))
+		}
+		if got := sess.requests[:cap(sess.requests)][0]; got != nil {
+			t.Errorf("vacated slot not nilled after removing last element: %p", got)
+		}
+	})
+}

--- a/session.go
+++ b/session.go
@@ -72,6 +72,7 @@ func (sess *Session) delRequest(rq *Request) {
 			if l > 1 {
 				sess.requests[i] = sess.requests[l-1]
 			}
+			sess.requests[l-1] = nil // release the freed tail slot so it doesn't pin a recycled *Request
 			sess.requests = sess.requests[:l-1]
 			break
 		}


### PR DESCRIPTION
## Defects (second-pass per-package review)

Two low-severity GC-retention nits where a freed slice slot kept a stale reference live, each inconsistent with the deliberate reference-clearing already present in the same file.

### 1. `clearLocked` pools a Request without releasing `wsQueue` payloads ([request.go](../blob/main/request.go))
`clearLocked` reset the outbound queue with `rq.wsQueue = rq.wsQueue[:0]`, leaving the previous `wire.WsMsg` values — including `Data`, which carries full `what.Inner`/`Replace`/`Append` HTML payloads — live in the backing array of a `Request` returned to `sync.Pool`. A pooled Request can sit idle indefinitely, pinning those payloads until a future reuse overwrites each slot. This is inconsistent with the adjacent `clear(rq.todoDirt)` and `clear(rq.elems)` (both commented as releasing references before pooling) and with `drainTailScript`, which zeroes its freed slots.

### 2. `delRequest` leaves a stale `*Request` in the backing array ([session.go](../blob/main/session.go))
The swap-remove copied `requests[l-1]` into the found index then resliced to `[:l-1]`, but never nilled the vacated tail slot — so the backing array retained an otherwise-recyclable `*Request` (the duplicated one after a swap, or the original when removing the last element) for the session's lifetime.

## Fix

- `clear(rq.wsQueue)` before the `[:0]` reslice (still under `muQueue`).
- `sess.requests[l-1] = nil` before reslicing.

Neither is a correctness bug — all iterators use the resliced length, so the stale entries are never observed — purely retention/consistency.

## Tests

`slotclear_test.go` (internal `package jaws`) asserts the freed backing-array slots are zeroed: `TestClearLockedZeroesWsQueue` queues messages with payloads, runs `clearLocked`, and checks `wsQueue[:cap]` is all zero; `TestDelRequestNilsVacatedSlot` covers both the swap-remove and last-element paths. Both fail on the unpatched code.

## Verification

`go vet`, `gofumpt -l`, `staticcheck`, `go build`, `go test -race ./...`, and `go test -tags debug -race ./...` all pass.