### PR TITLE
Deliver request-scoped JavaScript calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,9 @@ client/server protocol code:
   framing, quoting) and invalid frames are ignored/dropped.
 * `what.Remove` means remove child element(s). For browser-originated `Remove`
   messages, the WebSocket `Jid` identifies the parent/container in the DOM and
-  `Data` carries removed managed child IDs. The server only removes child IDs
-  that are known in the current request.
+  `Data` carries removed managed child IDs. A zero Jid identifies an ordinary
+  HTML-id container that is not managed by JaWS. The server only removes child
+  IDs that are known in the current request.
 * `what.Replace` replaces the target element HTML and carries plain HTML in `Data`.
 * `what.Call`/`what.Set` use `path + "=" + json` inside `Data`. Paths may not
   contain tabs, newlines, carriage returns, or `=`. Embedded tabs or newlines in

--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ client/server protocol code:
 * `what.Call`/`what.Set` use `path + "=" + json` inside `Data`. Paths may not
   contain tabs, newlines, carriage returns, or `=`. Embedded tabs or newlines in
   JSON break message framing; `Jaws.JsCall` compacts valid JSON before sending.
+  A `Call` selected by a nil destination or request key uses a zero Jid and does
+  not require a DOM element; HTML-id and tag destinations remain element-scoped.
+  An empty HTML-id destination is rejected because it has the same wire encoding
+  as the zero Jid.
 * `jawsVar(name, ...)` resolves properties from `window`, but WebSocket routing
   uses the top-level symbol name only. Register JaWS `JsVar` names as top-level
   identifiers (example: `app`), and use dotted suffixes as the JSON path

--- a/README.md
+++ b/README.md
@@ -165,9 +165,8 @@ client/server protocol code:
   framing, quoting) and invalid frames are ignored/dropped.
 * `what.Remove` means remove child element(s). For browser-originated `Remove`
   messages, the WebSocket `Jid` identifies the parent/container in the DOM and
-  `Data` carries removed managed child IDs. A zero Jid identifies an ordinary
-  HTML-id container that is not managed by JaWS. The server only removes child
-  IDs that are known in the current request.
+  `Data` carries removed managed child IDs. The server only removes child IDs
+  that are known in the current request.
 * `what.Replace` replaces the target element HTML and carries plain HTML in `Data`.
 * `what.Call`/`what.Set` use `path + "=" + json` inside `Data`. Paths may not
   contain tabs, newlines, carriage returns, or `=`. Embedded tabs or newlines in

--- a/README.md
+++ b/README.md
@@ -171,10 +171,10 @@ client/server protocol code:
 * `what.Call`/`what.Set` use `path + "=" + json` inside `Data`. Paths may not
   contain tabs, newlines, carriage returns, or `=`. Embedded tabs or newlines in
   JSON break message framing; `Jaws.JsCall` compacts valid JSON before sending.
-  A `Call` selected by a nil destination or request key uses a zero Jid and does
-  not require a DOM element; HTML-id and tag destinations remain element-scoped.
-  An empty HTML-id destination is rejected because it has the same wire encoding
-  as the zero Jid.
+  A `Call` selected by a nil destination or nonzero request key uses a zero Jid
+  and does not require a DOM element; a zero request key is dropped. HTML-id and
+  tag destinations remain element-scoped. An empty HTML-id destination is
+  rejected because it has the same wire encoding as the zero Jid.
 * `jawsVar(name, ...)` resolves properties from `window`, but WebSocket routing
   uses the top-level symbol name only. Register JaWS `JsVar` names as top-level
   identifiers (example: `app`), and use dotted suffixes as the JSON path

