### PR TITLE
Cancel and retire pending requests when Jaws closes

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,16 +198,16 @@ updates.
 
 ### Request lifecycle invariants
 
-`NewRequest` creates a pending request owned by the `Jaws` instance. `UseRequest`
-is the only operation that claims that pending request for a WebSocket, and it
-also removes the request from the pending set. A claimed Request is removed after
-its WebSocket processing exits. Maintenance or the per-IP limit can instead
-retire an unclaimed Request: its context is canceled, its key becomes
-unclaimable, and it is excluded from `Pending` and `RequestCount`. Retiring an
-unclaimed Request does not change its identity or Elements while an initial HTTP
-handler still holds them. Its key cannot be assigned to another Request while
-the retired Request remains reachable; no deadline is guaranteed for later
-reuse.
+While the `Jaws` instance is open, `NewRequest` creates a pending request owned
+by it. `UseRequest` is the only operation that claims that pending request for a
+WebSocket, and it also removes the request from the pending set. A claimed
+Request is removed after its WebSocket processing exits. Maintenance or the
+per-IP limit can instead retire an unclaimed Request: its context is canceled,
+its key becomes unclaimable, and it is excluded from `Pending` and
+`RequestCount`. Retiring an unclaimed Request does not change its identity or
+Elements while an initial HTTP handler still holds them. Its key cannot be
+assigned to another Request while the retired Request remains reachable; no
+deadline is guaranteed for later reuse.
 
 Dirtying is two-stage: `Request.Dirty` and `Jaws.Dirty` expand tags and record
 them on the `Jaws` instance, then the serving loop distributes those tags to

--- a/README.md
+++ b/README.md
@@ -461,9 +461,9 @@ requested during the JavaScript WebSocket HTTP request.
 
 ### Security of the WebSocket callback
 
-Each JaWS request gets a non-zero random 64-bit key not currently in use. This
-value is written to the HTML output so the JavaScript can construct the WebSocket
-callback URL.
+While the `Jaws` instance is open, each Request gets a non-zero random 64-bit key
+not currently in use. This value is written to the HTML output so the JavaScript
+can construct the WebSocket callback URL.
 
 While assigned to a Request, its callback key can claim that Request at most
 once. JaWS does not assign keys belonging to registered Requests or

--- a/jaws.go
+++ b/jaws.go
@@ -228,20 +228,47 @@ func New() (jw *Jaws, err error) {
 	return
 }
 
-// Close frees resources associated with the [Jaws] object, and
-// closes the completion channel if the [Jaws] was created with [New].
-// Once the completion channel is closed, broadcasts and sends may be discarded.
-// Subsequent calls to Close() have no effect.
+// Close cancels requests and frees resources associated with the Jaws object.
+//
+// Before Close returns, every current [Request.Context] is canceled, including
+// pending Requests whose WebSocket never connected. Non-running Requests are
+// unregistered before Close returns but are not pooled while an initial HTTP
+// handler may still hold them; a detached Request becomes garbage-collectable when
+// its owner releases it. Active WebSocket handlers observe cancellation and finish
+// asynchronously. Requests created after Close start canceled and cannot be
+// claimed with [Jaws.UseRequest]. Once the completion channel is closed, broadcasts
+// and sends may be discarded. Subsequent calls to Close have no effect.
 func (jw *Jaws) Close() {
+	var toLog []error
 	jw.mu.Lock()
 	select {
 	case <-jw.closeCh:
-		// already closed
+		jw.mu.Unlock()
+		return
 	default:
 		close(jw.closeCh)
 	}
 	jw.updateTicker.Stop()
+	for _, rq := range jw.requests {
+		if rq == nil {
+			continue
+		}
+		if rq.running.Load() {
+			rq.mu.Lock()
+			if cause := rq.cancelLocked(nil); cause != nil {
+				toLog = append(toLog, cause)
+			}
+			rq.mu.Unlock()
+		} else {
+			if cause := jw.retireNonRunningRequestLocked(rq, nil); cause != nil {
+				toLog = append(toLog, cause)
+			}
+		}
+	}
 	jw.mu.Unlock()
+	for _, cause := range toLog {
+		_ = jw.Log(cause)
+	}
 }
 
 // Done returns the channel that is closed when [Jaws.Close] has been called.

