### PR TITLE
Preserve leading newline in textarea/pre inner HTML

### DIFF
--- a/lib/htmlio/writehtml.go
+++ b/lib/htmlio/writehtml.go
@@ -152,6 +152,10 @@ func WriteHTMLInput(w io.Writer, jid jid.Jid, typeAttr, valueAttr string, attrs 
 // Unlike [WriteHTMLTag] it emits no value attribute; pass one via attrs (for
 // example Attr("value", v)) when a value="..." is needed.
 //
+// For a textarea or pre element whose innerHTML begins with LF or CR, the HTML
+// source includes one additional LF immediately after the start tag. The parser
+// consumes that prefix, preserving the content's leading newline in the DOM.
+//
 // The htmlTag parameter is trusted and written verbatim with no escaping or
 // validation; it MUST NOT be derived from untrusted data. The typeAttr parameter
 // must be an unescaped logical value; it is escaped for HTML source output. The
@@ -162,8 +166,8 @@ func WriteHTMLInner(w io.Writer, jid jid.Jid, htmlTag, typeAttr string, innerHTM
 	b := appendHTMLTag(nil, jid, htmlTag, typeAttr, "", attrs)
 	if needClosingTag(htmlTag) {
 		// The HTML parser strips one newline right after a textarea/pre start
-		// tag, so inject a matching one to preserve a value that begins with a
-		// newline (the browser then discards the injected one).
+		// tag, so prefix one LF to preserve content that begins with LF or CR.
+		// The browser consumes the prefix during parsing.
 		if isNewlineSensitive(htmlTag) && len(innerHTML) > 0 && (innerHTML[0] == '\n' || innerHTML[0] == '\r') {
 			b = append(b, '\n')
 		}

--- a/lib/htmlio/writehtml.go
+++ b/lib/htmlio/writehtml.go
@@ -35,6 +35,17 @@ func needClosingTag(tag string) bool {
 	return !ok
 }
 
+// isNewlineSensitive reports whether tag (case-insensitive) is a textarea or pre
+// element, for which the HTML parser strips one newline immediately following the
+// start tag.
+func isNewlineSensitive(tag string) bool {
+	switch strings.ToLower(tag) {
+	case "textarea", "pre":
+		return true
+	}
+	return false
+}
+
 // AppendAttrs appends each non-empty attribute fragment in attrs to b, each
 // prefixed with a single space so the result can be concatenated directly after a
 // tag name.
@@ -150,6 +161,12 @@ func WriteHTMLInput(w io.Writer, jid jid.Jid, typeAttr, valueAttr string, attrs 
 func WriteHTMLInner(w io.Writer, jid jid.Jid, htmlTag, typeAttr string, innerHTML template.HTML, attrs ...template.HTMLAttr) (err error) {
 	b := appendHTMLTag(nil, jid, htmlTag, typeAttr, "", attrs)
 	if needClosingTag(htmlTag) {
+		// The HTML parser strips one newline right after a textarea/pre start
+		// tag, so inject a matching one to preserve a value that begins with a
+		// newline (the browser then discards the injected one).
+		if isNewlineSensitive(htmlTag) && len(innerHTML) > 0 && (innerHTML[0] == '\n' || innerHTML[0] == '\r') {
+			b = append(b, '\n')
+		}
 		b = append(b, innerHTML...)
 		b = append(b, "</"...)
 		b = append(b, htmlTag...)

--- a/lib/htmlio/writehtml.go
+++ b/lib/htmlio/writehtml.go
@@ -152,9 +152,9 @@ func WriteHTMLInput(w io.Writer, jid jid.Jid, typeAttr, valueAttr string, attrs 
 // Unlike [WriteHTMLTag] it emits no value attribute; pass one via attrs (for
 // example Attr("value", v)) when a value="..." is needed.
 //
-// For a textarea or pre element whose innerHTML begins with LF or CR, the HTML
-// source includes one additional LF immediately after the start tag. The parser
-// consumes that prefix, preserving the content's leading newline in the DOM.
+// For textarea and pre elements, the HTML source includes one LF immediately
+// after the start tag. The parser consumes that prefix, so it adds no DOM content
+// while preserving a leading LF or CR from innerHTML.
 //
 // The htmlTag parameter is trusted and written verbatim with no escaping or
 // validation; it MUST NOT be derived from untrusted data. The typeAttr parameter
@@ -165,10 +165,10 @@ func WriteHTMLInput(w io.Writer, jid jid.Jid, typeAttr, valueAttr string, attrs 
 func WriteHTMLInner(w io.Writer, jid jid.Jid, htmlTag, typeAttr string, innerHTML template.HTML, attrs ...template.HTMLAttr) (err error) {
 	b := appendHTMLTag(nil, jid, htmlTag, typeAttr, "", attrs)
 	if needClosingTag(htmlTag) {
-		// The HTML parser strips one newline right after a textarea/pre start
-		// tag, so prefix one LF to preserve content that begins with LF or CR.
-		// The browser consumes the prefix during parsing.
-		if isNewlineSensitive(htmlTag) && len(innerHTML) > 0 && (innerHTML[0] == '\n' || innerHTML[0] == '\r') {
+		// The HTML parser strips one LF right after a textarea/pre start tag.
+		// Always provide that parser-consumed prefix so innerHTML is preserved
+		// regardless of whether its first character is LF, CR, or ordinary text.
+		if isNewlineSensitive(htmlTag) {
 			b = append(b, '\n')
 		}
 		b = append(b, innerHTML...)

--- a/lib/htmlio/writehtml_test.go
+++ b/lib/htmlio/writehtml_test.go
@@ -130,6 +130,63 @@ func Test_WriteHTMLInner_ClosingTag(t *testing.T) {
 	}
 }
 
+func Test_WriteHTMLInner_LeadingNewline(t *testing.T) {
+	tests := []struct {
+		name  string
+		tag   string
+		inner template.HTML
+		want  string
+	}{
+		{
+			name:  "textarea leading newline is doubled",
+			tag:   "textarea",
+			inner: "\nhello",
+			want:  "<textarea id=\"Jid.1\">\n\nhello</textarea>",
+		},
+		{
+			name:  "textarea leading CR is doubled",
+			tag:   "textarea",
+			inner: "\rhello",
+			want:  "<textarea id=\"Jid.1\">\n\rhello</textarea>",
+		},
+		{
+			name:  "uppercase TEXTAREA is newline-sensitive",
+			tag:   "TEXTAREA",
+			inner: "\nhello",
+			want:  "<TEXTAREA id=\"Jid.1\">\n\nhello</TEXTAREA>",
+		},
+		{
+			name:  "pre leading newline is doubled",
+			tag:   "pre",
+			inner: "\nhello",
+			want:  "<pre id=\"Jid.1\">\n\nhello</pre>",
+		},
+		{
+			name:  "textarea without leading newline is unchanged",
+			tag:   "textarea",
+			inner: "hello",
+			want:  "<textarea id=\"Jid.1\">hello</textarea>",
+		},
+		{
+			name:  "div leading newline is unchanged",
+			tag:   "div",
+			inner: "\nx",
+			want:  "<div id=\"Jid.1\">\nx</div>",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sb strings.Builder
+			if err := htmlio.WriteHTMLInner(&sb, jid.Jid(1), tt.tag, "", tt.inner); err != nil {
+				t.Fatal(err)
+			}
+			if got := sb.String(); got != tt.want {
+				t.Errorf("WriteHTMLInner() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 // FuzzAppendAttrValue guards the escaping invariant: for arbitrary input, the
 // bytes between the bounding double quotes must contain no raw '"' or '<' that
 // could break out of the attribute value or open a new tag.

--- a/lib/htmlio/writehtml_test.go
+++ b/lib/htmlio/writehtml_test.go
@@ -144,7 +144,7 @@ func Test_WriteHTMLInner_LeadingNewline(t *testing.T) {
 			want:  "<textarea id=\"Jid.1\">\n\nhello</textarea>",
 		},
 		{
-			name:  "textarea leading CR is doubled",
+			name:  "textarea leading CR is prefixed with LF",
 			tag:   "textarea",
 			inner: "\rhello",
 			want:  "<textarea id=\"Jid.1\">\n\rhello</textarea>",

--- a/lib/htmlio/writehtml_test.go
+++ b/lib/htmlio/writehtml_test.go
@@ -130,7 +130,7 @@ func Test_WriteHTMLInner_ClosingTag(t *testing.T) {
 	}
 }
 
-func Test_WriteHTMLInner_LeadingNewline(t *testing.T) {
+func Test_WriteHTMLInner_NewlineSensitivePrefix(t *testing.T) {
 	tests := []struct {
 		name  string
 		tag   string
@@ -138,7 +138,7 @@ func Test_WriteHTMLInner_LeadingNewline(t *testing.T) {
 		want  string
 	}{
 		{
-			name:  "textarea leading newline is doubled",
+			name:  "textarea leading LF is preserved after prefix",
 			tag:   "textarea",
 			inner: "\nhello",
 			want:  "<textarea id=\"Jid.1\">\n\nhello</textarea>",
@@ -156,16 +156,21 @@ func Test_WriteHTMLInner_LeadingNewline(t *testing.T) {
 			want:  "<TEXTAREA id=\"Jid.1\">\n\nhello</TEXTAREA>",
 		},
 		{
-			name:  "pre leading newline is doubled",
+			name:  "pre leading LF is preserved after prefix",
 			tag:   "pre",
 			inner: "\nhello",
 			want:  "<pre id=\"Jid.1\">\n\nhello</pre>",
 		},
 		{
-			name:  "textarea without leading newline is unchanged",
+			name:  "textarea ordinary content gets parser prefix",
 			tag:   "textarea",
 			inner: "hello",
-			want:  "<textarea id=\"Jid.1\">hello</textarea>",
+			want:  "<textarea id=\"Jid.1\">\nhello</textarea>",
+		},
+		{
+			name: "empty textarea gets parser prefix",
+			tag:  "textarea",
+			want: "<textarea id=\"Jid.1\">\n</textarea>",
 		},
 		{
 			name:  "div leading newline is unchanged",

--- a/lib/ui/input_widgets_test.go
+++ b/lib/ui/input_widgets_test.go
@@ -48,7 +48,7 @@ func TestInputTextWidgets(t *testing.T) {
 
 	textarea := NewTextarea(ss)
 	textareaElem, got := renderUI(t, rq, textarea)
-	mustMatch(t, `^<textarea id="Jid\.[0-9]+">quux</textarea>$`, got)
+	mustMatch(t, `^<textarea id="Jid\.[0-9]+">\nquux</textarea>$`, got)
 	textarea.JawsUpdate(textareaElem)
 }
 
@@ -421,7 +421,7 @@ func TestTextarea_RenderEscapesHTML(t *testing.T) {
 	ss := newTestSetter(`x</textarea><script>alert("x")</script>`)
 
 	_, got := renderUI(t, rq, NewTextarea(ss))
-	mustMatch(t, `^<textarea id="Jid\.[0-9]+">x&lt;/textarea&gt;&lt;script&gt;alert\(&#34;x&#34;\)&lt;/script&gt;</textarea>$`, got)
+	mustMatch(t, `^<textarea id="Jid\.[0-9]+">\nx&lt;/textarea&gt;&lt;script&gt;alert\(&#34;x&#34;\)&lt;/script&gt;</textarea>$`, got)
 }
 
 func TestTextarea_RenderPreservesLeadingNewline(t *testing.T) {

--- a/lib/ui/input_widgets_test.go
+++ b/lib/ui/input_widgets_test.go
@@ -424,6 +424,16 @@ func TestTextarea_RenderEscapesHTML(t *testing.T) {
 	mustMatch(t, `^<textarea id="Jid\.[0-9]+">x&lt;/textarea&gt;&lt;script&gt;alert\(&#34;x&#34;\)&lt;/script&gt;</textarea>$`, got)
 }
 
+func TestTextarea_RenderPreservesLeadingNewline(t *testing.T) {
+	_, rq := newCoreRequest(t)
+	ss := newTestSetter("\nhello")
+
+	_, got := renderUI(t, rq, NewTextarea(ss))
+	if want := "<textarea id=\"Jid.1\">\n\nhello</textarea>"; got != want {
+		t.Fatalf("rendered textarea = %q, want %q", got, want)
+	}
+}
+
 func TestInputTextWidget_RenderEscapesValueAttr(t *testing.T) {
 	_, rq := newCoreRequest(t)
 	value := `"&<>'\` + "\n"


### PR DESCRIPTION
The HTML parser consumes one LF immediately after a textarea or pre start tag. Without compensation, initial content beginning with LF or CR loses its leading newline in the DOM.

WriteHTMLInner now always writes one LF immediately after textarea/pre start tags. The parser consumes that prefix, so ordinary and empty content gain no DOM text while content beginning with LF or CR retains its leading newline. Other elements are unchanged, and tag matching remains case-insensitive.

Regression tests cover leading LF, leading CR, ordinary content, empty content, uppercase TEXTAREA, pre, unchanged div content, and complete Textarea widget renders.