--- a/broadcast.go
+++ b/broadcast.go
@@ -20,17 +20,16 @@ import (
 // [wire.Message.Dest].
 //
 // It must not be called before the JaWS processing loop ([Jaws.Serve] or
-// [Jaws.ServeWithTimeout]) is running. Otherwise this call may block once the
-// internal broadcast channel fills.
+// [Jaws.ServeWithTimeout]) is running. Otherwise this call may block.
 //
 // All convenience helpers on [Jaws] that call Broadcast inherit this requirement.
 //
-// A nil [wire.Message.Dest] targets every Request; a [key.Key] Dest targets the
-// single Request with that identity key, and a zero key is dropped; a string Dest
-// is an HTML id accepted by all Requests. An empty string Call destination is
-// reported as [ErrEmptyCallTarget] and the message is not sent. With a
-// [Jaws.Logger] configured, production builds log the error; otherwise, and in
-// debug builds, Broadcast panics. Any other Dest is expanded into tags.
+// A nil [wire.Message.Dest] targets every active Request; a [key.Key] Dest targets
+// the active Request with that identity key, and a zero key is dropped; a string
+// Dest is an HTML id accepted by all active Requests. An empty string Call
+// destination is reported as [ErrEmptyCallTarget] and the message is not sent.
+// With a [Jaws.Logger] configured, production builds log the error; otherwise,
+// and in debug builds, Broadcast panics. Any other Dest is expanded into tags.
 //
 // A [wire.Message.Dest] that cannot be expanded into tags (an illegal tag type)
 // is reported through [Jaws.MustLog], which panics when no [Jaws.Logger] is

--- a/broadcast.go
+++ b/broadcast.go
@@ -26,7 +26,10 @@ import (
 //
 // A nil [wire.Message.Dest] targets every Request; a [key.Key] Dest targets the
 // single Request with that identity key, and a zero key is dropped; a string Dest
-// is an HTML id accepted by all Requests. Any other Dest is expanded into tags.
+// is an HTML id accepted by all Requests. An empty string Call destination is
+// reported as [ErrEmptyCallTarget] through [Jaws.MustLog] (logged when a Logger is
+// configured, otherwise panicking); debug builds additionally panic. Any other
+// Dest is expanded into tags.
 //
 // A [wire.Message.Dest] that cannot be expanded into tags (an illegal tag type)
 // is reported through [Jaws.MustLog], which panics when no [Jaws.Logger] is
@@ -43,6 +46,12 @@ func (jw *Jaws) Broadcast(msg wire.Message) {
 			return
 		}
 	case string: // HTML id (accepted by all requests)
+		if msg.What == what.Call && dest == "" {
+			// An empty outbound Jid encodes a request-scoped Call. Reject an empty
+			// HTML-id destination rather than silently widening it to every Request.
+			jw.reportMisuse(fmt.Errorf("jaws: Broadcast: %w", ErrEmptyCallTarget))
+			return
+		}
 	default:
 		expanded, err := tag.TagExpand(nil, msg.Dest)
 		jw.MustLog(err)
@@ -366,7 +375,11 @@ func jsCallData(jsfunc, jsonstr string) string {
 // target selects which requests or elements receive the Call message. In each
 // receiving browser, jsfunc is resolved as a path from window and called with
 // JSON.parse(jsonstr); the matched element is not passed as this or as an
-// argument.
+// argument. A nil target calls every Request once, and a request key calls that
+// Request once without requiring a matching DOM element. An empty string target
+// is rejected because the empty wire Jid represents a request-scoped call;
+// [ErrEmptyCallTarget] is reported through [Jaws.MustLog] (logged when a Logger is
+// configured, otherwise panicking), and debug builds additionally panic.
 func (jw *Jaws) JsCall(target any, jsfunc, jsonstr string) {
 	jw.broadcastTo(target, what.Call, jsCallData(jsfunc, jsonstr))
 }

--- a/broadcast.go
+++ b/broadcast.go
@@ -16,7 +16,8 @@ import (
 	"github.com/linkdata/jaws/lib/wire"
 )
 
-// Broadcast sends a message to all [Request] values.
+// Broadcast sends msg to the active [Request] and [Element] values selected by
+// [wire.Message.Dest].
 //
 // It must not be called before the JaWS processing loop ([Jaws.Serve] or
 // [Jaws.ServeWithTimeout]) is running. Otherwise this call may block once the
@@ -27,9 +28,9 @@ import (
 // A nil [wire.Message.Dest] targets every Request; a [key.Key] Dest targets the
 // single Request with that identity key, and a zero key is dropped; a string Dest
 // is an HTML id accepted by all Requests. An empty string Call destination is
-// reported as [ErrEmptyCallTarget] through [Jaws.MustLog] (logged when a Logger is
-// configured, otherwise panicking); debug builds additionally panic. Any other
-// Dest is expanded into tags.
+// reported as [ErrEmptyCallTarget] and the message is not sent. With a
+// [Jaws.Logger] configured, production builds log the error; otherwise, and in
+// debug builds, Broadcast panics. Any other Dest is expanded into tags.
 //
 // A [wire.Message.Dest] that cannot be expanded into tags (an illegal tag type)
 // is reported through [Jaws.MustLog], which panics when no [Jaws.Logger] is
@@ -375,11 +376,11 @@ func jsCallData(jsfunc, jsonstr string) string {
 // target selects which requests or elements receive the Call message. In each
 // receiving browser, jsfunc is resolved as a path from window and called with
 // JSON.parse(jsonstr); the matched element is not passed as this or as an
-// argument. A nil target calls every Request once, and a request key calls that
-// Request once without requiring a matching DOM element. An empty string target
-// is rejected because the empty wire Jid represents a request-scoped call;
-// [ErrEmptyCallTarget] is reported through [Jaws.MustLog] (logged when a Logger is
-// configured, otherwise panicking), and debug builds additionally panic.
+// argument. A nil target calls each active Request once. A nonzero [key.Key]
+// target calls the matching active Request once without requiring a matching DOM
+// element; a zero key is ignored. An empty string target reports
+// [ErrEmptyCallTarget] and sends no call. With [Jaws.Logger] configured,
+// production builds log the error; otherwise, and in debug builds, JsCall panics.
 func (jw *Jaws) JsCall(target any, jsfunc, jsonstr string) {
 	jw.broadcastTo(target, what.Call, jsCallData(jsfunc, jsonstr))
 }

--- a/broadcast_production_regression_test.go
+++ b/broadcast_production_regression_test.go
@@ -1,0 +1,106 @@
+package jaws
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/linkdata/deadlock"
+	"github.com/linkdata/jaws/lib/what"
+)
+
+func TestJawsJsCallReachesRequestTargets(t *testing.T) {
+	tj := newTestJaws()
+	defer tj.Close()
+
+	requests := []*testRequest{
+		newWrappedTestRequest(tj.Jaws, nil),
+		newWrappedTestRequest(tj.Jaws, nil),
+	}
+	defer func() {
+		for _, tr := range requests {
+			tr.Close()
+		}
+		for _, tr := range requests {
+			<-tr.DoneCh
+		}
+	}()
+	for _, tr := range requests {
+		<-tr.ReadyCh
+	}
+
+	assertCall := func(tr *testRequest, wantData string) {
+		t.Helper()
+		select {
+		case msg := <-tr.OutCh:
+			if msg.What != what.Call {
+				t.Fatalf("message type = %v, want %v", msg.What, what.Call)
+			}
+			if msg.Jid != 0 {
+				t.Fatalf("message Jid = %v, want whole-request Jid 0", msg.Jid)
+			}
+			if msg.Data != wantData {
+				t.Fatalf("message data = %q, want %q", msg.Data, wantData)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("Jaws.JsCall did not reach the selected request")
+		}
+	}
+
+	tj.JsCall(nil, "app.refresh", `{"scope":"all"}`)
+	for _, tr := range requests {
+		assertCall(tr, `app.refresh={"scope":"all"}`)
+	}
+
+	tj.JsCall(requests[0].JawsKey, "app.refresh", `{"scope":"one"}`)
+	assertCall(requests[0], `app.refresh={"scope":"one"}`)
+	tj.JsCall(requests[1].JawsKey, "app.refresh", `{"scope":"other"}`)
+	assertCall(requests[1], `app.refresh={"scope":"other"}`)
+
+	// A page-global message is a per-subscription barrier: if either key-targeted
+	// Call leaked to the other Request, it appears before Reload and fails here.
+	tj.Reload()
+	for _, tr := range requests {
+		select {
+		case msg := <-tr.OutCh:
+			if msg.What != what.Reload {
+				t.Fatalf("request-key Call reached an unselected request before barrier: %+v", msg)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("Reload barrier did not reach request")
+		}
+	}
+}
+
+func TestJawsJsCallRejectsEmptyHTMLIDTarget(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+	logger := &captureErrorLogger{}
+	jw.Logger = logger
+
+	call := func() {
+		jw.JsCall("", "app.refresh", `{}`)
+	}
+	if deadlock.Debug {
+		func() {
+			defer func() {
+				if recovered := recover(); recovered == nil {
+					t.Fatal("empty HTML-id Call did not panic under deadlock.Debug")
+				}
+			}()
+			call()
+		}()
+	} else {
+		call()
+	}
+
+	if !errors.Is(logger.err, ErrEmptyCallTarget) {
+		t.Fatalf("empty HTML-id Call error = %v", logger.err)
+	}
+	if got := len(jw.bcastCh); got != 0 {
+		t.Fatalf("empty HTML-id Call queued %d broadcasts, want none", got)
+	}
+}

--- a/errors.go
+++ b/errors.go
@@ -35,6 +35,13 @@ var ErrRequestOverloaded = errors.New("request overloaded")
 // ErrRequestAlreadyClaimed is returned when [Jaws.UseRequest] is called more than once for a [Request].
 var ErrRequestAlreadyClaimed = errors.New("request already claimed")
 
+// ErrEmptyCallTarget indicates a Call message used an empty HTML id target.
+//
+// An empty wire id identifies a request-scoped JavaScript call, so accepting an
+// empty HTML id in [Jaws.JsCall] or [Jaws.Broadcast] would silently widen the
+// call to every selected Request.
+var ErrEmptyCallTarget = errors.New("empty HTML id cannot target Call")
+
 // ErrJavascriptDisabled is returned when the noscript probe indicates JavaScript is disabled.
 var ErrJavascriptDisabled = errors.New("javascript is disabled")
 

--- a/errors.go
+++ b/errors.go
@@ -35,11 +35,10 @@ var ErrRequestOverloaded = errors.New("request overloaded")
 // ErrRequestAlreadyClaimed is returned when [Jaws.UseRequest] is called more than once for a [Request].
 var ErrRequestAlreadyClaimed = errors.New("request already claimed")
 
-// ErrEmptyCallTarget indicates a Call message used an empty HTML id target.
+// ErrEmptyCallTarget indicates an element-scoped JavaScript call used an empty
+// HTML id target.
 //
-// An empty wire id identifies a request-scoped JavaScript call, so accepting an
-// empty HTML id in [Jaws.JsCall] or [Jaws.Broadcast] would silently widen the
-// call to every selected Request.
+// [Jaws.JsCall] and [Jaws.Broadcast] report this error and do not send the call.
 var ErrEmptyCallTarget = errors.New("empty HTML id cannot target Call")
 
 // ErrJavascriptDisabled is returned when the noscript probe indicates JavaScript is disabled.

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -2881,30 +2881,6 @@ func BenchmarkGetElementByJid(b *testing.B) {
 	}
 }
 
-// BenchmarkRequestHandleRemoveUnknownChildren measures validating a browser
-// cleanup acknowledgement whose child IDs are not registered in the Request.
-// Both managed and ordinary/static containers use this path.
-func BenchmarkRequestHandleRemoveUnknownChildren(b *testing.B) {
-	const elemCount = 1000
-	data := "Jid.1001\tJid.1002\tJid.1003\tJid.1004\tJid.1005\tJid.1006\tJid.1007\tJid.1008"
-	for _, tc := range []struct {
-		name         string
-		containerJid Jid
-	}{
-		{name: "managed-container", containerJid: 1},
-		{name: "static-container", containerJid: 0},
-	} {
-		b.Run(tc.name, func(b *testing.B) {
-			rq := newBenchRequest(b, elemCount)
-			b.ReportAllocs()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				rq.handleRemove(tc.containerJid, data)
-			}
-		})
-	}
-}
-
 // BenchmarkRequestHandleBroadcastCall measures dispatching request-scoped and
 // existing element-scoped JavaScript Call destinations.
 func BenchmarkRequestHandleBroadcastCall(b *testing.B) {

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -2905,6 +2905,70 @@ func BenchmarkRequestHandleRemoveUnknownChildren(b *testing.B) {
 	}
 }
 
+// BenchmarkRequestHandleBroadcastCall measures dispatching request-scoped and
+// existing element-scoped JavaScript Call destinations.
+func BenchmarkRequestHandleBroadcastCall(b *testing.B) {
+	for _, tc := range []struct {
+		name    string
+		dest    any
+		tagDest bool
+	}{
+		{name: "all-requests"},
+		{name: "request-key", dest: key.Key(1)},
+		{name: "html-id", dest: "target"},
+		{name: "tag", dest: tag.Tag("target"), tagDest: true},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			rq := newBenchRequest(b, 1)
+			if tc.tagDest {
+				rq.tagMap = make(map[any][]*Element)
+				rq.Tag(rq.elems[0], tc.dest)
+			}
+			msg := wire.Message{Dest: tc.dest, What: what.Call, Data: `app.refresh={"source":"server"}`}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				rq.handleBroadcast(msg, nil)
+				rq.muQueue.Lock()
+				rq.wsQueue = rq.wsQueue[:0]
+				rq.muQueue.Unlock()
+			}
+		})
+	}
+}
+
+// BenchmarkJawsBroadcastCallHTMLID guards the Call validation cost on the
+// existing non-empty HTML-id broadcast path.
+func BenchmarkJawsBroadcastCallHTMLID(b *testing.B) {
+	jw, err := New()
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(jw.Close)
+	drainDone := make(chan struct{})
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		for {
+			select {
+			case <-jw.bcastCh:
+			case <-drainDone:
+				return
+			}
+		}
+	}()
+	b.Cleanup(func() {
+		close(drainDone)
+		<-drained
+	})
+	msg := wire.Message{Dest: "target", What: what.Call, Data: `app.refresh={"source":"server"}`}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		jw.Broadcast(msg)
+	}
+}
+
 // BenchmarkRequestEventDispatch measures the request-level event path that
 // resolves Jids and reads a frozen Element's handlers. The bubbled case exercises
 // the per-candidate eligibility checks before every handler returns unhandled.

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -2881,6 +2881,30 @@ func BenchmarkGetElementByJid(b *testing.B) {
 	}
 }
 
