### PR TITLE
Wake idle requests when replacement contexts cancel

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,10 +459,10 @@ The reason is that there is no unbroken call chain from the time the Request
 object is created when the initial HTTP request comes in and when it is
 requested during the JavaScript WebSocket HTTP request.
 
-`Request.SetContext` must return a context derived from the supplied parent.
-If that replacement context is canceled or reaches its deadline, an idle live
-request wakes and shuts down immediately; it does not need an unrelated browser
-event or broadcast to notice the cancellation.
+`Request.SetContext` must return a non-nil context derived from the current
+context passed to it. If the returned context is canceled or its deadline
+expires, a running Request's WebSocket loop wakes promptly even while idle; no
+browser event or broadcast is needed.
 
 ### Security of the WebSocket callback
 

--- a/README.md
+++ b/README.md
@@ -459,6 +459,11 @@ The reason is that there is no unbroken call chain from the time the Request
 object is created when the initial HTTP request comes in and when it is
 requested during the JavaScript WebSocket HTTP request.
 
+`Request.SetContext` must return a context derived from the supplied parent.
+If that replacement context is canceled or reaches its deadline, an idle live
+request wakes and shuts down immediately; it does not need an unrelated browser
+event or broadcast to notice the cancellation.
+
 ### Security of the WebSocket callback
 
 While the `Jaws` instance is open, each Request gets a non-zero random 64-bit key

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -3032,6 +3032,34 @@ func BenchmarkRequestMarkWritten(b *testing.B) {
 	})
 }
 
+type benchmarkRequestContextKey struct{}
+
+// BenchmarkRequestSetContextValue guards the common value-only customization
+// path. Its Done channel is unchanged, so SetContext must avoid installing a
+// cancellation bridge or adding allocations beyond context.WithValue itself.
+func BenchmarkRequestSetContextValue(b *testing.B) {
+	jw, err := New()
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(jw.Close)
+	base, cancel := context.WithCancelCause(b.Context())
+	b.Cleanup(func() { cancel(nil) })
+	rq := &Request{Jaws: jw, JawsKey: key.Key(1), ctx: base, cancelFn: cancel}
+	b.ReportAllocs()
+	for b.Loop() {
+		rq.SetContext(func(old context.Context) context.Context {
+			return context.WithValue(old, benchmarkRequestContextKey{}, 1)
+		})
+		// Reset the benchmark fixture so value contexts do not form an ever-growing
+		// chain. SetContext itself still receives and derives from the real current
+		// context on every measured operation.
+		rq.mu.Lock()
+		rq.ctx = base
+		rq.mu.Unlock()
+	}
+}
+
 // BenchmarkRetirePendingRequests guards the exceptional lifecycle used when
 // maintenance or the per-IP cap revokes Requests whose initial handlers may
 // still own them. It measures both a single timeout and a full default-cap batch.

