### PR TITLE
Seed request lastWriteSeconds from live elapsed time

### DIFF
--- a/jaws.go
+++ b/jaws.go
@@ -155,7 +155,7 @@ type Jaws struct {
 	webSocketTimeout        time.Duration   // timeout duration passed to ServeWith
 	maintenanceInterval     time.Duration   // Serve maintenance tick interval; set by ServeWithTimeout and read under mu, zero until Serve starts
 	created                 time.Time       // monotonic base captured in New(); read-only after construction, basis for runtimeSeconds
-	runtimeSeconds          atomic.Int32    // whole seconds since created; refreshed by the Serve loop, read lock-free by MarkWritten and the eviction/idle checks
+	runtimeSeconds          atomic.Int32    // whole seconds since created; refreshed during request allocation and by the Serve loop, read lock-free by MarkWritten and the eviction/idle checks
 	bcastCh                 chan wire.Message
 	subCh                   chan subscription
 	unsubCh                 chan chan wire.Message

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -156,6 +156,36 @@ func TestJaws_MaxPendingRequestsPerIPEvictsOldestPending(t *testing.T) {
 	}
 }
 
+func TestJaws_MaxPendingRequestsPerIPUsesLiveElapsedBeforeServe(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+	jw.MaxPendingRequestsPerIP = 1
+
+	oldReq := newPendingLimitRequest("192.0.2.1:1000")
+	oldRq := jw.NewRequest(oldReq)
+	oldKey := oldRq.JawsKey
+
+	// Simulate an hour passing before Serve starts. runtimeSeconds still holds
+	// the value used for oldRq, so NewRequest must refresh it before deciding
+	// whether the pending cap may evict oldRq.
+	jw.created = time.Now().Add(-time.Hour)
+	newReq := newPendingLimitRequest("192.0.2.1:1001")
+	newRq := jw.NewRequest(newReq)
+
+	if got := jw.Pending(); got != 1 {
+		t.Fatalf("Pending() = %d, want 1", got)
+	}
+	if claimed := jw.UseRequest(oldKey, oldReq); claimed != nil {
+		t.Fatalf("old request claimed as %v after live elapsed eviction", claimed)
+	}
+	if claimed := jw.UseRequest(newRq.JawsKey, newReq); claimed != newRq {
+		t.Fatalf("new request claim = %v, want %v", claimed, newRq)
+	}
+}
+
 // reentrantLogger re-enters the Jaws instance while logging (via RequestCount,
 // which takes jw.mu.RLock), and records the logged error. If the framework ever
 // invokes the logger while holding jw.mu, this deadlocks.

--- a/request_test.go
+++ b/request_test.go
@@ -2012,6 +2012,31 @@ func TestCoverage_RequestMaintenanceClaimAndErrors(t *testing.T) {
 	maybePanic(errors.New("boom"))
 }
 