+// BenchmarkRequestHandleRemoveUnknownChildren measures validating a browser
+// cleanup acknowledgement whose child IDs are not registered in the Request.
+// Both managed and ordinary/static containers use this path.
+func BenchmarkRequestHandleRemoveUnknownChildren(b *testing.B) {
+	const elemCount = 1000
+	data := "Jid.1001\tJid.1002\tJid.1003\tJid.1004\tJid.1005\tJid.1006\tJid.1007\tJid.1008"
+	for _, tc := range []struct {
+		name         string
+		containerJid Jid
+	}{
+		{name: "managed-container", containerJid: 1},
+		{name: "static-container", containerJid: 0},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			rq := newBenchRequest(b, elemCount)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				rq.handleRemove(tc.containerJid, data)
+			}
+		})
+	}
+}
+
 // BenchmarkRequestEventDispatch measures the request-level event path that
 // resolves Jids and reads a frozen Element's handlers. The bubbled case exercises
 // the per-candidate eligibility checks before every handler returns unhandled.

--- a/lib/assets/jaws.js
+++ b/lib/assets/jaws.js
@@ -467,6 +467,10 @@ function jawsPerform(what, id, data) {
 			jawsOrder(data);
 			return;
 	}
+	if (what === 'Call' && id === '') {
+		jawsVar(path, data, what);
+		return;
+	}
 	const elem = document.getElementById(id);
 	if (elem === null) {
 		throw "jaws: element not found: " + id;

--- a/lib/assets/jaws.js
+++ b/lib/assets/jaws.js
@@ -12,7 +12,6 @@
 
 var jaws = null;
 var jawsIdPrefix = 'Jid.';
-var jawsManagedIdRx = /^Jid\.[1-9][0-9]*$/;
 var jawsDebug = false;
 
 function jawsContains(a, v) {
@@ -158,9 +157,7 @@ function jawsRemoving(topElem) {
 		}
 		val += elements[i].id;
 	}
-	const containerId = String(topElem.id || '');
-	const containerJid = jawsManagedIdRx.test(containerId) ? containerId : '';
-	jaws.send("Remove\t" + containerJid + "\t" + JSON.stringify(val) + "\n");
+	jaws.send("Remove\t" + topElem.id + "\t" + JSON.stringify(val) + "\n");
 }
 
 function jawsAttach(elem) {

--- a/lib/assets/jaws.js
+++ b/lib/assets/jaws.js
@@ -12,6 +12,7 @@
 
 var jaws = null;
 var jawsIdPrefix = 'Jid.';
+var jawsManagedIdRx = /^Jid\.[1-9][0-9]*$/;
 var jawsDebug = false;
 
 function jawsContains(a, v) {
@@ -157,7 +158,9 @@ function jawsRemoving(topElem) {
 		}
 		val += elements[i].id;
 	}
-	jaws.send("Remove\t" + topElem.id + "\t" + JSON.stringify(val) + "\n");
+	const containerId = String(topElem.id || '');
+	const containerJid = jawsManagedIdRx.test(containerId) ? containerId : '';
+	jaws.send("Remove\t" + containerJid + "\t" + JSON.stringify(val) + "\n");
 }
 
 function jawsAttach(elem) {

--- a/lib/assets/js_test.go
+++ b/lib/assets/js_test.go
@@ -355,7 +355,7 @@ func TestJawsJS_JsVarNestedPathHandlesShadowedHasOwnProperty(t *testing.T) {
 	}
 }
 
