### PR TITLE
Guard ApplyGetter auto-tag with usableAsTag

### DIFF
--- a/element.go
+++ b/element.go
@@ -371,8 +371,13 @@ func (elem *Element) ApplyParams(params []any) (attrs []template.HTMLAttr) {
 	return
 }
 
-// ApplyGetter examines getter, and if it is not nil, either adds it
-// as a tag, or, if it is a [tag.TagGetter], adds the result of that as a tag.
+// ApplyGetter examines getter and resolves its tag candidate.
+//
+// If getter implements [tag.TagGetter], the candidate is its returned value;
+// otherwise the candidate is getter itself. TagGetter values, supported tag
+// slices and runtime-comparable candidates are passed to [Element.Tag] for normal
+// validation. Other non-comparable candidates are not automatically tagged,
+// matching [ParseParams].
 //
 // If getter is an [InputHandler], [ClickHandler], [ContextMenuHandler] or
 // [InitialHTMLAttrHandler], relevant values are added to the [Element].
@@ -380,9 +385,10 @@ func (elem *Element) ApplyParams(params []any) (attrs []template.HTMLAttr) {
 // Finally, if getter is an [InitHandler], its JawsInit
 // function is called.
 //
-// Returns the Tag(s) added (or nil if getter was nil), any initial HTML attrs
-// provided by InitialHTMLAttrHandler, and any error returned from JawsInit()
-// if it was called.
+// Returns the tag that was added (nil if none was added, whether because getter
+// was nil or its candidate was not usable as a tag), any initial HTML attrs
+// provided by InitialHTMLAttrHandler, and any error returned from JawsInit() if it
+// was called.
 //
 // If the [Element] is already frozen and getter is an event handler, the handler
 // is not added: in production with a [Jaws.Logger] configured this is logged and
@@ -408,7 +414,11 @@ func (elem *Element) ApplyGetter(getter any) (tagValue any, attrs []template.HTM
 				attrs = append(attrs, attr)
 			}
 		}
-		elem.Tag(tagValue)
+		if usableAsTag(tagValue) {
+			elem.Tag(tagValue)
+		} else {
+			tagValue = nil
+		}
 		if initer, ok := getter.(InitHandler); ok {
 			err = initer.JawsInit(elem)
 		}

--- a/element_test.go
+++ b/element_test.go
@@ -1,9 +1,11 @@
 package jaws
 
 import (
+	"bytes"
 	"fmt"
 	"html/template"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -660,6 +662,57 @@ func TestElement_ApplyGetter_NonComparableHandler(t *testing.T) {
 	}
 	if err := CallEventHandlers(e.UI(), e, what.Click, "1 2 0 name"); err != nil {
 		t.Fatalf("expected click handler to run, got %v", err)
+	}
+}
+
+func TestElement_ApplyGetter_NonComparableHandler_NilLogger(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+	if jw.Logger != nil {
+		t.Fatal("expected nil Logger by default")
+	}
+
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	e := rq.NewElement(&testUi{s: "x"})
+	tch := testNonComparableClickHandler{names: []string{"name"}}
+	gotTag, _, err := e.ApplyGetter(tch)
+	if err != nil {
+		t.Fatalf("ApplyGetter returned error: %v", err)
+	}
+	if gotTag != nil {
+		t.Fatalf("expected declined non-comparable candidate to return a nil tag, got %#v", gotTag)
+	}
+	if len(e.handlers) != 1 {
+		t.Fatalf("expected 1 handler, got %d", len(e.handlers))
+	}
+	if got := rq.TagsOf(e); len(got) != 0 {
+		t.Fatalf("expected non-comparable handler to not be auto-tagged, got %v", got)
+	}
+	// The returned tag is what a widget stores and later dirties. A nil tag must
+	// not reach MustLog (which panics with a nil Logger); a non-comparable one would.
+	e.Dirty(gotTag)
+}
+
+func TestElement_ApplyGetter_NonComparableHandler_NoLog(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+	var buf bytes.Buffer
+	jw.Logger = slog.New(slog.NewTextHandler(&buf, nil))
+
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	e := rq.NewElement(&testUi{s: "x"})
+	tch := testNonComparableClickHandler{names: []string{"name"}}
+	if _, _, err := e.ApplyGetter(tch); err != nil {
+		t.Fatalf("ApplyGetter returned error: %v", err)
+	}
+	if strings.Contains(buf.String(), "not usable as tag") {
+		t.Fatalf("expected no not-usable-as-tag log, got %q", buf.String())
 	}
 }
 


### PR DESCRIPTION
Element.ApplyGetter auto-tagged the resolved getter unconditionally. For an event handler that is not comparable at runtime this reached tag.MustTagExpand -> Jaws.MustLog, which panics on the default nil Logger (jaws.go) and logs a spurious ERROR on every render otherwise.

Guard the auto-tag call with usableAsTag, matching the sibling ParseParams path, and update the doc comment to state only tag-usable (comparable) getters are auto-tagged. usableAsTag(nil) is true, so the nil-tag-getter case is unaffected.

Regression tests use a Jaws with the default nil Logger (and a with-logger variant asserting no "not usable as tag" log): without the fix ApplyGetter panics on a non-comparable handler; with it, ApplyGetter returns nil, registers exactly 1 handler and adds 0 tags.