--- a/request.go
+++ b/request.go
@@ -336,6 +336,10 @@ func (rq *Request) Context() (ctx context.Context) {
 // The returned context must be derived from oldCtx so cancellation and deadlines
 // continue to propagate to [Request.Context].
 //
+// Cancellation of a replacement context wakes an idle live Request immediately;
+// it does not wait for another WebSocket event or broadcast. Value-only contexts
+// that retain oldCtx's Done channel require no additional cancellation bridge.
+//
 // The function runs while the Request lock is held so the transform is atomic.
 // It must not call methods on the same Request, call code that may do so, or
 // block on work that needs the same Request.
@@ -344,11 +348,37 @@ func (rq *Request) Context() (ctx context.Context) {
 // builds report it via [Jaws.MustLog] and keep the existing context.
 func (rq *Request) SetContext(fn func(oldCtx context.Context) (newCtx context.Context)) {
 	rq.mu.Lock()
-	defer rq.mu.Unlock()
-	if newCtx := fn(rq.ctx); newCtx != nil {
-		rq.ctx = newCtx
-	} else {
+	locked := true
+	defer func() {
+		// Keep the Request usable if the caller's transform panics.
+		if locked {
+			rq.mu.Unlock()
+		}
+	}()
+	oldCtx := rq.ctx
+	newCtx := fn(oldCtx)
+	if newCtx == nil {
+		rq.mu.Unlock()
+		locked = false
 		rq.Jaws.reportMisuse(errors.New("jaws: SetContext function returned a nil context"))
+		return
+	}
+	rq.ctx = newCtx
+	cancelFn := rq.cancelFn
+	rq.mu.Unlock()
+	locked = false
+	if newCtx.Done() != oldCtx.Done() {
+		// process may already be blocked selecting on oldCtx.Done. When a
+		// replacement has its own cancellation channel, bridge that cancellation
+		// into the allocation's stable cancel function so the old select wakes.
+		// Capture only contexts and the cancel closure: capturing rq would let a
+		// delayed callback cancel an unrelated Request after pool reuse.
+		//
+		// Register after releasing rq.mu. context.AfterFunc synchronously invokes
+		// a custom context's registration hook, which may legitimately re-enter rq.
+		context.AfterFunc(newCtx, func() {
+			cancelFn(context.Cause(newCtx))
+		})
 	}
 }
 

--- a/request.go
+++ b/request.go
@@ -342,44 +342,41 @@ func (rq *Request) Context() (ctx context.Context) {
 //
 // The function runs while the Request lock is held so the transform is atomic.
 // It must not call methods on the same Request, call code that may do so, or
-// block on work that needs the same Request.
+// block on work that needs the same Request. If the function panics, SetContext
+// releases the lock before the panic continues.
 //
 // Returning a nil context is a programming error: debug builds panic and production
 // builds report it via [Jaws.MustLog] and keep the existing context.
 func (rq *Request) SetContext(fn func(oldCtx context.Context) (newCtx context.Context)) {
-	rq.mu.Lock()
-	locked := true
-	defer func() {
-		// Keep the Request usable if the caller's transform panics.
-		if locked {
-			rq.mu.Unlock()
-		}
-	}()
-	oldCtx := rq.ctx
-	newCtx := fn(oldCtx)
+	oldCtx, newCtx, cancelFn := rq.replaceContext(fn)
 	if newCtx == nil {
-		rq.mu.Unlock()
-		locked = false
 		rq.Jaws.reportMisuse(errors.New("jaws: SetContext function returned a nil context"))
 		return
 	}
-	rq.ctx = newCtx
-	cancelFn := rq.cancelFn
-	rq.mu.Unlock()
-	locked = false
-	if newCtx.Done() != oldCtx.Done() {
-		// process may already be blocked selecting on oldCtx.Done. When a
-		// replacement has its own cancellation channel, bridge that cancellation
-		// into the allocation's stable cancel function so the old select wakes.
-		// Capture only contexts and the cancel closure: capturing rq would let a
-		// delayed callback cancel an unrelated Request after pool reuse.
-		//
-		// Register after releasing rq.mu. context.AfterFunc synchronously invokes
-		// a custom context's registration hook, which may legitimately re-enter rq.
-		context.AfterFunc(newCtx, func() {
-			cancelFn(context.Cause(newCtx))
-		})
+	if newCtx.Done() == oldCtx.Done() {
+		return
 	}
+	// The request loop may already be blocked selecting on oldCtx.Done. Bridge a
+	// replacement's cancellation into the allocation's stable cancel function so
+	// that old select wakes. Register outside rq.mu because context.AfterFunc may
+	// synchronously invoke a custom context hook that re-enters the Request.
+	//
+	// Capture only the context and cancel closure: capturing rq would let a delayed
+	// callback cancel an unrelated Request after pool reuse.
+	context.AfterFunc(newCtx, func() {
+		cancelFn(context.Cause(newCtx))
+	})
+}
+
+func (rq *Request) replaceContext(fn func(oldCtx context.Context) (newCtx context.Context)) (oldCtx, newCtx context.Context, cancelFn context.CancelCauseFunc) {
+	rq.mu.Lock()
+	defer rq.mu.Unlock()
+	oldCtx = rq.ctx
+	if newCtx = fn(oldCtx); newCtx != nil {
+		rq.ctx = newCtx
+		cancelFn = rq.cancelFn
+	}
+	return
 }
 
 // maintenance reports whether rq has expired and should be retired. For a

--- a/request.go
+++ b/request.go
@@ -331,22 +331,21 @@ func (rq *Request) Context() (ctx context.Context) {
 	return
 }
 
-// SetContext atomically replaces the Request's context with the function return value.
-// The function is given the current context and must return a non-nil context.
-// The returned context must be derived from oldCtx so cancellation and deadlines
-// continue to propagate to [Request.Context].
+// SetContext atomically transforms the Request's context.
 //
-// Cancellation of a replacement context wakes an idle live Request immediately;
-// it does not wait for another WebSocket event or broadcast. Value-only contexts
-// that retain oldCtx's Done channel require no additional cancellation bridge.
+// fn receives the current context and must return a non-nil context derived from
+// it so cancellation and deadlines continue to propagate. Cancellation or
+// deadline expiration of the returned context wakes a running
+// [Request.ServeHTTP] loop promptly, even while it is idle; no WebSocket event or
+// broadcast is required.
 //
-// The function runs while the Request lock is held so the transform is atomic.
-// It must not call methods on the same Request, call code that may do so, or
-// block on work that needs the same Request. If the function panics, SetContext
-// releases the lock before the panic continues.
+// fn runs while the Request lock is held. It must not call methods on the same
+// Request, call code that may do so, or block on work that needs the same
+// Request. SetContext panics if fn is nil. If fn panics, SetContext releases the
+// lock and propagates the panic.
 //
 // Returning a nil context is a programming error: debug builds panic and production
-// builds report it via [Jaws.MustLog] and keep the existing context.
+// builds report it through [Jaws.MustLog] and retain the current context.
 func (rq *Request) SetContext(fn func(oldCtx context.Context) (newCtx context.Context)) {
 	oldCtx, newCtx, cancelFn := rq.replaceContext(fn)
 	if newCtx == nil {
@@ -354,6 +353,8 @@ func (rq *Request) SetContext(fn func(oldCtx context.Context) (newCtx context.Co
 		return
 	}
 	if newCtx.Done() == oldCtx.Done() {
+		// The request loop already observes this Done channel, so no cancellation
+		// bridge is needed.
 		return
 	}
 	// The request loop may already be blocked selecting on oldCtx.Done. Bridge a

--- a/request_test.go
+++ b/request_test.go
@@ -570,6 +570,135 @@ func TestRequest_SetContextCancellationStopsQueuedEvents(t *testing.T) {
 	}
 }
 
+type deferredAfterContext struct {
+	context.Context
+	mu       sync.Mutex
+	done     chan struct{}
+	err      error
+	callback func()
+	onAfter  func()
+}
+
+func (ctx *deferredAfterContext) Done() <-chan struct{} { return ctx.done }
+
+func (ctx *deferredAfterContext) Err() error {
+	ctx.mu.Lock()
+	defer ctx.mu.Unlock()
+	return ctx.err
+}
+
+func (ctx *deferredAfterContext) AfterFunc(fn func()) func() bool {
+	if ctx.onAfter != nil {
+		ctx.onAfter()
+	}
+	ctx.mu.Lock()
+	ctx.callback = fn
+	ctx.mu.Unlock()
+	return func() bool { return false }
+}
+
+func TestRequest_SetContextRegistersAfterFuncOutsideLock(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rq := jw.NewRequest(nil)
+	observed := make(chan context.Context, 1)
+	custom := &deferredAfterContext{
+		Context: rq.Context(),
+		done:    make(chan struct{}),
+		onAfter: func() {
+			observed <- rq.Context()
+		},
+	}
+	setDone := make(chan struct{})
+	go func() {
+		rq.SetContext(func(context.Context) context.Context { return custom })
+		close(setDone)
+	}()
+
+	select {
+	case <-setDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("SetContext deadlocked while a custom AfterFunc hook re-entered Request.Context")
+	}
+	select {
+	case got := <-observed:
+		if got != custom {
+			t.Fatalf("AfterFunc hook observed context %T, want replacement context", got)
+		}
+	default:
+		t.Fatal("replacement context's AfterFunc hook was not registered")
+	}
+	jw.Close()
+}
+
+func (ctx *deferredAfterContext) cancel() {
+	ctx.mu.Lock()
+	ctx.err = context.Canceled
+	close(ctx.done)
+	ctx.mu.Unlock()
+}
+
+func (ctx *deferredAfterContext) fire() {
+	ctx.mu.Lock()
+	fn := ctx.callback
+	ctx.mu.Unlock()
+	if fn != nil {
+		fn()
+	}
+}
+
+func TestRequest_SetContextDelayedCallbackDoesNotCancelReusedRequest(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+
+	first := jw.NewRequest(nil)
+	callbackCalled := make(chan struct{}, 1)
+	var callbackArmed atomic.Bool
+	first.mu.Lock()
+	firstCancel := first.cancelFn
+	first.cancelFn = func(cause error) {
+		firstCancel(cause)
+		if callbackArmed.Load() {
+			callbackCalled <- struct{}{}
+		}
+	}
+	first.mu.Unlock()
+	deferred := &deferredAfterContext{done: make(chan struct{})}
+	first.SetContext(func(old context.Context) context.Context {
+		deferred.Context = old
+		return deferred
+	})
+	deferred.cancel()
+	jw.recycle(first)
+
+	poolNew := jw.reqPool.New
+	jw.reqPool.New = func() any { return first }
+	defer func() { jw.reqPool.New = poolNew }()
+	second := jw.NewRequest(nil)
+	if second != first {
+		t.Fatal("request pool did not reuse the Request")
+	}
+	secondCtx := second.Context()
+	callbackArmed.Store(true)
+	deferred.fire()
+	select {
+	case <-callbackCalled:
+	case <-time.After(testTimeout):
+		t.Fatal("delayed SetContext callback did not run")
+	}
+	select {
+	case <-secondCtx.Done():
+		t.Fatal("delayed SetContext callback canceled the reused Request")
+	default:
+	}
+	jw.recycle(second)
+}
+
 func TestRequest_OutboundRespectsContextDone(t *testing.T) {
 	th := newTestHelper(t)
 	rq := newTestRequest(t)
@@ -2564,6 +2693,20 @@ type testServer struct {
 	connectedCh chan struct{}
 }
 
+type observedDoneContext struct {
+	context.Context
+	armed    atomic.Bool
+	once     sync.Once
+	observed chan struct{}
+}
+
+func (ctx *observedDoneContext) Done() <-chan struct{} {
+	if ctx.armed.Load() {
+		ctx.once.Do(func() { close(ctx.observed) })
+	}
+	return ctx.Context.Done()
+}
+
 func newTestServer(t *testing.T) (ts *testServer) {
 	t.Helper()
 	return newTestServerWithSession(t, true)
@@ -3081,6 +3224,73 @@ func TestWS_PingDisabledKeepsIdleConnection(t *testing.T) {
 
 	_ = conn.CloseNow()
 	waitForRequestCounts(t, ts.jw, 0, 0, testTimeout)
+}
+
+// TestWS_SetContextCancellationClosesIdleConnection proves production
+// reachability through a real WebSocket. The observed context confirms the
+// request loop is already blocked on the old Done channel before SetContext
+// installs and cancels a child context; the client must then observe the server
+// close without sending any unrelated wake-up message.
+func TestWS_SetContextCancellationClosesIdleConnection(t *testing.T) {
+	ts := newTestServerNoSession(t)
+	defer ts.Close()
+	ts.jw.WebSocketPingInterval = 0
+
+	observed := &observedDoneContext{
+		Context:  ts.rq.Context(),
+		observed: make(chan struct{}),
+	}
+	ts.rq.SetContext(func(context.Context) context.Context { return observed })
+
+	conn, resp, err := ts.Dial()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.CloseNow() }()
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusSwitchingProtocols)
+	}
+	select {
+	case <-ts.connectedCh:
+	case <-time.After(testTimeout):
+		t.Fatal("timeout waiting for websocket connect")
+	}
+
+	// Wake the loop once through a supported request-targeted broadcast. After it
+	// sends the alert it re-enters select and observes the old context's Done.
+	observed.armed.Store(true)
+	ts.rq.Alert("info", "prime idle select")
+	primeCtx, cancelPrime := context.WithTimeout(t.Context(), testTimeout)
+	defer cancelPrime()
+	if _, _, err = conn.Read(primeCtx); err != nil {
+		t.Fatalf("reading priming alert: %v", err)
+	}
+	select {
+	case <-observed.observed:
+	case <-time.After(testTimeout):
+		t.Fatal("request loop did not select on the old context")
+	}
+
+	ts.rq.SetContext(func(old context.Context) context.Context {
+		ctx, cancel := context.WithCancel(old)
+		cancel()
+		return ctx
+	})
+
+	readCtx, cancelRead := context.WithTimeout(t.Context(), testTimeout)
+	defer cancelRead()
+	for readCtx.Err() == nil {
+		if _, _, err = conn.Read(readCtx); err != nil {
+			break
+		}
+	}
+	if err == nil {
+		t.Fatal("WebSocket remained open after replacement context cancellation")
+	}
+	if readCtx.Err() != nil {
+		t.Fatalf("idle WebSocket closed only when the client read timed out: %v", err)
+	}
+	waitForRequestCount(t, ts.jw, 0, testTimeout)
 }
 
 // waitForRequestCount polls a Jaws served over a real WebSocket connection, so


### PR DESCRIPTION
## Summary

- Bridge cancellation from a replacement Request context into the allocation's stable cancel function.
- Keep the atomic lock-scoped transform in a small `replaceContext` helper, leaving `SetContext` to validate and optionally register the cancellation bridge without manual lock-state bookkeeping.
- Register custom context AfterFunc hooks outside the Request lock.
- Capture allocation-specific state so a delayed callback cannot cancel a pooled Request after reuse.

## Production reachability

A live WebSocket request loop can already be blocked on the old context Done channel when application code calls Request.SetContext. If a newly derived child is canceled, the idle socket otherwise stays open until an unrelated browser event or broadcast wakes the loop.

`TestWS_SetContextCancellationClosesIdleConnection` establishes a real WebSocket, proves the loop is selecting on the old Done channel, installs and cancels a child context, and observes immediate server-side close without another wake-up event. Additional tests cover a reentrant custom AfterFunc hook and force pool reuse before releasing a delayed callback. The delayed-callback test waits for the old allocation's cancel function before asserting that the reused Request remains live.

## Verification

- Real idle-WebSocket cancellation regression.
- Reentrant AfterFunc and deterministic delayed pool-reuse regressions.
- Focused SetContext/WebSocket race suite passes 20 repetitions.
- Full `go test -race ./...` passes on the final stack.
- `go vet`, staticcheck, golangci-lint, gosec, gofumpt, and `go build` pass.

## Performance

The feature-level comparison of updated #96 with #97 found `BenchmarkRequestSetContextValue` statistically unchanged at 112.7 versus 115.0 ns/op (p=0.669), with 48 B and 1 allocation per operation unchanged.

The cleanup refactor was also measured with ten alternating old/new #97 samples at GOMAXPROCS=1: 41.19 versus 38.77 ns/op, statistically unchanged (p=0.529), again with exactly 48 B and 1 allocation. This benchmark covers the common value-only path, whose Done channel is unchanged and therefore installs no cancellation bridge.

## Stack

Base: fix/close-pending-contexts. This is the top of the core lifecycle stack.
