### PR TITLE
Return nil result with ErrNotUsableAsTag from TagExpand

### DIFF
--- a/lib/tag/tag.go
+++ b/lib/tag/tag.go
@@ -91,7 +91,7 @@ func appendUniqueTag(result []any, tag any) ([]any, error) {
 
 func addTag(result []any, tag any) ([]any, error) {
 	if err := ensureUsableTag(tag); err != nil {
-		return result, err
+		return nil, err
 	}
 	return appendUniqueTag(result, tag)
 }

--- a/lib/tag/tag_test.go
+++ b/lib/tag/tag_test.go
@@ -284,6 +284,20 @@ func TestTagExpand_MultiRuntimeNonComparable(t *testing.T) {
 	}
 }
 
+// TestTagExpand_ValidThenRuntimeNonComparable covers a valid tag preceding a
+// runtime-non-comparable one: TagExpand must honor its nil-result contract for
+// ErrNotUsableAsTag and not leak the partial result accumulated before the
+// rejection.
+func TestTagExpand_ValidThenRuntimeNonComparable(t *testing.T) {
+	result, err := TagExpand(nil, []any{Tag("a"), testRuntimeNonComparable{v: func() {}}})
+	if !errors.Is(err, ErrNotUsableAsTag) {
+		t.Fatalf("expected ErrNotUsableAsTag, got %v", err)
+	}
+	if result != nil {
+		t.Fatalf("expected nil result, got %v", result)
+	}
+}
+
 // TestTagExpand_RuntimeNonComparableArray pins the reflect.Array arm of
 // ensureUsableTag independently of the struct arm. An array whose static type is
 // comparable ([1]any) but whose element holds a non-comparable value (a func)


### PR DESCRIPTION
TagExpand documents that a runtime-non-comparable value is rejected with ErrNotUsableAsTag and a nil result, but addTag's rejection path returned the partial result accumulated before the bad tag.

Fix: return nil (not the partial result) from addTag's rejection branch, which only ever carries ErrNotUsableAsTag. The ErrTooManyTags partial-result contract in appendUniqueTag is untouched.

Regression test TestTagExpand_ValidThenRuntimeNonComparable covers a valid tag preceding the non-comparable one; without the fix it returns []any{Tag("a")} instead of nil.