### PR TITLE
Preserve JsVar mutation order in broadcasts

### DIFF
--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -58,9 +58,9 @@ allowed paths there. The generic path setter is convenient for trusted demos, bu
 it can write exported JSON fields and append to slices until the serialized
 `MaxClientJsVarBytes` cap is hit on render.
 
-Concurrent writes to one `JsVar` are applied and queued for broadcast in the same
-order. Transport backpressure can therefore delay later writes to that `JsVar`,
-but does not hold its caller-provided value lock.
+Concurrent writes to one `JsVar` are applied one at a time, and any broadcasts
+they produce preserve that order. Transport backpressure can delay later writes,
+but it does not keep the locker passed to `NewJsVar` held.
 
 ## Building blocks
 

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -58,6 +58,10 @@ allowed paths there. The generic path setter is convenient for trusted demos, bu
 it can write exported JSON fields and append to slices until the serialized
 `MaxClientJsVarBytes` cap is hit on render.
 
+Concurrent writes to one `JsVar` are applied and queued for broadcast in the same
+order. Transport backpressure can therefore delay later writes to that `JsVar`,
+but does not hold its caller-provided value lock.
+
 ## Building blocks
 
 - `HTMLInner`

--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -87,6 +87,7 @@ var (
 //
 // It is safe for concurrent use when the locker passed to [NewJsVar] is safe
 // for concurrent use.
+// A JsVar must not be copied after first use.
 //
 // SECURITY: a JsVar is client-writable. Incoming browser "set" messages are
 // applied by path to the bound value. If the bound value implements [PathSetter]
@@ -105,8 +106,9 @@ var (
 // boolean field.
 type JsVar[T any] struct {
 	bind.RWLocker
-	Ptr      *T  // bound Go value
-	dirtyTag any // current dirty tag, set during render; read via JawsGetTag
+	Ptr      *T         // bound Go value
+	setMu    sync.Mutex // serializes each mutation with its broadcast
+	dirtyTag any        // current dirty tag, set during render; read via JawsGetTag
 }
 
 // MaxClientJsVarBytes bounds the JSON-serialized size of a client-writable [JsVar]
@@ -171,16 +173,18 @@ func (jsvar *JsVar[T]) setPathLocked(elem *jaws.Element, jsPath string, value an
 }
 
 func (jsvar *JsVar[T]) setPathLock(elem *jaws.Element, jsPath string, value any) (broadcasted bool, err error) {
+	jsvar.setMu.Lock()
+	defer jsvar.setMu.Unlock()
 	jsvar.Lock()
 	err = jsvar.setPathLocked(elem, jsPath, value)
 	dirtyTag := jsvar.dirtyTag
 	jsvar.Unlock()
-	// Marshal and broadcast outside the lock: value is the caller-owned argument
-	// (not read from Ptr), and jaws.Broadcast can block on the broadcast channel
-	// under backpressure. Holding the lock across that send would needlessly
-	// serialize concurrent setters and stall any code sharing the locker. This
-	// mirrors bind.binder, which mutates under the lock and runs side effects
-	// after releasing it.
+	// Marshal and broadcast outside the caller-provided lock: value is the
+	// caller-owned argument (not read from Ptr), and jaws.Broadcast can block on
+	// the broadcast channel under backpressure. The private setMu remains held so
+	// concurrent setters cannot apply a later mutation before this broadcast is
+	// queued. Code sharing the caller-provided locker is therefore not stalled by
+	// transport backpressure.
 	//
 	// Note that the broadcast carries the caller's requested value, not the value
 	// actually stored. If a PathSetter coerces or rejects the input (e.g. clamps a
@@ -231,6 +235,9 @@ func (jsvar *JsVar[T]) setPath(elem *jaws.Element, jsPath string, value any) (er
 // A set before the element has been rendered produces no broadcast: the dirty
 // tag does not exist yet and the initial render seeds the value via its
 // data-jawsdata attribute.
+//
+// Concurrent successful calls are serialized through mutation, JSON encoding,
+// and broadcast queueing, so peers observe changes in mutation order.
 func (jsvar *JsVar[T]) JawsSetPath(elem *jaws.Element, jsPath string, value any) (err error) {
 	return jsvar.setPath(elem, jsPath, value)
 }

--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -86,7 +86,10 @@ var (
 // JsVar binds a Go value to a named JavaScript variable in the browser.
 //
 // It is safe for concurrent use when the locker passed to [NewJsVar] is safe
-// for concurrent use.
+// for concurrent use. Concurrent writes are applied one at a time. Any
+// broadcasts they produce preserve the order in which the writes modify the
+// bound value.
+//
 // A JsVar must not be copied after first use.
 //
 // SECURITY: a JsVar is client-writable. Incoming browser "set" messages are
@@ -235,9 +238,6 @@ func (jsvar *JsVar[T]) setPath(elem *jaws.Element, jsPath string, value any) (er
 // A set before the element has been rendered produces no broadcast: the dirty
 // tag does not exist yet and the initial render seeds the value via its
 // data-jawsdata attribute.
-//
-// Concurrent successful calls are serialized through mutation, JSON encoding,
-// and broadcast queueing, so peers observe changes in mutation order.
 func (jsvar *JsVar[T]) JawsSetPath(elem *jaws.Element, jsPath string, value any) (err error) {
 	return jsvar.setPath(elem, jsPath, value)
 }

--- a/lib/ui/jsvar_benchmark_test.go
+++ b/lib/ui/jsvar_benchmark_test.go
@@ -1,0 +1,67 @@
+package ui
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/linkdata/jaws"
+)
+
+type benchmarkJsVarState struct {
+	Value int `json:"value"`
+}
+
+func (state *benchmarkJsVarState) JawsSetPath(_ *jaws.Element, _ string, value any) (err error) {
+	state.Value = value.(int)
+	return
+}
+
+func newBenchmarkJsVar(b *testing.B) (jsvar *JsVar[benchmarkJsVarState], elem *jaws.Element) {
+	b.Helper()
+
+	jw, err := jaws.New()
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(jw.Close)
+	go jw.Serve()
+
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	if rq == nil {
+		b.Fatal("nil request")
+	}
+	var mu sync.Mutex
+	state := benchmarkJsVarState{}
+	jsvar = NewJsVar(&mu, &state)
+	elem = rq.NewElement(jsvar)
+	if err = jsvar.JawsRender(elem, io.Discard, []any{"bench"}); err != nil {
+		b.Fatal(err)
+	}
+	return
+}
+
+func BenchmarkJsVarSetPathBroadcast(b *testing.B) {
+	jsvar, elem := newBenchmarkJsVar(b)
+
+	b.Run("Serial", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if err := jsvar.JawsSetPath(elem, "value", i); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("Parallel", func(b *testing.B) {
+		b.ReportAllocs()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				if err := jsvar.JawsSetPath(elem, "value", 1); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	})
+}

--- a/lib/ui/jsvar_order_test.go
+++ b/lib/ui/jsvar_order_test.go
@@ -1,0 +1,328 @@
+package ui
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/linkdata/jaws"
+	"github.com/linkdata/jaws/jawstest"
+	"github.com/linkdata/jaws/lib/what"
+	"github.com/linkdata/jaws/lib/wire"
+)
+
+type orderedMarshalValue struct {
+	Text    string
+	Entered chan<- struct{}
+	Release <-chan struct{}
+	Err     error
+	Panic   any
+}
+
+func (value orderedMarshalValue) MarshalJSON() (data []byte, err error) {
+	if value.Entered != nil {
+		close(value.Entered)
+		<-value.Release
+	}
+	if value.Err != nil {
+		return nil, value.Err
+	}
+	if value.Panic != nil {
+		panic(value.Panic)
+	}
+	return json.Marshal(value.Text)
+}
+
+type orderedPathState struct {
+	Value string `json:"value"`
+}
+
+func (state *orderedPathState) JawsSetPath(_ *jaws.Element, jsPath string, value any) (err error) {
+	if jsPath != "value" {
+		return fmt.Errorf("unexpected path %q", jsPath)
+	}
+	marshaled, ok := value.(orderedMarshalValue)
+	if !ok {
+		return fmt.Errorf("unexpected value type %T", value)
+	}
+	if state.Value == marshaled.Text {
+		return jaws.ErrValueUnchanged
+	}
+	state.Value = marshaled.Text
+	return
+}
+
+func newOrderedJsVar(t *testing.T) (jsvar *JsVar[orderedPathState], elem *jaws.Element, tr *jawstest.TestRequest) {
+	t.Helper()
+
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+	go jw.Serve()
+
+	tr = jawstest.NewTestRequest(jw, nil)
+	if tr == nil {
+		t.Fatal("nil test request")
+	}
+	t.Cleanup(func() {
+		tr.Close()
+		<-tr.DoneCh
+	})
+	<-tr.ReadyCh
+
+	var mu sync.Mutex
+	state := orderedPathState{Value: "initial"}
+	jsvar = NewJsVar(&mu, &state)
+	elem = tr.NewElement(jsvar)
+	if err = elem.JawsRender(io.Discard, []any{"ordered"}); err != nil {
+		t.Fatal(err)
+	}
+	return
+}
+
+func readJsVarMessage(t *testing.T, tr *jawstest.TestRequest, want what.What) (data string) {
+	t.Helper()
+	for {
+		select {
+		case <-t.Context().Done():
+			t.Fatalf("timed out waiting for JsVar %s message", want)
+		case msg := <-tr.OutCh:
+			if msg.What == want {
+				return msg.Data
+			}
+		}
+	}
+}
+
+func readJsVarSet(t *testing.T, tr *jawstest.TestRequest) (data string) {
+	t.Helper()
+	return readJsVarMessage(t, tr, what.Set)
+}
+
+func TestJsVarConcurrentBroadcastsFollowMutationOrder(t *testing.T) {
+	jsvar, elem, tr := newOrderedJsVar(t)
+
+	firstEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	firstErr := make(chan error, 1)
+	go func() {
+		firstErr <- jsvar.JawsSetPath(elem, "value", orderedMarshalValue{
+			Text:    "first",
+			Entered: firstEntered,
+			Release: releaseFirst,
+		})
+	}()
+	select {
+	case <-t.Context().Done():
+		close(releaseFirst)
+		t.Fatal("timed out waiting for the first value to enter JSON marshaling")
+	case <-firstEntered:
+	}
+
+	secondErr := make(chan error, 1)
+	go func() {
+		secondErr <- jsvar.JawsSetPath(elem, "value", orderedMarshalValue{Text: "second"})
+	}()
+
+	secondCompleted := false
+	timer := time.NewTimer(100 * time.Millisecond)
+	select {
+	case err := <-secondErr:
+		if err != nil {
+			t.Fatal(err)
+		}
+		secondCompleted = true
+	case <-timer.C:
+	}
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	close(releaseFirst)
+
+	select {
+	case <-t.Context().Done():
+		t.Fatal("timed out waiting for the first JsVar set")
+	case err := <-firstErr:
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !secondCompleted {
+		select {
+		case <-t.Context().Done():
+			t.Fatal("timed out waiting for the second JsVar set")
+		case err := <-secondErr:
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	got := []string{readJsVarSet(t, tr), readJsVarSet(t, tr)}
+	want := []string{`value="first"`, `value="second"`}
+	if got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("broadcast order = %q, want mutation order %q", got, want)
+	}
+	if current := jsvar.JawsGet(elem).Value; current != "second" {
+		t.Fatalf("bound value = %q, want latest mutation %q", current, "second")
+	}
+}
+
+func TestJsVarMarshalErrorReleasesSetterOrder(t *testing.T) {
+	jsvar, elem, tr := newOrderedJsVar(t)
+
+	errMarshal := errors.New("marshal failed")
+	err := jsvar.JawsSetPath(elem, "value", orderedMarshalValue{Text: "failed", Err: errMarshal})
+	if !errors.Is(err, errMarshal) {
+		t.Fatalf("JawsSetPath error = %v, want %v", err, errMarshal)
+	}
+
+	setErr := make(chan error, 1)
+	go func() {
+		setErr <- jsvar.JawsSetPath(elem, "value", orderedMarshalValue{Text: "recovered"})
+	}()
+	select {
+	case <-t.Context().Done():
+		t.Fatal("setter remained blocked after JSON marshal failure")
+	case err = <-setErr:
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := readJsVarSet(t, tr); got != `value="recovered"` {
+		t.Fatalf("broadcast = %q, want recovered value", got)
+	}
+}
+
+func TestJsVarRecoveredMarshalPanicReleasesSetterOrder(t *testing.T) {
+	jsvar, elem, tr := newOrderedJsVar(t)
+
+	errMarshalPanic := errors.New("marshal panic")
+	handler := New("set").Clicked(func(Object, *jaws.Element, jaws.Click) (err error) {
+		return jsvar.JawsSetPath(elem, "value", orderedMarshalValue{
+			Text:  "panicked",
+			Panic: errMarshalPanic,
+		})
+	})
+	handlerElem := tr.NewElement(NewButton(handler))
+	if err := handlerElem.JawsRender(io.Discard, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	tr.InCh <- wire.WsMsg{
+		Jid:  handlerElem.Jid(),
+		What: what.Click,
+		Data: "0 0 0 set",
+	}
+	if alert := readJsVarMessage(t, tr, what.Alert); !strings.Contains(alert, errMarshalPanic.Error()) {
+		t.Fatalf("recovered panic alert = %q, want %q", alert, errMarshalPanic)
+	}
+
+	setErr := make(chan error, 1)
+	go func() {
+		setErr <- jsvar.JawsSetPath(elem, "value", orderedMarshalValue{Text: "recovered"})
+	}()
+	select {
+	case <-t.Context().Done():
+		t.Fatal("setter remained blocked after recovered JSON marshal panic")
+	case err := <-setErr:
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := readJsVarSet(t, tr); got != `value="recovered"` {
+		t.Fatalf("broadcast = %q, want recovered value", got)
+	}
+}
+
+type reentrantPathState struct {
+	Value       string `json:"value"`
+	jsvar       *JsVar[reentrantPathState]
+	callbacks   int
+	callbackErr error
+}
+
+func (state *reentrantPathState) JawsSetPath(_ *jaws.Element, jsPath string, value any) (err error) {
+	if jsPath != "value" {
+		return fmt.Errorf("unexpected path %q", jsPath)
+	}
+	text, ok := value.(string)
+	if !ok {
+		return fmt.Errorf("unexpected value type %T", value)
+	}
+	if state.Value == text {
+		return jaws.ErrValueUnchanged
+	}
+	state.Value = text
+	return
+}
+
+func (state *reentrantPathState) JawsPathSet(elem *jaws.Element, jsPath string, _ any) {
+	state.callbacks++
+	if state.callbacks == 1 {
+		state.callbackErr = state.jsvar.JawsSetPath(elem, jsPath, "callback")
+	}
+}
+
+func TestJsVarSetPatherCanReenterSetter(t *testing.T) {
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+	go jw.Serve()
+
+	tr := jawstest.NewTestRequest(jw, nil)
+	if tr == nil {
+		t.Fatal("nil test request")
+	}
+	t.Cleanup(func() {
+		tr.Close()
+		<-tr.DoneCh
+	})
+	<-tr.ReadyCh
+
+	var mu sync.Mutex
+	state := reentrantPathState{Value: "initial"}
+	jsvar := NewJsVar(&mu, &state)
+	state.jsvar = jsvar
+	elem := tr.NewElement(jsvar)
+	if err = elem.JawsRender(io.Discard, []any{"reentrant"}); err != nil {
+		t.Fatal(err)
+	}
+
+	setErr := make(chan error, 1)
+	go func() {
+		setErr <- jsvar.JawsSetPath(elem, "value", "outer")
+	}()
+	select {
+	case <-t.Context().Done():
+		t.Fatal("SetPather callback deadlocked while re-entering the JsVar setter")
+	case err = <-setErr:
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if state.callbackErr != nil {
+		t.Fatalf("reentrant setter failed: %v", state.callbackErr)
+	}
+	if state.callbacks != 2 || state.Value != "callback" {
+		t.Fatalf("state after reentrant callback = %#v", state)
+	}
+
+	got := []string{readJsVarSet(t, tr), readJsVarSet(t, tr)}
+	want := []string{`value="outer"`, `value="callback"`}
+	if got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("broadcast order = %q, want callback order %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Serialize each JsVar mutation through JSON encoding and global broadcast enqueue.
- Release the caller-provided RWLocker before transport backpressure.
- Release the ordering mutex on marshal errors and panics, and keep SetPather callbacks reentrant.

## Production reachability

Concurrent supported server-side `JawsSetPath` calls can mutate in one order but enqueue their WebSocket broadcasts in the opposite order when the first value blocks in JSON marshaling. A production browser then ends with stale state even though the bound Go value contains the newer mutation.

`TestJsVarConcurrentBroadcastsFollowMutationOrder` runs the real Jaws Serve/request loop, blocks the first public setter in its marshaler, starts the second setter, and verifies peers receive the same order as the mutations. Recovery and reentrancy tests cover production marshal panic/error and callback paths.

## Verification

- Concurrent ordering, marshal error, recovered marshal panic, and reentrant SetPather tests
- Focused race run repeated 10 times
- Full `JAWS_REQUIRE_NODE=1 go test -race ./...` and all generation/lint/security gates

## Performance

Interleaved benchstat, n=10, 300ms, `-cpu=1,18`:

- Serial cpu1: 326.1 → 326.2 ns/op, unchanged (`p=0.781`).
- Serial cpu18: 439.3 → 454.1 ns/op, unchanged (`p=0.424`).
- Parallel cpu1: 309.3 → 313.5 ns/op (`+1.34%`).
- Parallel cpu18: 1638.5 → 501.1 ns/op (`-69.42%`).
- Bytes and allocations are unchanged.

## Stack

Base: `main`. This is the first PR in the JsVar stack.
