### PR TITLE
Fix inverted success-hook labels in ExampleBinder_hooks

### DIFF
--- a/lib/bind/example_test.go
+++ b/lib/bind/example_test.go
@@ -24,10 +24,10 @@ func ExampleBinder_hooks() {
 			return template.HTML(fmt.Sprintf("<strong>%d</strong>", cur.JawsGetLocked(elem))) // #nosec G203
 		}).
 		Success(func() {
-			calls = append(calls, "success-newest")
+			calls = append(calls, "success-oldest")
 		}).
 		Success(func() {
-			calls = append(calls, "success-oldest")
+			calls = append(calls, "success-newest")
 		})
 
 	if err := b.JawsSet(nil, 2); err != nil {
@@ -41,5 +41,5 @@ func ExampleBinder_hooks() {
 	// Output:
 	// 2
 	// <strong>2</strong>
-	// [set-locked success-oldest success-newest get-html]
+	// [set-locked success-newest success-oldest get-html]
 }


### PR DESCRIPTION
SuccessHook doc states success hooks run in reverse registration order (newest-registered first), but ExampleBinder_hooks labeled the first-registered hook "success-newest" and the second "success-oldest", so its pinned output demonstrated the opposite of the documented contract.

Swap the two labels to match registration age (first-registered is now "success-oldest", second is "success-newest") and update the pinned Output block so success entries reflect newest-first execution: `[set-locked success-newest success-oldest get-html]`.

The corrected Example is itself the regression test; `go test ./lib/bind/` passes.