--- a/jaws.go
+++ b/jaws.go
@@ -228,16 +228,18 @@ func New() (jw *Jaws, err error) {
 	return
 }
 
-// Close cancels requests and frees resources associated with the Jaws object.
+// Close initiates shutdown of the [Jaws] instance.
 //
-// Before Close returns, every current [Request.Context] is canceled, including
-// pending Requests whose WebSocket never connected. Non-running Requests are
-// unregistered before Close returns but are not pooled while an initial HTTP
-// handler may still hold them; a detached Request becomes garbage-collectable when
-// its owner releases it. Active WebSocket handlers observe cancellation and finish
-// asynchronously. Requests created after Close start canceled and cannot be
-// claimed with [Jaws.UseRequest]. Once the completion channel is closed, broadcasts
-// and sends may be discarded. Subsequent calls to Close have no effect.
+// [Jaws.Done] is closed as shutdown begins. Before Close returns, the context
+// returned by [Request.Context] for every current Request is canceled, including
+// pending Requests whose WebSocket never connected. Non-running Requests become
+// unclaimable but retain their identity while callers hold them. Active WebSocket
+// handlers observe cancellation and finish asynchronously.
+//
+// Calls to [Jaws.NewRequest] after shutdown begins return Requests with
+// already-canceled contexts that [Jaws.UseRequest] cannot claim. Broadcasts and
+// sends may be discarded after Done closes. Subsequent calls to Close have no
+// effect.
 func (jw *Jaws) Close() {
 	var toLog []error
 	jw.mu.Lock()
@@ -271,7 +273,7 @@ func (jw *Jaws) Close() {
 	}
 }
 
-// Done returns the channel that is closed when [Jaws.Close] has been called.
+// Done returns a channel closed when [Jaws.Close] begins shutdown.
 func (jw *Jaws) Done() <-chan struct{} {
 	return jw.closeCh
 }

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -100,6 +100,170 @@ func TestNew_DefaultWebSocketPingInterval(t *testing.T) {
 	}
 }
 
