### PR TITLE
Neutralize HTML5 --!> comment close in debug render

### DIFF
--- a/element.go
+++ b/element.go
@@ -128,8 +128,12 @@ func (elem *Element) renderDebug(w io.Writer) {
 		sb.WriteString("n/a")
 	}
 	sb.WriteByte(']')
-	_, _ = w.Write([]byte(strings.ReplaceAll(sb.String(), "-->", "==>") + " -->"))
+	_, _ = w.Write([]byte(debugCommentSanitizer.Replace(sb.String()) + " -->"))
 }
+
+// debugCommentSanitizer neutralizes both the standard "-->" and the HTML5
+// "--!>" comment-close sequences so tag text cannot escape the debug comment.
+var debugCommentSanitizer = strings.NewReplacer("-->", "==>", "--!>", "==>")
 
 // JawsRender calls [Renderer.JawsRender] for this [Element].
 //

--- a/element_test.go
+++ b/element_test.go
@@ -469,6 +469,26 @@ func TestElement_RenderDebugAndDeletedBranches(t *testing.T) {
 	elem.JawsUpdate()
 }
 
+func TestElement_RenderDebugSanitizesHTML5CommentClose(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	rq.Jaws.Debug = true
+
+	tu := &testUi{renderFn: func(*Element, io.Writer, []any) error { return nil }}
+	elem := rq.NewElement(tu)
+	elem.Tag(tag.Tag("x--!>y"))
+
+	var sb strings.Builder
+	elem.renderDebug(&sb)
+	if strings.Contains(sb.String(), "--!>") {
+		t.Fatalf("HTML5 comment close escaped the debug comment: %q", sb.String())
+	}
+}
+
 func TestElement_ApplyGetterDebugBranches(t *testing.T) {
 	rq := newTestRequest(t)
 	defer rq.Close()


### PR DESCRIPTION
In Debug mode, Element.renderDebug wrapped tag text in an HTML comment but sanitized only the standard `-->` close, so tag text containing the HTML5 `--!>` close escaped the comment and injected markup.

Fix: replace the single ReplaceAll with a package-level strings.Replacer that neutralizes both `-->` and `--!>`, keeping the legitimate trailing ` -->` appended after sanitizing.

Regression test: TestElement_RenderDebugSanitizesHTML5CommentClose tags an element with `x--!>y`, drives renderDebug, and asserts the output contains no `--!>`.