### PR TITLE
refactor: replace nanosecond-based timing with atomic second counter

### DIFF
--- a/jaws.go
+++ b/jaws.go
@@ -155,7 +155,8 @@ type Jaws struct {
 	MaxPendingRequestsPerIP int             // Maximum number of unclaimed Requests per client IP. Defaults to DefaultMaxPendingRequestsPerIP. Set <=0 to disable the cap.
 	webSocketTimeout        time.Duration   // timeout duration passed to ServeWith
 	maintenanceInterval     time.Duration   // Serve maintenance tick interval; set by ServeWithTimeout and read under mu, zero until Serve starts
-	created                 time.Time       // monotonic base captured in New(); read-only after construction, basis for nowNano
+	created                 time.Time       // monotonic base captured in New(); read-only after construction, basis for runtimeSeconds
+	runtimeSeconds          atomic.Uint32   // whole seconds since created; refreshed by the Serve loop, read lock-free by MarkWritten and the eviction/idle checks
 	bcastCh                 chan wire.Message
 	subCh                   chan subscription
 	unsubCh                 chan chan wire.Message
@@ -409,13 +410,15 @@ func (jw *Jaws) NewRequest(r *http.Request) (rq *Request) {
 	return
 }
 
-// nowNano returns monotonic nanoseconds elapsed since the [Jaws] was created.
+// refreshRuntimeSeconds updates runtimeSeconds to the whole seconds elapsed since
+// the [Jaws] was created.
 //
-// It is the basis for [Request.MarkWritten] and the pending-eviction recency check.
-// Because it derives from [time.Since] on a [time.Time] carrying the monotonic clock,
-// the value is immune to wall-clock and NTP adjustments.
-func (jw *Jaws) nowNano() int64 {
-	return int64(time.Since(jw.created))
+// It is called by the Serve loop (seeded once at start, then on every maintenance
+// tick), so the per-write [Request.MarkWritten] only does an atomic load rather than
+// reading the clock. Deriving from [time.Since] on a monotonic [time.Time] keeps the
+// counter immune to wall-clock and NTP adjustments.
+func (jw *Jaws) refreshRuntimeSeconds() {
+	jw.runtimeSeconds.Store(uint32(time.Since(jw.created) / time.Second))
 }
 
 // limitPendingRequestsLocked evicts pending Requests for remoteIP until the cap is
@@ -424,9 +427,9 @@ func (jw *Jaws) nowNano() int64 {
 func (jw *Jaws) limitPendingRequestsLocked(remoteIP netip.Addr) (toLog []error) {
 	limit := jw.MaxPendingRequestsPerIP
 	if limit > 0 {
-		nowNano := jw.nowNano()
+		nowSeconds := jw.runtimeSeconds.Load()
 		for len(jw.pending[remoteIP]) >= limit {
-			victim := jw.oldestEvictablePendingLocked(remoteIP, nowNano)
+			victim := jw.oldestEvictablePendingLocked(remoteIP, nowSeconds)
 			if victim == nil {
 				// Every pending Request for this IP is rendering or rendered too
 				// recently to evict safely. Recycling a still-rendering one would
@@ -449,34 +452,39 @@ func (jw *Jaws) limitPendingRequestsLocked(remoteIP netip.Addr) (toLog []error) 
 
 // oldestEvictablePendingLocked returns the oldest pending [Request] for remoteIP
 // that is safe to recycle, or nil if every one of them was written too recently to
-// evict safely. nowNano is the reference instant (see [Jaws.nowNano]); the caller
-// passes a single value so all candidates are judged against the same instant.
+// evict safely. nowSeconds is the reference instant ([Jaws.runtimeSeconds]); the
+// caller passes a single value so all candidates are judged against the same instant.
 // Caller must hold jw.mu.
 //
 // A Request is spared while its initial HTML may still be in flight. Recycling a
 // Request whose render goroutine is still writing would let a later [Jaws.NewRequest]
 // reuse the pooled pointer under a new key while that goroutine keeps appending
-// elements (see [Jaws.limitPendingRequestsLocked]). [RequestWriter.Write] stamps the
-// write instant on every write via [Request.MarkWritten], so a Request is treated as
-// possibly-rendering, and spared, while its last write is within 2*maintenanceInterval.
+// elements (see [Jaws.limitPendingRequestsLocked]). [RequestWriter.Write] records the
+// current second on every write via [Request.MarkWritten], so a Request is treated as
+// possibly-rendering, and spared, while its last write is within 2*maintenanceInterval
+// (rounded to whole seconds, with a one-second floor).
 //
-// The timestamp is the exact instant of the last write, not a value sampled once per
-// maintenance pass, so an actively writing render is always fresh and only a render
-// that has produced no write for two intervals — whether finished or merely stalled
-// between writes — becomes evictable. lastWriteNano is read lock-free, so this scan
-// takes no Request lock.
+// The recorded second advances only when the Request keeps writing, so an actively
+// writing render stays fresh while one that has produced no write for the window —
+// whether finished or merely stalled between writes — becomes evictable. lastWriteSeconds
+// is read lock-free, so this scan takes no Request lock; the coarse second granularity
+// is harmless because both operands derive from runtimeSeconds, so any refresh lag
+// cancels in the difference.
 //
 // maintenanceInterval is zero until [Jaws.ServeWithTimeout] starts; the window then
 // falls back to [DefaultUpdateInterval] so an in-flight render is still protected
 // before the maintenance pass begins running.
-func (jw *Jaws) oldestEvictablePendingLocked(remoteIP netip.Addr, nowNano int64) *Request {
+func (jw *Jaws) oldestEvictablePendingLocked(remoteIP netip.Addr, nowSeconds uint32) *Request {
 	interval := jw.maintenanceInterval
 	if interval <= 0 {
 		interval = DefaultUpdateInterval
 	}
-	spareWindow := int64(2 * interval)
+	spareSeconds := uint32(2 * interval / time.Second)
+	if spareSeconds == 0 {
+		spareSeconds = 1
+	}
 	for _, rq := range jw.pending[remoteIP] {
-		if nowNano-rq.lastWriteNano.Load() <= spareWindow {
+		if nowSeconds-rq.lastWriteSeconds.Load() <= spareSeconds {
 			continue
 		}
 		return rq
@@ -659,6 +667,9 @@ func (jw *Jaws) ServeWithTimeout(requestTimeout time.Duration) {
 	jw.webSocketTimeout = requestTimeout
 	jw.maintenanceInterval = maintenanceInterval
 	jw.mu.Unlock()
+	// Seed the seconds counter so it is accurate from the first request, then keep
+	// it fresh on every maintenance tick (see the case below).
+	jw.refreshRuntimeSeconds()
 
 	defer func() {
 		t.Stop()
@@ -707,6 +718,7 @@ func (jw *Jaws) ServeWithTimeout(requestTimeout time.Duration) {
 				mustBroadcast(wire.Message{What: what.Update})
 			}
 		case <-t.C:
+			jw.refreshRuntimeSeconds()
 			jw.maintenance(requestTimeout)
 		case sub := <-jw.subCh:
 			if sub.msgCh != nil {
@@ -750,9 +762,9 @@ func (jw *Jaws) unsubscribe(msgCh chan wire.Message) {
 func (jw *Jaws) maintenance(requestTimeout time.Duration) {
 	var toLog []error
 	jw.mu.Lock()
-	nowNano := jw.nowNano()
+	nowSeconds := jw.runtimeSeconds.Load()
 	for _, rq := range jw.requests {
-		if expired, cause := rq.maintenance(nowNano, requestTimeout); expired {
+		if expired, cause := rq.maintenance(nowSeconds, requestTimeout); expired {
 			if cause != nil {
 				toLog = append(toLog, cause)
 			}
@@ -839,7 +851,7 @@ func (jw *Jaws) getRequestLocked(jawsKey key.Key, r *http.Request, remoteIP neti
 	rq.mu.Lock()
 	defer rq.mu.Unlock()
 	rq.JawsKey = jawsKey
-	rq.lastWriteNano.Store(jw.nowNano())
+	rq.lastWriteSeconds.Store(jw.runtimeSeconds.Load())
 	rq.initial = r
 	rq.remoteIP = remoteIP
 	rq.ctx, rq.cancelFn = context.WithCancelCause(jw.BaseContext)

--- a/jaws.go
+++ b/jaws.go
@@ -418,7 +418,9 @@ func (jw *Jaws) NewRequest(r *http.Request) (rq *Request) {
 // reading the clock. Deriving from [time.Since] on a monotonic [time.Time] keeps the
 // counter immune to wall-clock and NTP adjustments.
 func (jw *Jaws) refreshRuntimeSeconds() {
-	jw.runtimeSeconds.Store(uint32(time.Since(jw.created) / time.Second))
+	// time.Since on a monotonic base is never negative, and whole seconds of uptime
+	// fit in uint32 for ~136 years, so the narrowing conversion cannot overflow.
+	jw.runtimeSeconds.Store(uint32(time.Since(jw.created) / time.Second)) //#nosec G115 -- bounded by process uptime
 }
 
 // limitPendingRequestsLocked evicts pending Requests for remoteIP until the cap is
@@ -479,12 +481,15 @@ func (jw *Jaws) oldestEvictablePendingLocked(remoteIP netip.Addr, nowSeconds uin
 	if interval <= 0 {
 		interval = DefaultUpdateInterval
 	}
-	spareSeconds := uint32(2 * interval / time.Second)
-	if spareSeconds == 0 {
-		spareSeconds = 1
+	spareWindow := 2 * interval
+	if spareWindow < time.Second {
+		spareWindow = time.Second // floor: the seconds counter advances at most once per second
 	}
 	for _, rq := range jw.pending[remoteIP] {
-		if nowSeconds-rq.lastWriteSeconds.Load() <= spareSeconds {
+		// Compare as durations (elapsed whole seconds vs the window) to avoid a
+		// lossy time.Duration->uint32 conversion; the uint32 subtraction is the
+		// elapsed seconds and widening it to time.Duration is always safe.
+		if time.Duration(nowSeconds-rq.lastWriteSeconds.Load())*time.Second <= spareWindow {
 			continue
 		}
 		return rq

--- a/jaws_benchmark_test.go
+++ b/jaws_benchmark_test.go
@@ -51,7 +51,7 @@ func newUnpooledBenchRequest(jw *Jaws) (rq *Request) {
 			}
 			rq.mu.Lock()
 			rq.JawsKey = jawsKey
-			rq.lastWriteNano.Store(jw.nowNano())
+			rq.lastWriteSeconds.Store(jw.runtimeSeconds.Load())
 			rq.remoteIP = remoteIP
 			rq.ctx, rq.cancelFn = context.WithCancelCause(jw.BaseContext)
 			rq.mu.Unlock()

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -128,12 +128,12 @@ func TestJaws_MaxPendingRequestsPerIPEvictsOldestPending(t *testing.T) {
 	oldReq := newPendingLimitRequest("192.0.2.1:1000")
 	oldRq := jw.NewRequest(oldReq)
 	oldKey := oldRq.JawsKey
-	setPendingLimitLastWrite(t, oldRq, time.Now().Add(-2*time.Hour))
+	setPendingLimitLastWrite(t, oldRq, 7200)
 
 	midReq := newPendingLimitRequest("192.0.2.1:1001")
 	midRq := jw.NewRequest(midReq)
 	midKey := midRq.JawsKey
-	setPendingLimitLastWrite(t, midRq, time.Now().Add(-time.Hour))
+	setPendingLimitLastWrite(t, midRq, 3600)
 
 	newReq := newPendingLimitRequest("192.0.2.1:1002")
 	newRq := jw.NewRequest(newReq)
@@ -195,7 +195,7 @@ func TestJaws_MaintenanceLogsCancelOutsideLock(t *testing.T) {
 
 	// A pending request idle long enough for the maintenance pass to recycle it.
 	rq := jw.NewRequest(newPendingLimitRequest("192.0.2.1:1000"))
-	setPendingLimitLastWrite(t, rq, time.Now().Add(-time.Hour))
+	setPendingLimitLastWrite(t, rq, 3600)
 
 	done := make(chan struct{})
 	go func() {
@@ -243,7 +243,7 @@ func TestJaws_MaxPendingRequestsPerIPSparesRenderingRequest(t *testing.T) {
 	idleRq := jw.NewRequest(idleReq)
 	idleKey := idleRq.JawsKey
 	// Age the idle Request well past the spare window so it is the eviction victim.
-	setPendingLimitLastWrite(t, idleRq, time.Now().Add(-time.Hour))
+	setPendingLimitLastWrite(t, idleRq, 3600)
 
 	// Creating a third same-IP Request trips the cap (pending == 2).
 	newReq := newPendingLimitRequest("192.0.2.1:1002")
@@ -290,7 +290,7 @@ func TestJaws_MaxPendingRequestsPerIPSparesRecentlyRenderedRequest(t *testing.T)
 	idleReq := newPendingLimitRequest("192.0.2.1:1001")
 	idleRq := jw.NewRequest(idleReq)
 	idleKey := idleRq.JawsKey
-	setPendingLimitLastWrite(t, idleRq, time.Now().Add(-time.Hour))
+	setPendingLimitLastWrite(t, idleRq, 3600)
 
 	// A third same-IP Request trips the cap (pending == 2).
 	newReq := newPendingLimitRequest("192.0.2.1:1002")
@@ -341,7 +341,7 @@ func TestJaws_MaxPendingRequestsPerIPSparesStalledLiveRender(t *testing.T) {
 	idleReq := newPendingLimitRequest("192.0.2.1:1001")
 	idleRq := jw.NewRequest(idleReq)
 	idleKey := idleRq.JawsKey
-	setPendingLimitLastWrite(t, idleRq, time.Now().Add(-time.Hour))
+	setPendingLimitLastWrite(t, idleRq, 3600)
 
 	// A third same-IP Request trips the cap (pending == 2).
 	newReq := newPendingLimitRequest("192.0.2.1:1002")
@@ -462,7 +462,7 @@ func TestJaws_MaxPendingRequestsPerIPKeepsLoopbackAddressesSeparate(t *testing.T
 
 	oldReq := newPendingLimitRequest("127.0.0.1:1000")
 	oldRq := jw.NewRequest(oldReq)
-	setPendingLimitLastWrite(t, oldRq, time.Now().Add(-time.Hour))
+	setPendingLimitLastWrite(t, oldRq, 3600)
 
 	newReq := newPendingLimitRequest("[::1]:1000")
 	newRq := jw.NewRequest(newReq)
@@ -518,7 +518,7 @@ func TestJaws_MaxPendingRequestsPerIPEvictionCause(t *testing.T) {
 
 	oldReq := newPendingLimitRequest("192.0.2.1:1000")
 	oldRq := jw.NewRequest(oldReq)
-	setPendingLimitLastWrite(t, oldRq, time.Now().Add(-time.Hour))
+	setPendingLimitLastWrite(t, oldRq, 3600)
 	jw.NewRequest(newPendingLimitRequest("192.0.2.1:1001"))
 
 	if logger.err == nil {
@@ -645,7 +645,7 @@ func TestJaws_MaxPendingRequestsPerIPMaintenanceRemovesPendingIndex(t *testing.T
 	jw.MaxPendingRequestsPerIP = 1
 
 	rq := jw.NewRequest(newPendingLimitRequest("192.0.2.1:1000"))
-	setPendingLimitLastWrite(t, rq, time.Now().Add(-time.Hour))
+	setPendingLimitLastWrite(t, rq, 3600)
 	jw.maintenance(time.Second)
 
 	if got := jw.Pending(); got != 0 {
@@ -662,13 +662,14 @@ func newPendingLimitRequest(remoteAddr string) *http.Request {
 	return r
 }
 
-func setPendingLimitLastWrite(t *testing.T, rq *Request, lastWrite time.Time) {
+func setPendingLimitLastWrite(t *testing.T, rq *Request, secondsAgo uint32) {
 	t.Helper()
-	// lastWriteNano holds monotonic nanos since rq.Jaws.created; convert the wall
-	// time the test wants relative to that base. A past instant yields a negative
-	// value, which reads as far older than any spare/idle window — exactly what an
-	// "aged" request should look like.
-	rq.lastWriteNano.Store(int64(lastWrite.Sub(rq.Jaws.created)))
+	// lastWriteSeconds holds the Jaws.runtimeSeconds value at the last write. Store
+	// runtimeSeconds-secondsAgo so the eviction/idle check (runtimeSeconds-lastWrite)
+	// reads back as secondsAgo. Unsigned wraparound makes this exact even when the
+	// counter is still zero (Serve not running in these tests), since both sides use
+	// the same runtimeSeconds value.
+	rq.lastWriteSeconds.Store(rq.Jaws.runtimeSeconds.Load() - secondsAgo)
 }
 
 func TestCoverage_GenerateHeadAndConvenienceBroadcasts(t *testing.T) {

--- a/lib/ui/requestwriter_test.go
+++ b/lib/ui/requestwriter_test.go
@@ -43,8 +43,8 @@ func TestRequestWriter_MethodsAndWidgetHelpers(t *testing.T) {
 	if got := buf.String(); got != "prefix" {
 		t.Fatalf("unexpected write output %q", got)
 	}
-	// Write records the write instant via Request.MarkWritten (covered by the core
-	// package's pending-eviction tests); lastWriteNano is unexported here.
+	// Write records the current second via Request.MarkWritten (covered by the core
+	// package's pending-eviction tests); lastWriteSeconds is unexported here.
 
 	if rw.Initial() == nil {
 		t.Fatal("expected initial request")

--- a/request.go
+++ b/request.go
@@ -50,26 +50,26 @@ type ConnectFn = func(rq *Request) error
 // [Request.Log] and [Request.MustLog] let it forward to the logger; both exist only for
 // that diagnostic use, not as a public nil-safe contract.
 type Request struct {
-	Jaws          *Jaws                   // (read-only) the JaWS instance the Request belongs to
-	JawsKey       key.Key                 // (read-only) random key identifying this Request in the WebSocket URI and the broadcast/tail target; read under mu by the identity check (destKey, wantMessage) and the render path (JawsKeyString, HeadHTML)
-	remoteIP      netip.Addr              // (read-only) remote IP, or the zero netip.Addr if unset
-	running       atomic.Bool             // if ServeHTTP() is running
-	claimed       atomic.Bool             // if UseRequest() has been called for it
-	lastWriteNano atomic.Int64            // monotonic nanos (Jaws.nowNano) of the most recent RequestWriter write; lock-free, drives pending-eviction recency (oldestEvictablePendingLocked) and idle expiry (maintenance)
-	mu            deadlock.RWMutex        // protects following
-	lastJid       Jid                     // last element Jid allocated within this Request
-	initial       *http.Request           // initial HTTP request passed to Jaws.NewRequest
-	session       *Session                // session, if established
-	todoDirt      []any                   // dirty tags
-	ctx           context.Context         // current context, derived from either Jaws or WS HTTP req
-	httpDoneCh    <-chan struct{}         // once claimed, set to http.Request.Context().Done()
-	cancelFn      context.CancelCauseFunc // cancel function
-	connectFn     ConnectFn               // a ConnectFn to call before starting message processing for the Request
-	elems         []*Element              // our Elements
-	tagMap        map[any][]*Element      // maps tags to Elements
-	muQueue       deadlock.Mutex          // protects wsQueue and tailsent
-	wsQueue       []wire.WsMsg            // queued messages to send
-	tailsent      bool
+	Jaws             *Jaws                   // (read-only) the JaWS instance the Request belongs to
+	JawsKey          key.Key                 // (read-only) random key identifying this Request in the WebSocket URI and the broadcast/tail target; read under mu by the identity check (destKey, wantMessage) and the render path (JawsKeyString, HeadHTML)
+	remoteIP         netip.Addr              // (read-only) remote IP, or the zero netip.Addr if unset
+	running          atomic.Bool             // if ServeHTTP() is running
+	claimed          atomic.Bool             // if UseRequest() has been called for it
+	lastWriteSeconds atomic.Uint32           // [Jaws.runtimeSeconds] value at the most recent RequestWriter write; lock-free, drives pending-eviction recency (oldestEvictablePendingLocked) and idle expiry (maintenance)
+	mu               deadlock.RWMutex        // protects following
+	lastJid          Jid                     // last element Jid allocated within this Request
+	initial          *http.Request           // initial HTTP request passed to Jaws.NewRequest
+	session          *Session                // session, if established
+	todoDirt         []any                   // dirty tags
+	ctx              context.Context         // current context, derived from either Jaws or WS HTTP req
+	httpDoneCh       <-chan struct{}         // once claimed, set to http.Request.Context().Done()
+	cancelFn         context.CancelCauseFunc // cancel function
+	connectFn        ConnectFn               // a ConnectFn to call before starting message processing for the Request
+	elems            []*Element              // our Elements
+	tagMap           map[any][]*Element      // maps tags to Elements
+	muQueue          deadlock.Mutex          // protects wsQueue and tailsent
+	wsQueue          []wire.WsMsg            // queued messages to send
+	tailsent         bool
 }
 
 type eventFnCall struct {
@@ -124,11 +124,12 @@ func (rq *Request) String() string {
 // MarkWritten records that the Request's initial HTML is being written, so the
 // pending-eviction logic spares it while a render is in flight.
 //
-// [RequestWriter.Write] calls it on every write; the recorded instant drives the
+// [RequestWriter.Write] calls it on every write; the recorded second drives the
 // recency window in [Jaws.oldestEvictablePendingLocked] and the idle expiry in
-// [Request.maintenance]. It is lock-free and safe to call concurrently.
+// [Request.maintenance]. It is a single atomic store of [Jaws.runtimeSeconds]
+// (no clock read), lock-free and safe to call concurrently.
 func (rq *Request) MarkWritten() {
-	rq.lastWriteNano.Store(rq.Jaws.nowNano())
+	rq.lastWriteSeconds.Store(rq.Jaws.runtimeSeconds.Load())
 }
 
 // destKey returns the Request's current identity key, read under rq.mu, for use as
@@ -178,10 +179,10 @@ func (rq *Request) claim(r *http.Request) error {
 				}
 			}
 			rq.httpDoneCh = httpDoneCh
-			// Refresh the write timestamp so a request claimed long after its initial
+			// Refresh the write second so a request claimed long after its initial
 			// render (a throttled or backgrounded tab) is not treated as idle and
 			// recycled in the window before ServeHTTP sets running.
-			rq.lastWriteNano.Store(rq.Jaws.nowNano())
+			rq.lastWriteSeconds.Store(rq.Jaws.runtimeSeconds.Load())
 			return nil
 		}
 	}
@@ -232,7 +233,7 @@ func (rq *Request) clearLocked() *Request {
 	rq.JawsKey = 0
 	rq.lastJid = 0
 	rq.connectFn = nil
-	rq.lastWriteNano.Store(0)
+	rq.lastWriteSeconds.Store(0)
 	rq.initial = nil
 	rq.killSessionLocked()
 	rq.running.Store(false)
@@ -477,18 +478,18 @@ func (rq *Request) SetContext(fn func(oldCtx context.Context) (newCtx context.Co
 // maintenance reports whether rq has expired and should be recycled. For a
 // request that never went live it cancels and reports expiry once it has been
 // idle (no [RequestWriter] write) longer than requestTimeout, or immediately if its
-// context is already done. nowNano is the reference instant (see [Jaws.nowNano]).
+// context is already done. nowSeconds is the reference instant ([Jaws.runtimeSeconds]).
 // Called from the Serve loop's maintenance pass while jw.mu is held.
 //
 // It returns the cancellation cause (or nil) rather than logging it, so the caller
 // can log it after releasing jw.mu — logging runs the user [Jaws.Logger], which
 // must not be invoked under a lock.
-func (rq *Request) maintenance(nowNano int64, requestTimeout time.Duration) (expired bool, cause error) {
+func (rq *Request) maintenance(nowSeconds uint32, requestTimeout time.Duration) (expired bool, cause error) {
 	if !rq.running.Load() {
 		rq.mu.Lock()
 		if rq.ctx.Err() != nil {
 			expired = true
-		} else if nowNano-rq.lastWriteNano.Load() > int64(requestTimeout) {
+		} else if nowSeconds-rq.lastWriteSeconds.Load() > uint32(requestTimeout/time.Second) {
 			cause = rq.cancelLocked(newErrNoWebSocketRequest(rq))
 			expired = true
 		}

--- a/request.go
+++ b/request.go
@@ -489,7 +489,7 @@ func (rq *Request) maintenance(nowSeconds uint32, requestTimeout time.Duration) 
 		rq.mu.Lock()
 		if rq.ctx.Err() != nil {
 			expired = true
-		} else if nowSeconds-rq.lastWriteSeconds.Load() > uint32(requestTimeout/time.Second) {
+		} else if time.Duration(nowSeconds-rq.lastWriteSeconds.Load())*time.Second > requestTimeout {
 			cause = rq.cancelLocked(newErrNoWebSocketRequest(rq))
 			expired = true
 		}

--- a/request_test.go
+++ b/request_test.go
@@ -677,13 +677,13 @@ func TestRequest_ClaimRefreshesLastWriteAndStartServeGuards(t *testing.T) {
 	rq := jw.NewRequest(hr)
 
 	// Simulate a page that rendered long ago (idle) before its WebSocket connects.
-	rq.lastWriteNano.Store(jw.nowNano() - int64(time.Hour))
+	rq.lastWriteSeconds.Store(jw.runtimeSeconds.Load() - 3600)
 
 	if jw.UseRequest(rq.JawsKey, hr) != rq {
 		t.Fatal("expected claim to succeed")
 	}
-	// claim refreshed the write timestamp, so the just-claimed request is not idle.
-	if expired, _ := rq.maintenance(jw.nowNano(), time.Second); expired {
+	// claim refreshed the write second, so the just-claimed request is not idle.
+	if expired, _ := rq.maintenance(jw.runtimeSeconds.Load(), time.Second); expired {
 		t.Fatal("a freshly claimed request must not be treated as idle by maintenance")
 	}
 
@@ -1732,7 +1732,7 @@ func TestCoverage_PendingSubscribeMaintenanceAndParse(t *testing.T) {
 	<-unsubDone
 
 	// Request timeout path.
-	rq.lastWriteNano.Store(jw.nowNano() - int64(time.Hour))
+	rq.lastWriteSeconds.Store(jw.runtimeSeconds.Load() - 3600)
 	jw.maintenance(time.Second)
 	if got := jw.RequestCount(); got != 0 {
 		t.Fatalf("expected request recycled, got %d", got)
@@ -1783,25 +1783,25 @@ func TestCoverage_RequestMaintenanceClaimAndErrors(t *testing.T) {
 		t.Fatalf("unexpected error text: %v", err)
 	}
 
-	nowNano := jw.nowNano()
+	nowSeconds := jw.runtimeSeconds.Load()
 	rqM := jw.NewRequest(httptest.NewRequest("GET", "/", nil))
-	rqM.lastWriteNano.Store(nowNano - int64(time.Hour))
-	if expired, _ := rqM.maintenance(nowNano, time.Second); !expired {
+	rqM.lastWriteSeconds.Store(nowSeconds - 3600)
+	if expired, _ := rqM.maintenance(nowSeconds, time.Second); !expired {
 		t.Fatal("expected maintenance timeout")
 	}
 	rqR := jw.NewRequest(httptest.NewRequest("GET", "/", nil))
 	rqR.MarkWritten()
-	if expired, _ := rqR.maintenance(jw.nowNano(), time.Hour); expired {
+	if expired, _ := rqR.maintenance(jw.runtimeSeconds.Load(), time.Hour); expired {
 		t.Fatal("a freshly written request must not be idle-expired")
 	}
 	rqC := jw.NewRequest(httptest.NewRequest("GET", "/", nil))
 	rqC.cancel(errors.New("cancelled"))
-	if expired, _ := rqC.maintenance(jw.nowNano(), time.Hour); !expired {
+	if expired, _ := rqC.maintenance(jw.runtimeSeconds.Load(), time.Hour); !expired {
 		t.Fatal("expected maintenance cancellation")
 	}
 	rqOK := jw.NewRequest(httptest.NewRequest("GET", "/", nil))
 	rqOK.MarkWritten()
-	if expired, _ := rqOK.maintenance(jw.nowNano(), time.Hour); expired {
+	if expired, _ := rqOK.maintenance(jw.runtimeSeconds.Load(), time.Hour); expired {
 		t.Fatal("expected maintenance keepalive")
 	}
 
@@ -2929,7 +2929,7 @@ func TestServe_MarksRequestRunningSoMaintenanceSkips(t *testing.T) {
 	// Make the request look long-idle, then run a maintenance pass directly. A
 	// running request must not be recycled; before the fix it would be removed
 	// from jw.requests and its elements cleared while process is still using them.
-	tr.lastWriteNano.Store(jw.nowNano() - int64(time.Hour))
+	tr.lastWriteSeconds.Store(jw.runtimeSeconds.Load() - 3600)
 	jw.maintenance(time.Millisecond)
 
 	if got := jw.RequestCount(); got != 1 {


### PR DESCRIPTION
- Replace `nowNano()` method and `created`-based nanosecond timestamps with an atomic `runtimeSeconds` counter refreshed by the Serve loop.
- Update eviction and idle checks to use whole seconds instead of nanoseconds, improving performance by avoiding clock reads on hot paths.
- Adjust test helpers to accept seconds-ago values directly for clarity and consistency.