+// TestJaws_CloseCancelsPendingHTTPWork drives a normal HTTP handler that starts
+// request-scoped work before the WebSocket connects. Close must synchronously
+// cancel that pending Request so the handler's work can stop.
+func TestJaws_CloseCancelsPendingHTTPWork(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type startedRequest struct {
+		rq       *Request
+		sentinel *Element
+	}
+	requestStarted := make(chan startedRequest, 1)
+	handlerDone := make(chan *Element, 1)
+	handler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		rq := jw.NewRequest(r)
+		requestStarted <- startedRequest{rq: rq, sentinel: rq.NewElement(&testUi{})}
+		<-rq.Context().Done()
+		// A normal HTTP owner may still run cleanup after observing cancellation.
+		// Close must not have cleared or pooled its Request underneath it.
+		handlerDone <- rq.NewElement(&testUi{})
+	})
+	go handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+	started := <-requestStarted
+	rq := started.rq
+
+	jw.Close()
+	select {
+	case <-rq.Context().Done():
+	default:
+		t.Fatal("Close returned with pending Request context still live")
+	}
+	if cause := context.Cause(rq.Context()); !errors.Is(cause, context.Canceled) {
+		t.Fatalf("Close cancellation cause = %v, want context.Canceled", cause)
+	}
+	if jw.RequestCount() != 0 || jw.Pending() != 0 {
+		t.Fatalf("Close retained pending Request: key %v, requests %d, pending %d", rq.JawsKey, jw.RequestCount(), jw.Pending())
+	}
+	if rq.JawsKey == 0 || started.sentinel.Deleted() {
+		t.Fatalf("Close cleared or pooled an HTTP-owned Request: key %v, sentinel deleted %t", rq.JawsKey, started.sentinel.Deleted())
+	}
+	select {
+	case elem := <-handlerDone:
+		if elem == nil || elem.Deleted() {
+			t.Fatal("Close cleared the Request while its HTTP owner was still using it")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("request-scoped HTTP work did not observe Close cancellation")
+	}
+}
+
+func TestJaws_CloseRejectsClaimedRequestBeforeServe(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial := httptest.NewRequest(http.MethodGet, "http://example.test/", nil)
+	initial.RemoteAddr = "192.0.2.1:1000"
+	rq := jw.NewRequest(initial)
+	sentinel := rq.NewElement(&testUi{})
+	key := rq.JawsKey
+	websocketRequest := httptest.NewRequest(http.MethodGet, "http://example.test/jaws/"+key.String(), nil)
+	websocketRequest.RemoteAddr = initial.RemoteAddr
+	if claimed := jw.UseRequest(key, websocketRequest); claimed != rq {
+		t.Fatalf("UseRequest() = %p, want %p", claimed, rq)
+	}
+
+	jw.Close()
+	recorder := httptest.NewRecorder()
+	rq.ServeHTTP(recorder, websocketRequest)
+	if recorder.Code != http.StatusGone {
+		t.Fatalf("ServeHTTP after Close status = %d, want %d", recorder.Code, http.StatusGone)
+	}
+	if rq.JawsKey == 0 {
+		t.Fatal("Close cleared a Request that its initial HTTP handler may still own")
+	}
+	if sentinel.Deleted() {
+		t.Fatal("Close deleted an Element that its initial HTTP handler may still own")
+	}
+	if got := jw.RequestCount(); got != 0 {
+		t.Fatalf("RequestCount() after Close = %d, want 0", got)
+	}
+}
+
+func TestJaws_CloseHandlesRetiredKeyReservation(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	jw.MaxPendingRequestsPerIP = 1
+
+	retired := jw.NewRequest(newPendingLimitRequest("192.0.2.1:1000"))
+	setPendingLimitLastWrite(t, retired, 3600)
+	replacement := jw.NewRequest(newPendingLimitRequest("192.0.2.1:1001"))
+
+	jw.Close()
+	if got := jw.RequestCount(); got != 0 {
+		t.Fatalf("RequestCount() after Close = %d, want 0", got)
+	}
+	for name, rq := range map[string]*Request{"retired": retired, "replacement": replacement} {
+		select {
+		case <-rq.Context().Done():
+		default:
+			t.Fatalf("%s Request context remains live after Close", name)
+		}
+		jw.mu.RLock()
+		tombstone, reserved := jw.requests[rq.JawsKey]
+		jw.mu.RUnlock()
+		if !reserved || tombstone != nil {
+			t.Fatalf("%s key map entry = %v, %t, want nil tombstone", name, tombstone, reserved)
+		}
+	}
+	runtime.KeepAlive(retired)
+	runtime.KeepAlive(replacement)
+}
+
+func TestJaws_NewRequestRacingCloseStartsCanceled(t *testing.T) {
+	for range 20 {
+		jw, err := New()
+		if err != nil {
+			t.Fatal(err)
+		}
+		start := make(chan struct{})
+		requestCh := make(chan *Request, 1)
+		closed := make(chan struct{})
+		request := httptest.NewRequest(http.MethodGet, "/", nil)
+		go func() {
+			<-start
+			requestCh <- jw.NewRequest(request)
+		}()
+		go func() {
+			<-start
+			jw.Close()
+			close(closed)
+		}()
+		close(start)
+		rq := <-requestCh
+		<-closed
+		select {
+		case <-rq.Context().Done():
+		default:
+			t.Fatal("Request racing Close retained a live context")
+		}
+		if claimed := jw.UseRequest(rq.JawsKey, request); claimed != nil {
+			t.Fatalf("UseRequest after Close = %p, want nil", claimed)
+		}
+		requestsBefore := jw.RequestCount()
+		pendingBefore := jw.Pending()
+		postClose := jw.NewRequest(request)
+		select {
+		case <-postClose.Context().Done():
+		default:
+			t.Fatal("Request created after Close retained a live context")
+		}
+		if jw.RequestCount() != requestsBefore || jw.Pending() != pendingBefore {
+			t.Fatalf("post-Close Request was registered: requests %d -> %d, pending %d -> %d", requestsBefore, jw.RequestCount(), pendingBefore, jw.Pending())
+		}
+		// The documented repeated Close no-op remains safe after post-close
+		// allocation.
+		jw.Close()
+	}
+}
+
 func TestJaws_MaxPendingRequestsPerIPDisabled(t *testing.T) {
 	for _, limit := range []int{0, -1} {
 		jw, err := New()
@@ -2367,6 +2531,33 @@ func (benchUnhandledClickHandler) JawsClick(*Element, Click) error {
 }
 
 var benchRequestSink *Request
+
+func BenchmarkJawsClosePendingRequests(b *testing.B) {
+	for _, pending := range []int{0, 1, 100} {
+		b.Run("pending="+strconv.Itoa(pending), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				jw := &Jaws{
+					closeCh:      make(chan struct{}),
+					updateTicker: time.NewTicker(time.Hour),
+					requests:     make(map[key.Key]*Request, pending),
+					requestCount: pending,
+				}
+				for i := range pending {
+					jawsKey := key.Key(i + 1)
+					ctx, cancel := context.WithCancelCause(b.Context())
+					jw.requests[jawsKey] = &Request{
+						Jaws:     jw,
+						JawsKey:  jawsKey,
+						ctx:      ctx,
+						cancelFn: cancel,
+					}
+				}
+				jw.Close()
+			}
+		})
+	}
+}
 
 // newBenchRequest returns a Request seeded with n Elements (Jids 1..n, ascending).
 func newBenchRequest(b *testing.B, n int) *Request {

--- a/request.go
+++ b/request.go
@@ -132,6 +132,9 @@ func (rq *Request) claim(r *http.Request) error {
 		if !equalIP(rq.remoteIP, actualIP) {
 			return newErrWebSocketIPMismatchLocked(rq, actualIP)
 		}
+		if rq.ctx.Err() != nil {
+			return context.Cause(rq.ctx)
+		}
 		if rq.claimed.CompareAndSwap(false, true) {
 			// Layer a fresh cancelable context over the current one (which may
 			// have been customized via SetContext) so the claim has its own
@@ -735,10 +738,16 @@ func (rq *Request) MustLog(err error) {
 func (rq *Request) startServe() (ok bool) {
 	rq.Jaws.mu.Lock()
 	defer rq.Jaws.mu.Unlock()
+	select {
+	case <-rq.Jaws.closeCh:
+		return false
+	default:
+	}
 	rq.mu.RLock()
 	registered := rq.Jaws.requests[rq.JawsKey] == rq
+	contextLive := rq.ctx != nil && rq.ctx.Err() == nil
 	rq.mu.RUnlock()
-	return registered && rq.claimed.Load() && rq.running.CompareAndSwap(false, true)
+	return registered && contextLive && rq.claimed.Load() && rq.running.CompareAndSwap(false, true)
 }
 
 func (rq *Request) stopServe() {

--- a/requestpool.go
+++ b/requestpool.go
@@ -19,7 +19,10 @@ import (
 	"github.com/linkdata/jaws/lib/key"
 )
 
-// NewRequest returns a new pending JaWS request.
+// NewRequest returns a new JaWS Request.
+//
+// While the [Jaws] instance is open, the returned Request is pending until it is
+// claimed or retired.
 //
 // Call this as soon as you start processing an HTML request, and store the
 // returned [Request] pointer so it can be used while constructing the HTML

--- a/requestpool.go
+++ b/requestpool.go
@@ -29,6 +29,9 @@ import (
 // Automatic timeout handling is performed by [Jaws.ServeWithTimeout]. The default
 // [Jaws.Serve] helper uses a 10-second timeout.
 //
+// A Request created after [Jaws.Close] has an already-canceled context and cannot
+// be claimed by [Jaws.UseRequest].
+//
 // When timeout maintenance or the per-IP pending limit retires an unclaimed
 // Request, its key becomes unclaimable. The key also remains unavailable for
 // assignment to another Request while the retired Request is reachable; no
@@ -48,14 +51,24 @@ func (jw *Jaws) NewRequest(r *http.Request) (rq *Request) {
 		// the counter, so a stale value could otherwise make an old pending Request
 		// look freshly written and briefly overshoot the cap.
 		jw.refreshRuntimeSeconds()
-		toLog = jw.limitPendingRequestsLocked(remoteIP)
+		closed := false
+		select {
+		case <-jw.closeCh:
+			closed = true
+		default:
+			toLog = jw.limitPendingRequestsLocked(remoteIP)
+		}
 		for rq == nil {
 			jawsKey := jw.nonZeroRandomLocked()
 			if _, ok := jw.requests[jawsKey]; !ok {
-				rq = jw.getRequestLocked(jawsKey, r, remoteIP)
-				jw.requests[jawsKey] = rq
-				jw.requestCount++
-				jw.pending[rq.remoteIP] = append(jw.pending[rq.remoteIP], rq)
+				rq = jw.getRequestLocked(jawsKey, r, remoteIP, !closed)
+				if closed {
+					rq.cancelFn(nil)
+				} else {
+					jw.requests[jawsKey] = rq
+					jw.requestCount++
+					jw.pending[rq.remoteIP] = append(jw.pending[rq.remoteIP], rq)
+				}
 			}
 		}
 	}()
@@ -200,8 +213,9 @@ func (jw *Jaws) UseRequest(jawsKey key.Key, r *http.Request) (rq *Request) {
 
 // getRequestLocked allocates a Request from the pool for jawsKey. remoteIP is the
 // already-resolved client IP for r (see NewRequest, the sole caller), passed in to
-// avoid recomputing jw.clientIP(r). Caller must hold jw.mu.
-func (jw *Jaws) getRequestLocked(jawsKey key.Key, r *http.Request, remoteIP netip.Addr) (rq *Request) {
+// avoid recomputing jw.clientIP(r). attachSession is false after Jaws.Close, when
+// the canceled Request is returned without registration. Caller must hold jw.mu.
+func (jw *Jaws) getRequestLocked(jawsKey key.Key, r *http.Request, remoteIP netip.Addr, attachSession bool) (rq *Request) {
 	rq = jw.reqPool.Get().(*Request)
 	rq.mu.Lock()
 	defer rq.mu.Unlock()
@@ -210,7 +224,7 @@ func (jw *Jaws) getRequestLocked(jawsKey key.Key, r *http.Request, remoteIP neti
 	rq.initial = r
 	rq.remoteIP = remoteIP
 	rq.ctx, rq.cancelFn = context.WithCancelCause(jw.BaseContext)
-	if r != nil {
+	if attachSession && r != nil {
 		if sess := jw.getSessionLocked(getCookieSessionsIDs(r.Header, jw.CookieName), rq.remoteIP); sess != nil {
 			sess.addRequest(rq)
 			rq.session = sess
@@ -263,7 +277,9 @@ func (jw *Jaws) retireNonRunningRequestLocked(rq *Request, err error) (cause err
 	return
 }
 
-// recycleLockedWithCause recycles rq, optionally cancelling its context with err.
+// recycleLockedWithCause cancels and recycles rq.
+//
+// It uses err as the cancellation cause when non-nil.
 // It returns the cancellation cause (or nil) instead of logging it, so the caller
 // can log it after releasing jw.mu (see the package locking contract). Caller must
 // hold jw.mu.
@@ -271,9 +287,7 @@ func (jw *Jaws) recycleLockedWithCause(rq *Request, err error) (cause error) {
 	rq.mu.Lock()
 	defer rq.mu.Unlock()
 	if rq.JawsKey != 0 && jw.requests[rq.JawsKey] == rq {
-		if err != nil {
-			cause = rq.cancelLocked(err)
-		}
+		cause = rq.cancelLocked(err)
 		jw.removePendingRequestLocked(rq)
 		delete(jw.requests, rq.JawsKey)
 		jw.requestCount--

--- a/testhelpers_test.go
+++ b/testhelpers_test.go
@@ -748,18 +748,15 @@ func TestNewRequestHarness_ReturnsNilOnClaimFailure(t *testing.T) {
 	}
 }
 
-func TestNewTestRequest_PanicsWhenJawsClosed(t *testing.T) {
+func TestNewTestRequest_ReturnsNilWhenJawsClosed(t *testing.T) {
 	jw, err := New()
 	if err != nil {
 		t.Fatal(err)
 	}
 	jw.Close()
-	defer func() {
-		if recover() == nil {
-			t.Fatal("expected panic when the Jaws instance is closed")
-		}
-	}()
-	NewTestRequest(jw, nil)
+	if tr := NewTestRequest(jw, nil); tr != nil {
+		t.Fatalf("NewTestRequest after Jaws.Close = %p, want nil", tr)
+	}
 }
 
 func TestTestServe_TimesOutWhenServeNotRunning(t *testing.T) {


### PR DESCRIPTION
## Summary

- Make Jaws.Close synchronously cancel every current Request context.
- Retire non-running Requests with #95's lifecycle helper, preserving handler-owned fields while replacing registered map entries with nil key reservations.
- Skip existing retired-key tombstones during shutdown, cancel active WebSocket Requests for asynchronous teardown, and reject claimed Requests that try to start after shutdown.
- Return already-canceled unregistered Requests from NewRequest after Close and serialize NewRequest with Close so their race cannot leave live or claimable work behind.

## Production reachability

A normal HTTP handler can create a Request and block request-scoped work on Request.Context before the WebSocket connects. Production shutdown previously closed Jaws without canceling that context, so the handler remained blocked.

`TestJaws_CloseCancelsPendingHTTPWork` drives that normal `http.Handler` path, creates a sentinel Element, calls Close, and proves cancellation is synchronous while the handler can safely finish cleanup on the preserved Request. The claimed-before-serve regression exercises NewRequest, UseRequest, Close, and Request.ServeHTTP and verifies HTTP 410 without clearing handler-owned state. A repeated NewRequest/Close race proves both orderings produce canceled, unclaimable Requests.

`TestJaws_CloseHandlesRetiredKeyReservation` first reaches #95's production cap-retirement path, retaining both the retired Request and its replacement, then calls Close. It proves shutdown ignores the existing nil tombstone, retires the remaining live Request, cancels both contexts, and leaves both numeric keys reserved for their runtime cleanups.

## Verification

- Close cancellation, claimed-before-serve, retired-tombstone, and NewRequest/Close race regressions.
- Focused race suite repeated 20 times.
- Full `go test -race ./...` passes on #96 and the final stack.
- `go vet`, staticcheck, golangci-lint, gosec, gofumpt, and `go build` pass.

## Performance

`BenchmarkJawsClosePendingRequests`, eight alternating samples against updated #95 at GOMAXPROCS=1:

- pending=0: 548.6 to 555.3 ns/op, statistically unchanged; 824 B and 6 allocations unchanged.
- pending=1: 1.721 to 2.518 microseconds/op (+46.35%); 10 to 13 allocations.
- pending=100: 80.36 to 134.53 microseconds/op (+67.40%); 309 to 510 allocations, while bytes fell 12.44%.

This is one-time shutdown work the base path skips. The pending cases now synchronously cancel, detach, reserve keys, and register runtime cleanups; normal request processing is measured separately in #95 and remains statistically unchanged.

## Stack

Base: fix/initial-render-lifetime. It reuses #95's logical-retirement and key-reservation invariants; no render lease or HeadHTML/TailHTML tracking is involved.
