### PR TITLE
Execute unwrapped templates in testTemplateUI.JawsRender

### DIFF
--- a/request_test.go
+++ b/request_test.go
@@ -2150,6 +2150,20 @@ func TestRequest_Template(t *testing.T) {
 	}
 }
 
+func TestRequest_Template_Unwrapped(t *testing.T) {
+	is := newTestHelper(t)
+	rq := newTestRequest(t)
+	defer rq.Close()
+
+	if err := rq.Template("", "testtemplate", tag.Tag("dot")); err != nil {
+		t.Fatal(err)
+	}
+	is.Equal(len(rq.elems), 1)
+	if got := rq.BodyHTML(); !strings.Contains(string(got), "dot") {
+		t.Errorf("Request.Template() = %q, want it to contain %q", got, "dot")
+	}
+}
+
 type templateDot struct {
 	clickedCh chan struct{}
 	gotName   string

--- a/testhelpers_test.go
+++ b/testhelpers_test.go
@@ -226,6 +226,7 @@ func (t testTemplateUI) JawsRender(elem *Element, w io.Writer, params []any) (er
 		elem.AddHandlers(handlers...)
 		err = fmt.Errorf("missing template %q", t.Name)
 		if tmpl := elem.Request.Jaws.LookupTemplate(t.Name); tmpl != nil {
+			err = nil
 			if doWrap {
 				err = writeTestTemplateWrapperStart(elem, w, t.OuterHTMLTag, attrs)
 			}


### PR DESCRIPTION
The testTemplateUI.JawsRender test helper pre-seeded err with a "missing template" error and only overwrote it inside the doWrap branch. When OuterHTMLTag was empty (doWrap false), a found template was never executed and the helper returned a bogus error with no output.

Fix: clear err immediately after a successful LookupTemplate, before the doWrap block, mirroring lib/ui Template.lookup.

Adds TestRequest_Template_Unwrapped covering the unwrapped render path; it fails with `missing template "testtemplate"` on unfixed source and passes after.