-func TestJawsJS_RemoveFromNonManagedContainerProducesCleanupFrame(t *testing.T) {
+func TestJawsJS_RemoveFromNonManagedContainerIsInvalidAndDroppedByParser(t *testing.T) {
 	raw := runJawsJSSnippet(t, `
 	function FakeSocket() { this.readyState = 1; this.sent = []; }
 	FakeSocket.prototype.send = function(msg) { this.sent.push(msg); };
@@ -363,9 +363,7 @@ WebSocket = FakeSocket;
 jaws = new FakeSocket();
 
 const topElem = {
-	// An application ID may share the reserved-looking prefix without having the
-	// positive decimal form of a server-managed Jid.
-	id: "Jid.static",
+	id: "container",
 	querySelectorAll: function() {
 		return [{ id: "Jid.1" }, { id: "Jid.2" }];
 	}
@@ -378,18 +376,8 @@ process.stdout.write(jaws.sent[0] || "");
 		t.Fatal("jawsRemoving did not emit a websocket frame")
 	}
 
-	msg, ok := wire.Parse([]byte(raw))
-	if !ok {
-		t.Fatalf("Remove cleanup frame must be parseable by wire.Parse, got %q", raw)
-	}
-	if msg.What != what.Remove {
-		t.Fatalf("unexpected what: got %v", msg.What)
-	}
-	if msg.Jid != 0 {
-		t.Fatalf("non-managed container cleanup Jid = %v, want request-scoped Jid 0", msg.Jid)
-	}
-	if msg.Data != "Jid.1\tJid.2" {
-		t.Fatalf("unexpected cleanup ids %q", msg.Data)
+	if msg, ok := wire.Parse([]byte(raw)); ok {
+		t.Fatalf("expected invalid untrusted Remove frame to be dropped by parser, got %+v from %q", msg, raw)
 	}
 }
 

--- a/lib/assets/js_test.go
+++ b/lib/assets/js_test.go
@@ -393,6 +393,89 @@ process.stdout.write(jaws.sent[0] || "");
 	}
 }
 
+func TestJawsJS_RequestScopedCallDoesNotRequireElement(t *testing.T) {
+	raw := runJawsJSSnippet(t, `
+let called = null;
+let lookedUp = false;
+window.app = {
+	refresh: function(value) { called = value; }
+};
+document.getElementById = function() {
+	lookedUp = true;
+	return null;
+};
+
+let thrown = "";
+try {
+	jawsPerform("Call", "", 'app.refresh={"source":"server"}');
+} catch (err) {
+	thrown = String(err);
+}
+process.stdout.write(JSON.stringify({ called: called, lookedUp: lookedUp, thrown: thrown }));
+`)
+
+	var got struct {
+		Called struct {
+			Source string `json:"source"`
+		} `json:"called"`
+		LookedUp bool   `json:"lookedUp"`
+		Thrown   string `json:"thrown"`
+	}
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unexpected JSON output %q: %v", raw, err)
+	}
+	if got.Thrown != "" {
+		t.Fatalf("request-scoped Call failed before invocation: %s", got.Thrown)
+	}
+	if got.LookedUp {
+		t.Fatal("request-scoped Call attempted an element lookup")
+	}
+	if got.Called.Source != "server" {
+		t.Fatalf("request-scoped Call argument = %+v, want source=server", got.Called)
+	}
+}
+
+func TestJawsJS_ElementScopedCallStillRequiresElement(t *testing.T) {
+	raw := runJawsJSSnippet(t, `
+let calls = 0;
+let lookups = [];
+window.app = {
+	refresh: function() { calls++; }
+};
+document.getElementById = function(id) {
+	lookups.push(id);
+	return id === "Jid.1" ? { id: id } : null;
+};
+
+jawsPerform("Call", "Jid.1", 'app.refresh={}');
+let missingError = "";
+try {
+	jawsPerform("Call", "Jid.2", 'app.refresh={}');
+} catch (err) {
+	missingError = String(err);
+}
+process.stdout.write(JSON.stringify({ calls: calls, lookups: lookups, missingError: missingError }));
+`)
+
+	var got struct {
+		Calls        int      `json:"calls"`
+		Lookups      []string `json:"lookups"`
+		MissingError string   `json:"missingError"`
+	}
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unexpected JSON output %q: %v", raw, err)
+	}
+	if got.Calls != 1 {
+		t.Fatalf("element-scoped calls = %d, want 1", got.Calls)
+	}
+	if !reflect.DeepEqual(got.Lookups, []string{"Jid.1", "Jid.2"}) {
+		t.Fatalf("element lookups = %#v, want both targeted IDs", got.Lookups)
+	}
+	if !strings.Contains(got.MissingError, "element not found: Jid.2") {
+		t.Fatalf("missing element error = %q", got.MissingError)
+	}
+}
+
 func TestJawsJS_JsVarWithoutRegisteredTopLevelNameDoesNotEmitInvalidFrame(t *testing.T) {
 	raw := runJawsJSSnippet(t, `
 function FakeSocket() { this.readyState = 1; this.sent = []; }

--- a/lib/assets/js_test.go
+++ b/lib/assets/js_test.go
@@ -355,7 +355,7 @@ func TestJawsJS_JsVarNestedPathHandlesShadowedHasOwnProperty(t *testing.T) {
 	}
 }
 
-func TestJawsJS_RemoveFromNonManagedContainerIsInvalidAndDroppedByParser(t *testing.T) {
+func TestJawsJS_RemoveFromNonManagedContainerProducesCleanupFrame(t *testing.T) {
 	raw := runJawsJSSnippet(t, `
 	function FakeSocket() { this.readyState = 1; this.sent = []; }
 	FakeSocket.prototype.send = function(msg) { this.sent.push(msg); };
@@ -363,7 +363,9 @@ WebSocket = FakeSocket;
 jaws = new FakeSocket();
 
 const topElem = {
-	id: "container",
+	// An application ID may share the reserved-looking prefix without having the
+	// positive decimal form of a server-managed Jid.
+	id: "Jid.static",
 	querySelectorAll: function() {
 		return [{ id: "Jid.1" }, { id: "Jid.2" }];
 	}
@@ -376,8 +378,18 @@ process.stdout.write(jaws.sent[0] || "");
 		t.Fatal("jawsRemoving did not emit a websocket frame")
 	}
 
-	if msg, ok := wire.Parse([]byte(raw)); ok {
-		t.Fatalf("expected invalid untrusted Remove frame to be dropped by parser, got %+v from %q", msg, raw)
+	msg, ok := wire.Parse([]byte(raw))
+	if !ok {
+		t.Fatalf("Remove cleanup frame must be parseable by wire.Parse, got %q", raw)
+	}
+	if msg.What != what.Remove {
+		t.Fatalf("unexpected what: got %v", msg.What)
+	}
+	if msg.Jid != 0 {
+		t.Fatalf("non-managed container cleanup Jid = %v, want request-scoped Jid 0", msg.Jid)
+	}
+	if msg.Data != "Jid.1\tJid.2" {
+		t.Fatalf("unexpected cleanup ids %q", msg.Data)
 	}
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -2663,28 +2663,20 @@ func TestRequest_JsCallFunctionPathDoesNotBreakWireFraming(t *testing.T) {
 	}
 }
 
-func TestRequest_IncomingRemoveWithZeroContainerJidCleansManagedDescendants(t *testing.T) {
+func TestRequest_IncomingRemoveWithZeroContainerJidIsIgnored(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		rq := newTestRequest(t)
 		defer closeRequestInBubble(rq)
 
 		elem := rq.NewElement(&testUi{})
-		tagValue := tag.Tag("removed-from-static-container")
-		rq.Tag(elem, tagValue)
 
-		// A zero Jid represents a non-managed DOM container in this request. The
-		// browser still reports the managed descendants removed from that container.
-		// synctest.Wait makes the deletion assertions wait for the process loop.
+		// handleRemove only acts when the container Jid is > 0, so a Remove with a
+		// zero Jid must be ignored. synctest.Wait blocks until the process loop has
+		// handled the message, so the survival assertion is not vacuous.
 		rq.InCh <- wire.WsMsg{What: what.Remove, Jid: 0, Data: elem.Jid().String()}
 		synctest.Wait()
-		if got := rq.GetElementByJid(elem.Jid()); got != nil {
-			t.Fatalf("removed descendant %s remains registered", elem.Jid())
-		}
-		if !elem.Deleted() {
-			t.Fatalf("removed descendant %s is not marked deleted", elem.Jid())
-		}
-		if got := rq.GetElements(tagValue); len(got) != 0 {
-			t.Fatalf("removed descendant %s remains registered under its tag: %+v", elem.Jid(), got)
+		if got := rq.GetElementByJid(elem.Jid()); got == nil {
+			t.Fatalf("element %s should not be deletable through zero-container Remove", elem.Jid())
 		}
 	})
 }

--- a/request_test.go
+++ b/request_test.go
@@ -2663,20 +2663,28 @@ func TestRequest_JsCallFunctionPathDoesNotBreakWireFraming(t *testing.T) {
 	}
 }
 
-func TestRequest_IncomingRemoveWithZeroContainerJidIsIgnored(t *testing.T) {
+func TestRequest_IncomingRemoveWithZeroContainerJidCleansManagedDescendants(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		rq := newTestRequest(t)
 		defer closeRequestInBubble(rq)
 
 		elem := rq.NewElement(&testUi{})
+		tagValue := tag.Tag("removed-from-static-container")
+		rq.Tag(elem, tagValue)
 
-		// handleRemove only acts when the container Jid is > 0, so a Remove with a
-		// zero Jid must be ignored. synctest.Wait blocks until the process loop has
-		// handled the message, so the survival assertion is not vacuous.
+		// A zero Jid represents a non-managed DOM container in this request. The
+		// browser still reports the managed descendants removed from that container.
+		// synctest.Wait makes the deletion assertions wait for the process loop.
 		rq.InCh <- wire.WsMsg{What: what.Remove, Jid: 0, Data: elem.Jid().String()}
 		synctest.Wait()
-		if got := rq.GetElementByJid(elem.Jid()); got == nil {
-			t.Fatalf("element %s should not be deletable through zero-container Remove", elem.Jid())
+		if got := rq.GetElementByJid(elem.Jid()); got != nil {
+			t.Fatalf("removed descendant %s remains registered", elem.Jid())
+		}
+		if !elem.Deleted() {
+			t.Fatalf("removed descendant %s is not marked deleted", elem.Jid())
+		}
+		if got := rq.GetElements(tagValue); len(got) != 0 {
+			t.Fatalf("removed descendant %s remains registered under its tag: %+v", elem.Jid(), got)
 		}
 	})
 }

--- a/requestloop.go
+++ b/requestloop.go
@@ -231,15 +231,14 @@ func (rq *Request) handleRemove(containerJid Jid, data string) {
 	// Incoming what.Remove messages from jaws.js are cleanup acknowledgements sent
 	// while applying server-driven DOM mutation commands (Inner, Replace, Delete or
 	// Remove). Data is a tab-separated list of managed descendant IDs that were
-	// removed from the DOM. A positive WebSocket Jid identifies a managed
-	// parent/container and must not itself be deleted here; Jid zero means the
-	// container has an ordinary HTML id and is not registered on the Request.
+	// removed from the DOM. The WebSocket Jid identifies the parent/container being
+	// mutated and must not itself be deleted here.
 	//
 	// The client is already trusted only within its own request: a malicious client
 	// can fully control the DOM and UI it presents to its user. Treating arbitrary
 	// child removals as request-local state cleanup is therefore not a server-side
 	// privilege boundary; IDs are only looked up in this Request.
-	if containerJid.IsValid() {
+	if containerJid > 0 {
 		rq.mu.Lock()
 		defer rq.mu.Unlock()
 		// Collect the requested child elements, then delete them in a single pass

--- a/requestloop.go
+++ b/requestloop.go
@@ -218,14 +218,15 @@ func (rq *Request) handleRemove(containerJid Jid, data string) {
 	// Incoming what.Remove messages from jaws.js are cleanup acknowledgements sent
 	// while applying server-driven DOM mutation commands (Inner, Replace, Delete or
 	// Remove). Data is a tab-separated list of managed descendant IDs that were
-	// removed from the DOM. The WebSocket Jid identifies the parent/container being
-	// mutated and must not itself be deleted here.
+	// removed from the DOM. A positive WebSocket Jid identifies a managed
+	// parent/container and must not itself be deleted here; Jid zero means the
+	// container has an ordinary HTML id and is not registered on the Request.
 	//
 	// The client is already trusted only within its own request: a malicious client
 	// can fully control the DOM and UI it presents to its user. Treating arbitrary
 	// child removals as request-local state cleanup is therefore not a server-side
 	// privilege boundary; IDs are only looked up in this Request.
-	if containerJid > 0 {
+	if containerJid.IsValid() {
 		rq.mu.Lock()
 		defer rq.mu.Unlock()
 		// Collect the requested child elements, then delete them in a single pass

--- a/requestloop.go
+++ b/requestloop.go
@@ -134,6 +134,19 @@ func (rq *Request) handleBroadcast(tagmsg wire.Message, eventCallCh chan eventFn
 			What: tagmsg.What,
 		})
 		return
+	case what.Call:
+		// A nil or request-key destination selects the Request itself rather than
+		// an Element. Serve has already filtered key-targeted messages, so the
+		// empty Jid field tells the browser to perform one request-scoped call.
+		switch tagmsg.Dest.(type) {
+		case nil, key.Key:
+			rq.queue(wire.WsMsg{
+				Jid:  0,
+				Data: tagmsg.Data,
+				What: tagmsg.What,
+			})
+			return
+		}
 	}
 
 	// collect all elements marked with the tag in the message
@@ -142,8 +155,8 @@ func (rq *Request) handleBroadcast(tagmsg wire.Message, eventCallCh chan eventFn
 	case nil:
 		// matches no elements
 	case key.Key:
-		// request-targeted; page-global What values (Reload/Redirect/Order/Alert)
-		// already returned above, so there are no elements to resolve here
+		// request-targeted; page-global What values and Call already returned
+		// above, so there are no elements to resolve here
 	case string:
 		// target is a regular HTML ID. With Jid < 0, wire.WsMsg.Append writes Data
 		// verbatim and the browser splits the frame on '\t' (fields) and '\n' (frames),


### PR DESCRIPTION
## Summary

- Deliver `Jaws.JsCall(nil, ...)` once to every selected Request and a request-key target once to that Request.
- Dispatch zero-Jid Calls in shipped `jaws.js` without a DOM lookup while preserving HTML-id and tag element scope.
- Reject an empty HTML-id Call with stable `ErrEmptyCallTarget` so it cannot widen silently to request scope.

## Production reachability

Nil and request-key values are documented public `Jaws.JsCall` targets. In production they traverse Broadcast, subscription filtering, the Request queue, WebSocket framing, and shipped `jaws.js`. The selected Request previously resolved no Elements and silently emitted nothing.

`TestJawsJsCallReachesRequestTargets` runs two real served Requests and proves the selected clients receive the right frames. The shipped-client tests execute actual `jaws.js` and prove a zero-Jid Call invokes the window function without an element while element-scoped Calls still require one.

## Verification

- Real served-request routing and empty-target misuse tests
- Shipped `jaws.js` request-scoped and element-scoped tests
- Full Node-required race suite and all generation/lint/security gates

## Performance

Interleaved benchstat, n=10, 300ms, cpu1:

- Former no-op paths now queue required work: all Requests 5.107 → 8.626 ns; request key 4.787 → 8.359 ns.
- Existing HTML-id path 39.00 → 38.68 ns (`p=0.669`), tag path 51.91 → 52.00 ns (`p=0.353`), and public HTML-id Broadcast 104.0 → 104.1 ns (`p=0.956`) are unchanged.
- Allocation counts are unchanged in every case.

## Stack

Base: `main`. PR #99 was retired after confirming that no production code or known dependent uses its non-Jid removal path.