+func TestNewRequest_SeedsLastWriteFromLiveElapsed(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+
+	// Simulate an hour of startup before Serve runs. Serve is deliberately not
+	// started, so runtimeSeconds is never advanced by its maintenance loop.
+	jw.created = time.Now().Add(-time.Hour)
+
+	rq := jw.NewRequest(httptest.NewRequest("GET", "/", nil))
+
+	// The seed must reflect true elapsed time (~3600s), not the stale zero that
+	// runtimeSeconds still holds before Serve seeds it.
+	if got := rq.lastWriteSeconds.Load(); got < 3595 || got > 3605 {
+		t.Fatalf("expected lastWriteSeconds seeded to ~3600, got %d", got)
+	}
+
+	// A brand-new request must not be idle-expired by the first maintenance pass.
+	if expired, _ := rq.maintenance(jw.runtimeSeconds.Load(), time.Hour); expired {
+		t.Fatal("a brand-new pre-Serve request must not be idle-expired")
+	}
+}
+
 func TestCoverage_RequestProcessHTTPDoneAndBroadcastDone(t *testing.T) {
 	jw, err := New()
 	if err != nil {

--- a/requestpool.go
+++ b/requestpool.go
@@ -200,6 +200,11 @@ func (jw *Jaws) getRequestLocked(jawsKey key.Key, r *http.Request, remoteIP neti
 	rq.mu.Lock()
 	defer rq.mu.Unlock()
 	rq.JawsKey = jawsKey
+	// Freshen the shared counter first so the seed reflects true elapsed time even
+	// before the Serve loop starts advancing runtimeSeconds; otherwise a request
+	// created pre-Serve would seed 0 and be idle-expired by the first maintenance
+	// pass once Serve seeds runtimeSeconds to the real elapsed value.
+	jw.refreshRuntimeSeconds()
 	rq.lastWriteSeconds.Store(jw.runtimeSeconds.Load())
 	rq.initial = r
 	rq.remoteIP = remoteIP

--- a/requestpool.go
+++ b/requestpool.go
@@ -36,6 +36,11 @@ func (jw *Jaws) NewRequest(r *http.Request) (rq *Request) {
 	func() {
 		jw.mu.Lock()
 		defer jw.mu.Unlock()
+		// Refresh before enforcing the pending cap as well as before seeding the
+		// new Request. Before Serve starts there is no maintenance loop to advance
+		// the counter, so a stale value could otherwise make an old pending Request
+		// look freshly written and briefly overshoot the cap.
+		jw.refreshRuntimeSeconds()
 		toLog = jw.limitPendingRequestsLocked(remoteIP)
 		for rq == nil {
 			jawsKey := jw.nonZeroRandomLocked()
@@ -57,9 +62,10 @@ func (jw *Jaws) NewRequest(r *http.Request) (rq *Request) {
 // refreshRuntimeSeconds updates runtimeSeconds to the whole seconds elapsed since
 // the [Jaws] was created.
 //
-// The Serve loop calls it (seeded once at start, then on every maintenance tick), so
-// the per-write [Request.MarkWritten] only does an atomic load rather than reading
-// the clock.
+// Request allocation calls it before pending-request eviction and timestamp
+// seeding. The Serve loop also calls it once at start and on every maintenance
+// tick, so per-write [Request.MarkWritten] only does an atomic load rather than
+// reading the clock.
 func (jw *Jaws) refreshRuntimeSeconds() {
 	// time.Since on a monotonic base is never negative and keeps the counter immune to
 	// wall-clock and NTP adjustments. The int32 conversion is intentionally
@@ -200,11 +206,6 @@ func (jw *Jaws) getRequestLocked(jawsKey key.Key, r *http.Request, remoteIP neti
 	rq.mu.Lock()
 	defer rq.mu.Unlock()
 	rq.JawsKey = jawsKey
-	// Freshen the shared counter first so the seed reflects true elapsed time even
-	// before the Serve loop starts advancing runtimeSeconds; otherwise a request
-	// created pre-Serve would seed 0 and be idle-expired by the first maintenance
-	// pass once Serve seeds runtimeSeconds to the real elapsed value.
-	jw.refreshRuntimeSeconds()
 	rq.lastWriteSeconds.Store(jw.runtimeSeconds.Load())
 	rq.initial = r
 	rq.remoteIP = remoteIP


### PR DESCRIPTION
A Request created before Serve could inherit a stale runtimeSeconds value. That made a fresh Request look old when the Serve loop first refreshed the counter, and the same stale value could prevent the pending-request cap from evicting an older pre-Serve request.

NewRequest now refreshes runtimeSeconds immediately after acquiring Jaws.mu, before both the pending-request limit scan and the new Request's lastWriteSeconds seed. The Serve loop continues to refresh the shared counter at startup and on maintenance ticks.

Regression coverage verifies both behaviors:

- a newly allocated pre-Serve Request is seeded from live elapsed time and is not immediately idle-expired
- an old pre-Serve pending Request is evicted on the next same-IP allocation when the cap is reached