### PR TITLE
Initialize dynamically inserted jawstrees reliably

### DIFF
--- a/jawsboot/README.md
+++ b/jawsboot/README.md
@@ -83,5 +83,8 @@ assets
     └── index.html
 ```
 
-Page templates rendered through `ui.Handler` should include `{{$.HeadHTML}}`
-inside `<head>` and `{{$.TailHTML}}` before the closing `</body>` tag.
+The examples use `{{$.HeadHTML}}` inside `<head>` to emit the configured
+resources and Request key metadata. Applications that provide equivalent markup
+may omit it. `{{$.TailHTML}}` is optional; placing it before the closing
+`</body>` tag applies updates queued during initial rendering before the
+WebSocket connects.

--- a/jawstree/README.md
+++ b/jawstree/README.md
@@ -127,10 +127,12 @@ tree := jawstree.New("mytree", ui.NewJsVar(&mu, root), jawstree.InitiallyExpande
 mux.Handle("GET /", ui.Handler(jw, "index.html", tree))
 ```
 
-In the page template, render the tree (it emits a hidden data element and the
-init script) and provide a container element whose HTML id equals the tree id;
-Quercus.js renders the tree into that container, and without it the tree
-silently fails to appear:
+In the page template, render the tree (it emits a hidden data element and queues
+an initializer through the fixed browser adapter) and provide a container element
+whose HTML id equals the tree id. JaWS retains the initializer until the deferred
+tree assets are ready. Quercus.js renders the tree into that container, and without
+it the tree silently fails to appear. The same initialization works when a JaWS
+container or template inserts the tree through a live DOM update:
 
 ```html
 <!DOCTYPE html>

--- a/jawstree/README.md
+++ b/jawstree/README.md
@@ -97,8 +97,11 @@ assets
     └── index.html
 ```
 
-Page templates rendered through `ui.Handler` should include `{{$.HeadHTML}}`
-inside `<head>` and `{{$.TailHTML}}` before the closing `</body>` tag.
+The examples use `{{$.HeadHTML}}` inside `<head>` to emit the configured
+resources and Request key metadata. Applications that provide equivalent markup
+may omit it. `{{$.TailHTML}}` is optional; placing it before the closing
+`</body>` tag applies updates queued during initial rendering before the
+WebSocket connects.
 
 ## Using the tree widget
 

--- a/jawstree/README.md
+++ b/jawstree/README.md
@@ -127,13 +127,11 @@ tree := jawstree.New("mytree", ui.NewJsVar(&mu, root), jawstree.InitiallyExpande
 mux.Handle("GET /", ui.Handler(jw, "index.html", tree))
 ```
 
-In the page template, render the tree (it emits a hidden data element and queues
-an initializer through the preloaded browser adapter) and provide a container
-element whose HTML id equals the tree id. JaWS opens the WebSocket after the
-deferred page assets are ready, so the same initialization works when a JaWS
-container or template inserts the tree through a live DOM update. Quercus.js
-renders the tree into that container, and without it the tree silently fails to
-appear:
+In the page template, render the tree and provide a container element whose HTML
+id equals the tree id. The tree initializes after deferred page assets are ready,
+including when a JaWS container or template inserts it through a live DOM update.
+Quercus.js renders the tree into that container, and without it the tree silently
+fails to appear:
 
 ```html
 <!DOCTYPE html>

--- a/jawstree/README.md
+++ b/jawstree/README.md
@@ -128,11 +128,12 @@ mux.Handle("GET /", ui.Handler(jw, "index.html", tree))
 ```
 
 In the page template, render the tree (it emits a hidden data element and queues
-an initializer through the fixed browser adapter) and provide a container element
-whose HTML id equals the tree id. JaWS retains the initializer until the deferred
-tree assets are ready. Quercus.js renders the tree into that container, and without
-it the tree silently fails to appear. The same initialization works when a JaWS
-container or template inserts the tree through a live DOM update:
+an initializer through the preloaded browser adapter) and provide a container
+element whose HTML id equals the tree id. JaWS opens the WebSocket after the
+deferred page assets are ready, so the same initialization works when a JaWS
+container or template inserts the tree through a live DOM update. Quercus.js
+renders the tree into that container, and without it the tree silently fails to
+appear:
 
 ```html
 <!DOCTYPE html>

--- a/jawstree/assets/jawstree.js
+++ b/jawstree/assets/jawstree.js
@@ -41,6 +41,14 @@ function jawstreeSetData(t, data) {
     t.setData(jawstreeViewChildren(data, t.options.multiSelectEnabled, t.options.cascadeSelectChildren));
 }
 
+function jawstreeInit(arg) {
+    window["jawstree_"+arg.tree] = jawstreeNew(
+        arg.tree,
+        window["jawstreeroot_"+arg.tree],
+        arg.options
+    );
+}
+
 function jawstreeSet(arg) {
     var t = window["jawstree_"+arg.tree];
     var wasApplyingSet = t.jawsApplyingSet;

--- a/jawstree/dynamic_insert_production_regression_test.go
+++ b/jawstree/dynamic_insert_production_regression_test.go
@@ -1,0 +1,341 @@
+package jawstree
+
+import (
+	"encoding/json"
+	"html/template"
+	"image/color"
+	"image/png"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/linkdata/deadlock"
+	"github.com/linkdata/jaws"
+	"github.com/linkdata/jaws/jawstest"
+	jawsassets "github.com/linkdata/jaws/lib/assets"
+	"github.com/linkdata/jaws/lib/ui"
+	"github.com/linkdata/jaws/lib/what"
+	"github.com/linkdata/jaws/lib/wire"
+)
+
+type dynamicTreeContainer struct {
+	contents []jaws.UI
+}
+
+func (c *dynamicTreeContainer) JawsContains(*jaws.Element) []jaws.UI {
+	return c.contents
+}
+
+func jawstreeFirefoxPath(t *testing.T) string {
+	t.Helper()
+	for _, name := range []string{"firefox", "firefox-esr"} {
+		if filename, err := exec.LookPath(name); err == nil {
+			return filename
+		}
+	}
+	if runtime.GOOS == "darwin" {
+		const filename = "/Applications/Firefox.app/Contents/MacOS/firefox"
+		if _, err := os.Stat(filename); err == nil {
+			return filename
+		}
+	}
+	t.Skip("Firefox is required for the dynamic Tree production regression")
+	return ""
+}
+
+func TestTreeInitialAndDynamicInitializationWithClientAssets(t *testing.T) {
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+	go jw.Serve()
+
+	tr := jawstest.NewTestRequest(jw, nil)
+	if tr == nil {
+		t.Fatal("nil test request")
+	}
+	defer func() {
+		tr.Close()
+		<-tr.DoneCh
+	}()
+	<-tr.ReadyCh
+
+	// Render an initial Tree and its documented target before the WebSocket queue
+	// is flushed. Its Call will exercise dependency readiness in the browser.
+	initialTarget := ui.NewDiv(template.HTML(`<div id="initial"></div>`))
+	initialTargetElem := tr.NewElement(initialTarget)
+	var initial strings.Builder
+	if err := initialTargetElem.JawsRender(&initial, nil); err != nil {
+		t.Fatal(err)
+	}
+	initialRoot := &Node{Children: []*Node{{Name: "Before assets"}}}
+	var initialMu deadlock.RWMutex
+	initialTree := New("initial", ui.NewJsVar(&initialMu, initialRoot))
+	initialTreeElem := tr.NewElement(initialTree)
+	if err := initialTreeElem.JawsRender(&initial, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Render the dynamic Tree's documented target through the normal UI path,
+	// then render the initially empty dynamic Container alongside it.
+	target := ui.NewDiv(template.HTML(`<div id="dynamic"></div>`))
+	targetElem := tr.NewElement(target)
+	if err := targetElem.JawsRender(&initial, nil); err != nil {
+		t.Fatal(err)
+	}
+	contents := &dynamicTreeContainer{}
+	container := ui.NewContainer("div", contents)
+	containerElem := tr.NewElement(container)
+	if err := containerElem.JawsRender(&initial, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Render a second target and empty live Container for the remove-before-ready
+	// lifecycle. Its Tree will be appended and removed entirely through updates.
+	staleTarget := ui.NewDiv(template.HTML(`<div id="stale"></div>`))
+	staleTargetElem := tr.NewElement(staleTarget)
+	if err := staleTargetElem.JawsRender(&initial, nil); err != nil {
+		t.Fatal(err)
+	}
+	staleContents := &dynamicTreeContainer{}
+	staleContainer := ui.NewContainer("div", staleContents)
+	staleContainerElem := tr.NewElement(staleContainer)
+	if err := staleContainerElem.JawsRender(&initial, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(initial.String(), `<div id="initial"></div>`) ||
+		!strings.Contains(initial.String(), `<div id="dynamic"></div>`) ||
+		!strings.Contains(initial.String(), `<div id="stale"></div>`) {
+		t.Fatalf("initial page is missing a documented Tree target: %q", initial.String())
+	}
+
+	tr.InCh <- wire.WsMsg{}
+	var initialCall wire.WsMsg
+	select {
+	case initialCall = <-tr.OutCh:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for initial Tree initializer")
+	}
+	if initialCall.What != what.Call || initialCall.Jid != initialTreeElem.Jid() {
+		t.Fatalf("initial Tree message = %+v, want element-scoped Call for %s", initialCall, initialTreeElem.Jid())
+	}
+	if want := `jawsCallWhenReady={"id":` + strconv.Quote(initialTreeElem.Jid().String()) + `,"path":"jawstreeInit","data":{"tree":"initial","options":0}}`; initialCall.Data != want {
+		t.Fatalf("initial Tree data = %q, want %q", initialCall.Data, want)
+	}
+
+	root := &Node{Children: []*Node{{Name: "Documents"}}}
+	var mu deadlock.RWMutex
+	tree := New("dynamic", ui.NewJsVar(&mu, root), InitiallyExpanded)
+	contents.contents = []jaws.UI{tree}
+
+	// This is the supported production path: dirtying the Container's source lets
+	// the Request process loop render the new Tree and send its DOM and Call frames.
+	tr.Dirty(contents)
+
+	got := make([]wire.WsMsg, 0, 3)
+	for len(got) < 3 {
+		select {
+		case msg := <-tr.OutCh:
+			got = append(got, msg)
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for dynamic tree messages; got %+v", got)
+		}
+	}
+
+	if got[0].What != what.Append || got[0].Jid != containerElem.Jid() {
+		t.Fatalf("first dynamic message = %+v, want parent Append", got[0])
+	}
+	if strings.Contains(got[0].Data, "<script") {
+		t.Fatalf("dynamic Tree HTML contains an inert script: %q", got[0].Data)
+	}
+	if !strings.Contains(got[0].Data, `data-jawsname="jawstreeroot_dynamic"`) {
+		t.Fatalf("dynamic Tree HTML is missing root data: %q", got[0].Data)
+	}
+	if got[1].What != what.Order || got[1].Jid != containerElem.Jid() {
+		t.Fatalf("second dynamic message = %+v, want parent Order", got[1])
+	}
+	if got[2].What != what.Call || got[2].Jid <= containerElem.Jid() {
+		t.Fatalf("third dynamic message = %+v, want child initializer Call", got[2])
+	}
+	if !strings.Contains(got[0].Data, `id="`+got[2].Jid.String()+`"`) {
+		t.Fatalf("Append HTML does not contain initializer target %s: %q", got[2].Jid, got[0].Data)
+	}
+	if want := `jawsCallWhenReady={"id":` + strconv.Quote(got[2].Jid.String()) + `,"path":"jawstreeInit","data":{"tree":"dynamic","options":2}}`; got[2].Data != want {
+		t.Fatalf("initializer data = %q, want %q", got[2].Data, want)
+	}
+
+	staleRoot := &Node{Children: []*Node{{Name: "Must not appear"}}}
+	var staleMu deadlock.RWMutex
+	staleTree := New("stale", ui.NewJsVar(&staleMu, staleRoot))
+	staleContents.contents = []jaws.UI{staleTree}
+	tr.Dirty(staleContents)
+
+	staleAdd := make([]wire.WsMsg, 0, 3)
+	for len(staleAdd) < 3 {
+		select {
+		case msg := <-tr.OutCh:
+			staleAdd = append(staleAdd, msg)
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for stale Tree append messages; got %+v", staleAdd)
+		}
+	}
+	if staleAdd[0].What != what.Append || staleAdd[0].Jid != staleContainerElem.Jid() {
+		t.Fatalf("first stale Tree message = %+v, want parent Append", staleAdd[0])
+	}
+	if strings.Contains(staleAdd[0].Data, "<script") ||
+		!strings.Contains(staleAdd[0].Data, `data-jawsname="jawstreeroot_stale"`) {
+		t.Fatalf("stale Tree Append has unexpected HTML: %q", staleAdd[0].Data)
+	}
+	if staleAdd[1].What != what.Order || staleAdd[1].Jid != staleContainerElem.Jid() {
+		t.Fatalf("second stale Tree message = %+v, want parent Order", staleAdd[1])
+	}
+	if staleAdd[2].What != what.Call || staleAdd[2].Jid <= staleContainerElem.Jid() {
+		t.Fatalf("third stale Tree message = %+v, want child initializer Call", staleAdd[2])
+	}
+	if !strings.Contains(staleAdd[0].Data, `id="`+staleAdd[2].Jid.String()+`"`) {
+		t.Fatalf("stale Append HTML does not contain initializer target %s: %q", staleAdd[2].Jid, staleAdd[0].Data)
+	}
+	if want := `jawsCallWhenReady={"id":` + strconv.Quote(staleAdd[2].Jid.String()) + `,"path":"jawstreeInit","data":{"tree":"stale","options":0}}`; staleAdd[2].Data != want {
+		t.Fatalf("stale initializer data = %q, want %q", staleAdd[2].Data, want)
+	}
+
+	// Remove the Tree before browser readiness. The queued Call remains in the
+	// already-sent frame, so the client must use its originating Jid to suppress it.
+	staleContents.contents = nil
+	tr.Dirty(staleContents)
+	var staleRemove wire.WsMsg
+	select {
+	case staleRemove = <-tr.OutCh:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for stale Tree removal")
+	}
+	if staleRemove.What != what.Remove || staleRemove.Jid != staleContainerElem.Jid() ||
+		staleRemove.Data != staleAdd[2].Jid.String() {
+		t.Fatalf("stale Tree removal = %+v, want parent Remove of %s", staleRemove, staleAdd[2].Jid)
+	}
+
+	// Replay the initial Call after jaws.js has loaded but before jawstree.js and
+	// treeview.js. The readiness queue must retain it until both dependencies exist.
+	initialFrameJSON, err := json.Marshal(string(initialCall.Append(nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Replay the live Container frames after DOMContentLoaded, matching the normal
+	// dynamic-update path after all shipped assets are ready.
+	var dynamicFrame []byte
+	for i := range got {
+		dynamicFrame = got[i].Append(dynamicFrame)
+	}
+	dynamicFrameJSON, err := json.Marshal(string(dynamicFrame))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Replay both update passes before readiness: the Append queues initialization,
+	// then the Remove deletes its originating element while the static target stays.
+	var staleLifecycleFrame []byte
+	for i := range staleAdd {
+		staleLifecycleFrame = staleAdd[i].Append(staleLifecycleFrame)
+	}
+	staleLifecycleFrame = staleRemove.Append(staleLifecycleFrame)
+	staleLifecycleFrameJSON, err := json.Marshal(string(staleLifecycleFrame))
+	if err != nil {
+		t.Fatal(err)
+	}
+	jawstreeJS, err := assetsFS.ReadFile("assets/jawstree.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	treeviewJS, err := assetsFS.ReadFile("assets/treeview.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	htmlPath := filepath.Join(dir, "dynamic-tree.html")
+	screenshotPath := filepath.Join(dir, "dynamic-tree.png")
+	profilePath := filepath.Join(dir, "firefox-profile")
+	if err := os.Mkdir(profilePath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	htmlText := `<!doctype html><html><head>
+<meta name="jawsKey" content="1">
+<style>#result{position:fixed;inset:0;z-index:9999;background:rgb(255,0,0)}</style>
+</head><body>` + initial.String() + `<div id="result"></div>
+<script>
+window.WebSocket = class {
+	constructor() { this.readyState = 1; }
+	addEventListener() {}
+	send() {}
+};
+</script>
+<script>` + jawsassets.JavascriptText + `</script>
+<script>
+jawsMessage({data:` + string(initialFrameJSON) + `});
+jawsMessage({data:` + string(staleLifecycleFrameJSON) + `});
+window.jawstreeInitializerWasPending = (window.jawstree_initial === undefined);
+window.jawstreeRemovedBeforeReady =
+	(document.getElementById(` + strconv.Quote(staleAdd[2].Jid.String()) + `) === null);
+</script>
+<script>` + string(jawstreeJS) + `</script>
+<script>` + string(treeviewJS) + `</script>
+<script>
+window.addEventListener("DOMContentLoaded", function() {
+	const initialTarget = document.getElementById("initial");
+	const initialText = initialTarget && initialTarget.querySelector(".treeview-node-text");
+	const initialTree = window.jawstree_initial;
+	jawsMessage({data:` + string(dynamicFrameJSON) + `});
+	const dynamicTarget = document.getElementById("dynamic");
+	const dynamicText = dynamicTarget && dynamicTarget.querySelector(".treeview-node-text");
+	const dynamicTree = window.jawstree_dynamic;
+	const staleTarget = document.getElementById("stale");
+	if (window.jawstreeInitializerWasPending &&
+		window.jawstreeRemovedBeforeReady &&
+		initialTree instanceof window.Treeview &&
+		initialText && initialText.textContent === "Before assets" &&
+		initialTarget.querySelector("ul") &&
+		dynamicTree instanceof window.Treeview &&
+		dynamicText && dynamicText.textContent === "Documents" &&
+		dynamicTarget.querySelector("ul") &&
+		window.jawstree_stale === undefined &&
+		staleTarget && !staleTarget.querySelector("ul")) {
+		document.getElementById("result").style.background = "rgb(0,255,0)";
+	}
+});
+</script>
+</body></html>`
+	if err := os.WriteFile(htmlPath, []byte(htmlText), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	pageURL := (&url.URL{Scheme: "file", Path: htmlPath}).String()
+	cmd := exec.CommandContext(t.Context(), jawstreeFirefoxPath(t),
+		"--headless", "--new-instance", "--profile", profilePath,
+		"--screenshot", screenshotPath, "--window-size", "64,64", pageURL)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("Firefox failed: %v\n%s", err, output)
+	}
+
+	f, err := os.Open(screenshotPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	img, decodeErr := png.Decode(f)
+	closeErr := f.Close()
+	if decodeErr != nil {
+		t.Fatal(decodeErr)
+	}
+	if closeErr != nil {
+		t.Fatal(closeErr)
+	}
+	pixel := color.RGBAModel.Convert(img.At(32, 32)).(color.RGBA)
+	if pixel.R > 32 || pixel.G < 224 || pixel.B > 32 {
+		t.Fatalf("Tree readiness lifecycle failed through the shipped client assets; center pixel = %#v, want green", pixel)
+	}
+}

--- a/jawstree/dynamic_insert_production_regression_test.go
+++ b/jawstree/dynamic_insert_production_regression_test.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -49,7 +48,7 @@ func jawstreeFirefoxPath(t *testing.T) string {
 	return ""
 }
 
-func TestTreeInitialAndDynamicInitializationWithClientAssets(t *testing.T) {
+func TestTreeDynamicInitializationWithClientAssets(t *testing.T) {
 	jw, err := jaws.New()
 	if err != nil {
 		t.Fatal(err)
@@ -58,35 +57,17 @@ func TestTreeInitialAndDynamicInitializationWithClientAssets(t *testing.T) {
 	go jw.Serve()
 
 	tr := jawstest.NewTestRequest(jw, nil)
-	if tr == nil {
-		t.Fatal("nil test request")
-	}
 	defer func() {
 		tr.Close()
 		<-tr.DoneCh
 	}()
 	<-tr.ReadyCh
 
-	// Render an initial Tree and its documented target before the WebSocket queue
-	// is flushed. Its Call will exercise dependency readiness in the browser.
-	initialTarget := ui.NewDiv(template.HTML(`<div id="initial"></div>`))
-	initialTargetElem := tr.NewElement(initialTarget)
-	var initial strings.Builder
-	if err := initialTargetElem.JawsRender(&initial, nil); err != nil {
-		t.Fatal(err)
-	}
-	initialRoot := &Node{Children: []*Node{{Name: "Before assets"}}}
-	var initialMu deadlock.RWMutex
-	initialTree := New("initial", ui.NewJsVar(&initialMu, initialRoot))
-	initialTreeElem := tr.NewElement(initialTree)
-	if err := initialTreeElem.JawsRender(&initial, nil); err != nil {
-		t.Fatal(err)
-	}
-
-	// Render the dynamic Tree's documented target through the normal UI path,
-	// then render the initially empty dynamic Container alongside it.
+	// Render the documented target and an initially empty live Container. The Tree
+	// itself enters the page only through the subsequent Container update.
 	target := ui.NewDiv(template.HTML(`<div id="dynamic"></div>`))
 	targetElem := tr.NewElement(target)
+	var initial strings.Builder
 	if err := targetElem.JawsRender(&initial, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -97,158 +78,60 @@ func TestTreeInitialAndDynamicInitializationWithClientAssets(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Render a second target and empty live Container for the remove-before-ready
-	// lifecycle. Its Tree will be appended and removed entirely through updates.
-	staleTarget := ui.NewDiv(template.HTML(`<div id="stale"></div>`))
-	staleTargetElem := tr.NewElement(staleTarget)
-	if err := staleTargetElem.JawsRender(&initial, nil); err != nil {
-		t.Fatal(err)
-	}
-	staleContents := &dynamicTreeContainer{}
-	staleContainer := ui.NewContainer("div", staleContents)
-	staleContainerElem := tr.NewElement(staleContainer)
-	if err := staleContainerElem.JawsRender(&initial, nil); err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(initial.String(), `<div id="initial"></div>`) ||
-		!strings.Contains(initial.String(), `<div id="dynamic"></div>`) ||
-		!strings.Contains(initial.String(), `<div id="stale"></div>`) {
-		t.Fatalf("initial page is missing a documented Tree target: %q", initial.String())
-	}
-
-	tr.InCh <- wire.WsMsg{}
-	var initialCall wire.WsMsg
-	select {
-	case initialCall = <-tr.OutCh:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for initial Tree initializer")
-	}
-	if initialCall.What != what.Call || initialCall.Jid != initialTreeElem.Jid() {
-		t.Fatalf("initial Tree message = %+v, want element-scoped Call for %s", initialCall, initialTreeElem.Jid())
-	}
-	if want := `jawsCallWhenReady={"id":` + strconv.Quote(initialTreeElem.Jid().String()) + `,"path":"jawstreeInit","data":{"tree":"initial","options":0}}`; initialCall.Data != want {
-		t.Fatalf("initial Tree data = %q, want %q", initialCall.Data, want)
-	}
-
 	root := &Node{Children: []*Node{{Name: "Documents"}}}
 	var mu deadlock.RWMutex
 	tree := New("dynamic", ui.NewJsVar(&mu, root), InitiallyExpanded)
 	contents.contents = []jaws.UI{tree}
-
-	// This is the supported production path: dirtying the Container's source lets
-	// the Request process loop render the new Tree and send its DOM and Call frames.
 	tr.Dirty(contents)
 
-	got := make([]wire.WsMsg, 0, 3)
-	for len(got) < 3 {
+	frames := make([]wire.WsMsg, 0, 4)
+	for len(frames) < 3 {
 		select {
 		case msg := <-tr.OutCh:
-			got = append(got, msg)
+			frames = append(frames, msg)
 		case <-time.After(time.Second):
-			t.Fatalf("timed out waiting for dynamic tree messages; got %+v", got)
+			t.Fatalf("timed out waiting for dynamic Tree messages; got %+v", frames)
 		}
 	}
-
-	if got[0].What != what.Append || got[0].Jid != containerElem.Jid() {
-		t.Fatalf("first dynamic message = %+v, want parent Append", got[0])
+	if frames[0].What != what.Append || frames[0].Jid != containerElem.Jid() {
+		t.Fatalf("first dynamic message = %+v, want parent Append", frames[0])
 	}
-	if strings.Contains(got[0].Data, "<script") {
-		t.Fatalf("dynamic Tree HTML contains an inert script: %q", got[0].Data)
+	if frames[1].What != what.Order || frames[1].Jid != containerElem.Jid() {
+		t.Fatalf("second dynamic message = %+v, want parent Order", frames[1])
 	}
-	if !strings.Contains(got[0].Data, `data-jawsname="jawstreeroot_dynamic"`) {
-		t.Fatalf("dynamic Tree HTML is missing root data: %q", got[0].Data)
+	if frames[2].What != what.Call || frames[2].Jid <= containerElem.Jid() ||
+		frames[2].Data != `jawstreeInit={"tree":"dynamic","options":2}` {
+		t.Fatalf("third dynamic message = %+v, want child initializer Call", frames[2])
 	}
-	if got[1].What != what.Order || got[1].Jid != containerElem.Jid() {
-		t.Fatalf("second dynamic message = %+v, want parent Order", got[1])
-	}
-	if got[2].What != what.Call || got[2].Jid <= containerElem.Jid() {
-		t.Fatalf("third dynamic message = %+v, want child initializer Call", got[2])
-	}
-	if !strings.Contains(got[0].Data, `id="`+got[2].Jid.String()+`"`) {
-		t.Fatalf("Append HTML does not contain initializer target %s: %q", got[2].Jid, got[0].Data)
-	}
-	if want := `jawsCallWhenReady={"id":` + strconv.Quote(got[2].Jid.String()) + `,"path":"jawstreeInit","data":{"tree":"dynamic","options":2}}`; got[2].Data != want {
-		t.Fatalf("initializer data = %q, want %q", got[2].Data, want)
+	if strings.Contains(frames[0].Data, "<script") ||
+		!strings.Contains(frames[0].Data, `data-jawsname="jawstreeroot_dynamic"`) ||
+		!strings.Contains(frames[0].Data, `id="`+frames[2].Jid.String()+`"`) {
+		t.Fatalf("dynamic Tree Append has unexpected HTML: %q", frames[0].Data)
 	}
 
-	staleRoot := &Node{Children: []*Node{{Name: "Must not appear"}}}
-	var staleMu deadlock.RWMutex
-	staleTree := New("stale", ui.NewJsVar(&staleMu, staleRoot))
-	staleContents.contents = []jaws.UI{staleTree}
-	tr.Dirty(staleContents)
-
-	staleAdd := make([]wire.WsMsg, 0, 3)
-	for len(staleAdd) < 3 {
-		select {
-		case msg := <-tr.OutCh:
-			staleAdd = append(staleAdd, msg)
-		case <-time.After(time.Second):
-			t.Fatalf("timed out waiting for stale Tree append messages; got %+v", staleAdd)
-		}
-	}
-	if staleAdd[0].What != what.Append || staleAdd[0].Jid != staleContainerElem.Jid() {
-		t.Fatalf("first stale Tree message = %+v, want parent Append", staleAdd[0])
-	}
-	if strings.Contains(staleAdd[0].Data, "<script") ||
-		!strings.Contains(staleAdd[0].Data, `data-jawsname="jawstreeroot_stale"`) {
-		t.Fatalf("stale Tree Append has unexpected HTML: %q", staleAdd[0].Data)
-	}
-	if staleAdd[1].What != what.Order || staleAdd[1].Jid != staleContainerElem.Jid() {
-		t.Fatalf("second stale Tree message = %+v, want parent Order", staleAdd[1])
-	}
-	if staleAdd[2].What != what.Call || staleAdd[2].Jid <= staleContainerElem.Jid() {
-		t.Fatalf("third stale Tree message = %+v, want child initializer Call", staleAdd[2])
-	}
-	if !strings.Contains(staleAdd[0].Data, `id="`+staleAdd[2].Jid.String()+`"`) {
-		t.Fatalf("stale Append HTML does not contain initializer target %s: %q", staleAdd[2].Jid, staleAdd[0].Data)
-	}
-	if want := `jawsCallWhenReady={"id":` + strconv.Quote(staleAdd[2].Jid.String()) + `,"path":"jawstreeInit","data":{"tree":"stale","options":0}}`; staleAdd[2].Data != want {
-		t.Fatalf("stale initializer data = %q, want %q", staleAdd[2].Data, want)
-	}
-
-	// Remove the Tree before browser readiness. The queued Call remains in the
-	// already-sent frame, so the client must use its originating Jid to suppress it.
-	staleContents.contents = nil
-	tr.Dirty(staleContents)
-	var staleRemove wire.WsMsg
+	// Queue an ordinary dirty update immediately after insertion. The production
+	// writer may coalesce it with the Append/Order/initializer messages above, so
+	// the browser regression replays all four in one WebSocket frame.
+	tree.Lock()
+	root.Children[0].Name = "Updated"
+	tree.Unlock()
+	jw.Dirty(root)
 	select {
-	case staleRemove = <-tr.OutCh:
+	case msg := <-tr.OutCh:
+		frames = append(frames, msg)
 	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for stale Tree removal")
+		t.Fatalf("timed out waiting for dynamic Tree update; got %+v", frames)
 	}
-	if staleRemove.What != what.Remove || staleRemove.Jid != staleContainerElem.Jid() ||
-		staleRemove.Data != staleAdd[2].Jid.String() {
-		t.Fatalf("stale Tree removal = %+v, want parent Remove of %s", staleRemove, staleAdd[2].Jid)
+	if frames[3].What != what.Call || frames[3].Jid != frames[2].Jid ||
+		!strings.Contains(frames[3].Data, `"name":"Updated"`) {
+		t.Fatalf("fourth dynamic message = %+v, want child jawstreeSet Call", frames[3])
 	}
 
-	// Replay the initial Call after jaws.js has loaded but before jawstree.js and
-	// treeview.js. The readiness queue must retain it until both dependencies exist.
-	initialFrameJSON, err := json.Marshal(string(initialCall.Append(nil)))
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Replay the live Container frames after DOMContentLoaded, matching the normal
-	// dynamic-update path after all shipped assets are ready.
 	var dynamicFrame []byte
-	for i := range got {
-		dynamicFrame = got[i].Append(dynamicFrame)
+	for i := range frames {
+		dynamicFrame = frames[i].Append(dynamicFrame)
 	}
 	dynamicFrameJSON, err := json.Marshal(string(dynamicFrame))
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Replay both update passes before readiness: the Append queues initialization,
-	// then the Remove deletes its originating element while the static target stays.
-	var staleLifecycleFrame []byte
-	for i := range staleAdd {
-		staleLifecycleFrame = staleAdd[i].Append(staleLifecycleFrame)
-	}
-	staleLifecycleFrame = staleRemove.Append(staleLifecycleFrame)
-	staleLifecycleFrameJSON, err := json.Marshal(string(staleLifecycleFrame))
-	if err != nil {
-		t.Fatal(err)
-	}
-	jawstreeJS, err := assetsFS.ReadFile("assets/jawstree.js")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -256,61 +139,72 @@ func TestTreeInitialAndDynamicInitializationWithClientAssets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	dir := t.TempDir()
-	htmlPath := filepath.Join(dir, "dynamic-tree.html")
-	screenshotPath := filepath.Join(dir, "dynamic-tree.png")
-	profilePath := filepath.Join(dir, "firefox-profile")
-	if err := os.Mkdir(profilePath, 0o700); err != nil {
+	jawstreeJS, err := assetsFS.ReadFile("assets/jawstree.js")
+	if err != nil {
 		t.Fatal(err)
+	}
+
+	// Recreate the generated defer lifecycle with actual external scripts. The fake
+	// WebSocket records whether core JaWS waits for the later deferred dependencies
+	// before connecting, then delivers the genuine server frame.
+	dir := t.TempDir()
+	for name, data := range map[string][]byte{
+		"jaws.js":     []byte(jawsassets.JavascriptText),
+		"jawstree.js": jawstreeJS,
+		"treeview.js": treeviewJS,
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0o600); err != nil {
+			t.Fatal(err)
+		}
 	}
 	htmlText := `<!doctype html><html><head>
 <meta name="jawsKey" content="1">
 <style>#result{position:fixed;inset:0;z-index:9999;background:rgb(255,0,0)}</style>
-</head><body>` + initial.String() + `<div id="result"></div>
 <script>
+window.dynamicFrame = ` + string(dynamicFrameJSON) + `;
 window.WebSocket = class {
-	constructor() { this.readyState = 1; }
-	addEventListener() {}
+	constructor() {
+		this.readyState = 1;
+		window.connectedAfterAssets =
+			typeof window.jawstreeInit === "function" &&
+			typeof window.Treeview === "function";
+	}
+	addEventListener(name, fn) {
+		if (name === "message") {
+			queueMicrotask(function() {
+				fn({data: window.dynamicFrame});
+			});
+		}
+	}
 	send() {}
 };
 </script>
-<script>` + jawsassets.JavascriptText + `</script>
-<script>
-jawsMessage({data:` + string(initialFrameJSON) + `});
-jawsMessage({data:` + string(staleLifecycleFrameJSON) + `});
-window.jawstreeInitializerWasPending = (window.jawstree_initial === undefined);
-window.jawstreeRemovedBeforeReady =
-	(document.getElementById(` + strconv.Quote(staleAdd[2].Jid.String()) + `) === null);
-</script>
-<script>` + string(jawstreeJS) + `</script>
-<script>` + string(treeviewJS) + `</script>
+<script defer src="jaws.js"></script>
+<script defer src="jawstree.js"></script>
+<script defer src="treeview.js"></script>
+</head><body>` + initial.String() + `<div id="result"></div>
 <script>
 window.addEventListener("DOMContentLoaded", function() {
-	const initialTarget = document.getElementById("initial");
-	const initialText = initialTarget && initialTarget.querySelector(".treeview-node-text");
-	const initialTree = window.jawstree_initial;
-	jawsMessage({data:` + string(dynamicFrameJSON) + `});
-	const dynamicTarget = document.getElementById("dynamic");
-	const dynamicText = dynamicTarget && dynamicTarget.querySelector(".treeview-node-text");
-	const dynamicTree = window.jawstree_dynamic;
-	const staleTarget = document.getElementById("stale");
-	if (window.jawstreeInitializerWasPending &&
-		window.jawstreeRemovedBeforeReady &&
-		initialTree instanceof window.Treeview &&
-		initialText && initialText.textContent === "Before assets" &&
-		initialTarget.querySelector("ul") &&
-		dynamicTree instanceof window.Treeview &&
-		dynamicText && dynamicText.textContent === "Documents" &&
-		dynamicTarget.querySelector("ul") &&
-		window.jawstree_stale === undefined &&
-		staleTarget && !staleTarget.querySelector("ul")) {
-		document.getElementById("result").style.background = "rgb(0,255,0)";
-	}
+	setTimeout(function() {
+		const target = document.getElementById("dynamic");
+		const text = target && target.querySelector(".treeview-node-text");
+		if (window.connectedAfterAssets &&
+			window.jawstree_dynamic instanceof window.Treeview &&
+			text && text.textContent === "Updated" && target.querySelector("ul")) {
+			document.getElementById("result").style.background = "rgb(0,255,0)";
+		}
+	}, 0);
 });
 </script>
 </body></html>`
+
+	htmlPath := filepath.Join(dir, "dynamic-tree.html")
+	screenshotPath := filepath.Join(dir, "dynamic-tree.png")
+	profilePath := filepath.Join(dir, "firefox-profile")
 	if err := os.WriteFile(htmlPath, []byte(htmlText), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(profilePath, 0o700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -336,6 +230,6 @@ window.addEventListener("DOMContentLoaded", function() {
 	}
 	pixel := color.RGBAModel.Convert(img.At(32, 32)).(color.RGBA)
 	if pixel.R > 32 || pixel.G < 224 || pixel.B > 32 {
-		t.Fatalf("Tree readiness lifecycle failed through the shipped client assets; center pixel = %#v, want green", pixel)
+		t.Fatalf("dynamic Tree did not initialize through shipped assets; center pixel = %#v, want green", pixel)
 	}
 }

--- a/jawstree/initscript.go
+++ b/jawstree/initscript.go
@@ -4,14 +4,11 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-
-	"github.com/linkdata/jaws"
 )
 
 const (
-	initScriptPath           = "/jaws/.jawstree"
-	initScriptPattern        = initScriptPath + "/{tree}/{options}"
-	readyInitCallMaxOverhead = len(`{"id":"Jid.","path":"jawstreeInit","data":{"tree":"","options":}}`) + 40
+	initScriptPath    = "/jaws/.jawstree"
+	initScriptPattern = initScriptPath + "/{tree}/{options}"
 )
 
 var (
@@ -39,26 +36,10 @@ func initScriptURL(tree string, options Option) string {
 	return initScriptPath + "/" + url.PathEscape(tree) + "/" + strconv.FormatInt(int64(options), 10)
 }
 
-func appendReadyInitCallData(b []byte, id jaws.Jid, tree string, options Option) []byte {
-	if b == nil {
-		// Reserve the fixed JSON syntax plus 20 decimal digits each for the Jid and
-		// options. Tree names need no escaping beyond quotes because New validates
-		// them with isSafeTreeName.
-		b = make([]byte, 0, len(tree)+readyInitCallMaxOverhead)
-	}
-	b = append(b, `{"id":`...)
-	b = id.AppendQuote(b)
-	b = append(b, `,"path":"jawstreeInit","data":{"tree":`...)
-	b = strconv.AppendQuote(b, tree)
-	b = append(b, `,"options":`...)
-	b = strconv.AppendInt(b, int64(options), 10)
-	b = append(b, `}}`...)
-	return b
-}
-
 func appendInitScript(b []byte, tree string, options Option) []byte {
-	// Run the initializer immediately when this external script loads after the
-	// document is parsed, and otherwise defer it to DOMContentLoaded.
+	// Run the initializer immediately if the document is already parsed (the tree
+	// was inserted via a WebSocket update after load) and otherwise defer it to
+	// DOMContentLoaded.
 	b = append(b, `(function(){var i=function(){window["jawstree_"+`...)
 	b = strconv.AppendQuote(b, tree)
 	b = append(b, `]=jawstreeNew(`...)

--- a/jawstree/initscript.go
+++ b/jawstree/initscript.go
@@ -4,11 +4,14 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+
+	"github.com/linkdata/jaws"
 )
 
 const (
-	initScriptPath    = "/jaws/.jawstree"
-	initScriptPattern = initScriptPath + "/{tree}/{options}"
+	initScriptPath           = "/jaws/.jawstree"
+	initScriptPattern        = initScriptPath + "/{tree}/{options}"
+	readyInitCallMaxOverhead = len(`{"id":"Jid.","path":"jawstreeInit","data":{"tree":"","options":}}`) + 40
 )
 
 var (
@@ -36,10 +39,26 @@ func initScriptURL(tree string, options Option) string {
 	return initScriptPath + "/" + url.PathEscape(tree) + "/" + strconv.FormatInt(int64(options), 10)
 }
 
+func appendReadyInitCallData(b []byte, id jaws.Jid, tree string, options Option) []byte {
+	if b == nil {
+		// Reserve the fixed JSON syntax plus 20 decimal digits each for the Jid and
+		// options. Tree names need no escaping beyond quotes because New validates
+		// them with isSafeTreeName.
+		b = make([]byte, 0, len(tree)+readyInitCallMaxOverhead)
+	}
+	b = append(b, `{"id":`...)
+	b = id.AppendQuote(b)
+	b = append(b, `,"path":"jawstreeInit","data":{"tree":`...)
+	b = strconv.AppendQuote(b, tree)
+	b = append(b, `,"options":`...)
+	b = strconv.AppendInt(b, int64(options), 10)
+	b = append(b, `}}`...)
+	return b
+}
+
 func appendInitScript(b []byte, tree string, options Option) []byte {
-	// Run the initializer immediately if the document is already parsed (the tree
-	// was inserted via a WebSocket update after load) and otherwise defer it to
-	// DOMContentLoaded.
+	// Run the initializer immediately when this external script loads after the
+	// document is parsed, and otherwise defer it to DOMContentLoaded.
 	b = append(b, `(function(){var i=function(){window["jawstree_"+`...)
 	b = strconv.AppendQuote(b, tree)
 	b = append(b, `]=jawstreeNew(`...)

--- a/jawstree/initscript_benchmark_test.go
+++ b/jawstree/initscript_benchmark_test.go
@@ -55,9 +55,9 @@ func BenchmarkTreeJawsRender(b *testing.B) {
 		}
 
 		b.StopTimer()
-		// Queue a same-element marker after any initializer and wake the live
-		// Request loop. Draining through that marker leaves the real queue empty for
-		// the next measured render on both the script and Call implementations.
+		// Queue a same-element marker and wake the live Request loop. Draining
+		// through that marker leaves the real queue empty for the next measured
+		// render, including if rendering later gains another queued operation.
 		elems[len(elems)-1].SetValue("benchmark-drain")
 		tr.InCh <- wire.WsMsg{}
 		for {

--- a/jawstree/initscript_benchmark_test.go
+++ b/jawstree/initscript_benchmark_test.go
@@ -1,0 +1,76 @@
+package jawstree
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/linkdata/deadlock"
+	"github.com/linkdata/jaws"
+	"github.com/linkdata/jaws/jawstest"
+	"github.com/linkdata/jaws/lib/ui"
+	"github.com/linkdata/jaws/lib/what"
+	"github.com/linkdata/jaws/lib/wire"
+)
+
+var treeRenderSink string
+
+// BenchmarkTreeJawsRender measures rendering a Tree into a fresh buffer and its
+// real Request queue.
+func BenchmarkTreeJawsRender(b *testing.B) {
+	jw, err := jaws.New()
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer jw.Close()
+	go jw.Serve()
+
+	tr := jawstest.NewTestRequest(jw, nil)
+	defer func() {
+		tr.Close()
+		<-tr.DoneCh
+	}()
+	<-tr.ReadyCh
+
+	root := &Node{Children: []*Node{{Name: "Documents"}}}
+	var mu deadlock.RWMutex
+	tree := New("benchmark_tree", ui.NewJsVar(&mu, root), InitiallyExpanded|SearchEnabled)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	elems := make([]*jaws.Element, 0, 64)
+	for renderedCount := 0; renderedCount < b.N; {
+		b.StopTimer()
+		elems = elems[:0]
+		for range min(64, b.N-renderedCount) {
+			elems = append(elems, tr.NewElement(tree))
+		}
+		b.StartTimer()
+
+		for _, elem := range elems {
+			var rendered strings.Builder
+			if err = tree.JawsRender(elem, &rendered, nil); err != nil {
+				b.Fatal(err)
+			}
+			treeRenderSink = rendered.String()
+		}
+
+		b.StopTimer()
+		// Queue a same-element marker after any initializer and wake the live
+		// Request loop. Draining through that marker leaves the real queue empty for
+		// the next measured render on both the script and Call implementations.
+		elems[len(elems)-1].SetValue("benchmark-drain")
+		tr.InCh <- wire.WsMsg{}
+		for {
+			msg := <-tr.OutCh
+			if msg.What == what.Value {
+				break
+			}
+		}
+		for _, elem := range elems {
+			tr.DeleteElement(elem)
+		}
+		renderedCount += len(elems)
+		b.StartTimer()
+	}
+	b.StopTimer()
+}

--- a/jawstree/js_test.go
+++ b/jawstree/js_test.go
@@ -56,6 +56,47 @@ eval(src);
 	return out.String()
 }
 
+func TestJawstreeJS_InitUsesPreloadedRoot(t *testing.T) {
+	raw := runJawstreeJSSnippet(t, `
+const root = { children: [{ id: "children.0", name: "Documents" }] };
+let got = null;
+const initialized = { ready: true };
+window["jawstreeroot_dynamic"] = root;
+jawstreeNew = function(tree, data, options) {
+	got = { tree: tree, data: data, options: options };
+	return initialized;
+};
+
+jawstreeInit({ tree: "dynamic", options: 3 });
+process.stdout.write(JSON.stringify({
+	got: got,
+	usesRoot: got.data === root,
+	stored: window["jawstree_dynamic"] === initialized
+}));
+`)
+
+	var got struct {
+		Got struct {
+			Tree    string `json:"tree"`
+			Options int    `json:"options"`
+		} `json:"got"`
+		UsesRoot bool `json:"usesRoot"`
+		Stored   bool `json:"stored"`
+	}
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unexpected JSON output %q: %v", raw, err)
+	}
+	if got.Got.Tree != "dynamic" || got.Got.Options != 3 {
+		t.Fatalf("initializer arguments = %+v, want tree=dynamic options=3", got.Got)
+	}
+	if !got.UsesRoot {
+		t.Fatal("initializer did not use the root seeded by the hidden JsVar")
+	}
+	if !got.Stored {
+		t.Fatal("initializer did not store the constructed tree on window")
+	}
+}
+
 func TestJawstreeJS_SetPathSingleSelectDeselect(t *testing.T) {
 	raw := runJawstreeJSSnippet(t, `
 function run(options, selected, arg) {

--- a/jawstree/regression_test.go
+++ b/jawstree/regression_test.go
@@ -61,9 +61,8 @@ func TestSetup_PrefixVariants(t *testing.T) {
 	}
 }
 
-// TestNew_RejectsInvalidID verifies that New panics on ids that would otherwise
-// fail far downstream (a render-time "illegal jsvar name" and a 400 on the
-// init-script route), while accepting a valid one.
+// TestNew_RejectsInvalidID verifies that New rejects ids that cannot identify the
+// browser-side root variable and tree instance, while accepting a valid one.
 func TestNew_RejectsInvalidID(t *testing.T) {
 	var mu deadlock.RWMutex
 	for _, id := range []string{"", "my-tree", "tree.1", "a b", "with/slash"} {

--- a/jawstree/tree.go
+++ b/jawstree/tree.go
@@ -90,7 +90,7 @@ func New(id string, jsvar *ui.JsVar[Node], options ...Option) (t *Tree) {
 	return
 }
 
-// JawsRender renders the hidden root data element and queues tree initialization.
+// JawsRender renders the tree state and schedules browser initialization.
 func (tree *Tree) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err error) {
 	if len(params) == 0 {
 		params = tree.renderParams[:]

--- a/jawstree/tree.go
+++ b/jawstree/tree.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/linkdata/jaws"
-	"github.com/linkdata/jaws/lib/htmlio"
 	"github.com/linkdata/jaws/lib/ui"
 )
 
@@ -45,10 +44,10 @@ func New(id string, jsvar *ui.JsVar[Node], options ...Option) (t *Tree) {
 	if jsvar.Ptr == nil {
 		panic("jawstree.New: jsvar.Ptr must not be nil")
 	}
-	// id is a URL path segment for the init-script route and the key the browser
-	// uses to bracket-index the tree's globals (window["jawstree_"+id] and
-	// window["jawstreeroot_"+id]). Validating it here turns what would otherwise be
-	// a 400 on the init-script route into an immediate, clear panic.
+	// id is the key the browser uses to bracket-index the tree's globals
+	// (window["jawstree_"+id] and window["jawstreeroot_"+id]), and is also accepted
+	// by the initializer route. Validate it at construction so an invalid browser
+	// identity fails immediately.
 	if !isSafeTreeName(id) {
 		panic("jawstree.New: id must be non-empty and contain only [A-Za-z0-9_$]")
 	}
@@ -59,9 +58,9 @@ func New(id string, jsvar *ui.JsVar[Node], options ...Option) (t *Tree) {
 	for _, opt := range options {
 		t.options |= opt
 	}
-	// options is serialized verbatim into the init-script route, which rejects a
-	// negative value (see serveInitScript). Panic here so a bad Option surfaces as a
-	// clear construction error rather than a silent 400 and a tree that never renders.
+	// options is serialized verbatim into the browser initializer. Panic here so a
+	// bad Option surfaces as a clear construction error rather than a tree that
+	// never renders.
 	if t.options < 0 {
 		panic("jawstree.New: options must be non-negative")
 	}
@@ -87,14 +86,13 @@ func New(id string, jsvar *ui.JsVar[Node], options ...Option) (t *Tree) {
 	return
 }
 
-// JawsRender renders the hidden root data element and tree initialization script.
+// JawsRender renders the hidden root data element and queues tree initialization.
 func (tree *Tree) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err error) {
 	if err = tree.JsVar.JawsRender(elem, w, append([]any{"jawstreeroot_" + tree.id}, params...)); err == nil {
-		var b []byte
-		b = append(b, "\n<script"...)
-		b = htmlio.AppendAttr(b, "src", initScriptURL(tree.id, tree.options))
-		b = append(b, "></script>"...)
-		_, err = w.Write(b)
+		// Dynamic renderers allocate nested Elements after their existing parent.
+		// The Request send queue orders messages by Jid, so the parent's DOM mutation
+		// reaches the browser before this element-scoped initializer Call.
+		elem.JsCall("jawsCallWhenReady", string(appendReadyInitCallData(nil, elem.Jid(), tree.id, tree.options)))
 	}
 	return
 }

--- a/jawstree/tree.go
+++ b/jawstree/tree.go
@@ -22,8 +22,10 @@ var _ jaws.UI = (*Tree)(nil)
 // [Tree.SetSelected]) under the lock is safe, but adding, removing, or reordering Children
 // afterward breaks that mapping and is unsupported on a rendered Tree.
 type Tree struct {
-	id      string // HTML ID of the tree
-	options Option
+	id           string // HTML ID of the tree
+	options      Option
+	renderParams [1]any
+	initCallData string
 	*ui.JsVar[Node]
 }
 
@@ -64,6 +66,8 @@ func New(id string, jsvar *ui.JsVar[Node], options ...Option) (t *Tree) {
 	if t.options < 0 {
 		panic("jawstree.New: options must be non-negative")
 	}
+	t.renderParams[0] = "jawstreeroot_" + t.id
+	t.initCallData = `{"tree":` + strconv.Quote(t.id) + `,"options":` + strconv.FormatInt(int64(t.options), 10) + `}`
 	// Normalize away any nil children before assigning IDs so a node's slice
 	// index (its ID) always matches its position in the compacted wire array
 	// emitted by marshalJSON; otherwise a nil child desyncs the two and client
@@ -88,11 +92,13 @@ func New(id string, jsvar *ui.JsVar[Node], options ...Option) (t *Tree) {
 
 // JawsRender renders the hidden root data element and queues tree initialization.
 func (tree *Tree) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err error) {
-	if err = tree.JsVar.JawsRender(elem, w, append([]any{"jawstreeroot_" + tree.id}, params...)); err == nil {
-		// Dynamic renderers allocate nested Elements after their existing parent.
-		// The Request send queue orders messages by Jid, so the parent's DOM mutation
-		// reaches the browser before this element-scoped initializer Call.
-		elem.JsCall("jawsCallWhenReady", string(appendReadyInitCallData(nil, elem.Jid(), tree.id, tree.options)))
+	if len(params) == 0 {
+		params = tree.renderParams[:]
+	} else {
+		params = append([]any{tree.renderParams[0]}, params...)
+	}
+	if err = tree.JsVar.JawsRender(elem, w, params); err == nil {
+		elem.JsCall("jawstreeInit", tree.initCallData)
 	}
 	return
 }

--- a/jawstree/tree_test.go
+++ b/jawstree/tree_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/linkdata/jaws"
 	"github.com/linkdata/jaws/jawstest"
 	"github.com/linkdata/jaws/lib/ui"
+	"github.com/linkdata/jaws/lib/what"
 	"github.com/linkdata/jaws/lib/wire"
 )
 
@@ -151,19 +152,21 @@ func TestTreeSelectionMethods(t *testing.T) {
 	}
 }
 
-func TestTreeRenderEmitsRootDataAndInitScriptForPageContainer(t *testing.T) {
+func TestTreeRenderEmitsRootDataAndQueuesInitializerForPageContainer(t *testing.T) {
 	jw, err := jaws.New()
 	maybeError(t, err)
 	defer jw.Close()
 
-	rq := jw.NewRequest(nil)
+	httpRequest := httptest.NewRequest(http.MethodGet, "/", nil)
+	rq := jw.NewRequest(httpRequest)
+
 	var mu deadlock.RWMutex
 	root := &Node{Children: []*Node{{Name: "Documents"}}}
 	tree := New("mytree", ui.NewJsVar(&mu, root), InitiallyExpanded)
 	elem := rq.NewElement(tree)
 
 	var body bytes.Buffer
-	if err := tree.JawsRender(elem, &body, nil); err != nil {
+	if err := elem.JawsRender(&body, nil); err != nil {
 		t.Fatal(err)
 	}
 	rendered := body.String()
@@ -175,11 +178,40 @@ func TestTreeRenderEmitsRootDataAndInitScriptForPageContainer(t *testing.T) {
 	if !strings.Contains(rendered, `data-jawsdata=`) || !strings.Contains(rendered, "Documents") {
 		t.Fatalf("rendered tree is missing serialized root data: %q", rendered)
 	}
-	if want := initScriptURL("mytree", InitiallyExpanded); !strings.Contains(rendered, `src="`+want+`"`) {
-		t.Fatalf("rendered tree is missing init script %q: %q", want, rendered)
+	if strings.Contains(rendered, "<script") {
+		t.Fatalf("rendered tree contains a per-render script: %q", rendered)
 	}
 	if !strings.Contains(page, `<div id="mytree"></div>`) {
 		t.Fatalf("page is missing the Quercus container: %q", page)
+	}
+
+	// Match the production lifecycle: initial rendering queues the Call before the
+	// browser claims the Request and starts its WebSocket processing loop.
+	if claimed := jw.UseRequest(rq.JawsKey, httpRequest); claimed != rq {
+		t.Fatal("failed to claim rendered request")
+	}
+	go jw.Serve()
+	inCh, outCh, _, readyCh, doneCh := jw.TestServe(rq, func(recovered any) {
+		if recovered != nil {
+			panic(recovered)
+		}
+	})
+	defer func() {
+		close(inCh)
+		<-doneCh
+	}()
+	<-readyCh
+
+	select {
+	case msg := <-outCh:
+		if msg.What != what.Call || msg.Jid != elem.Jid() {
+			t.Fatalf("initializer message = %+v, want element-scoped Call for %s", msg, elem.Jid())
+		}
+		if want := `jawsCallWhenReady={"id":` + strconv.Quote(elem.Jid().String()) + `,"path":"jawstreeInit","data":{"tree":"mytree","options":2}}`; msg.Data != want {
+			t.Fatalf("initializer data = %q, want %q", msg.Data, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for initial tree initializer")
 	}
 }
 
@@ -355,18 +387,28 @@ func TestTree(t *testing.T) {
 	elem := rq.NewElement(tree)
 
 	var sb strings.Builder
-	err = tree.JawsRender(elem, &sb, nil)
+	err = elem.JawsRender(&sb, nil)
 	maybeError(t, err)
 
-	if strings.Contains(sb.String(), "DOMContentLoaded") {
-		t.Error("unexpected inline script")
+	if strings.Contains(sb.String(), "<script") {
+		t.Error("unexpected per-render script")
 	}
 
+	// The initial render queues one element-scoped initializer. Wake the request
+	// loop and drain it before testing later tree updates.
+	rq.InCh <- wire.WsMsg{}
+	select {
+	case msg := <-rq.OutCh:
+		if msg.What != what.Call || msg.Jid != elem.Jid() || msg.Data != `jawsCallWhenReady={"id":`+strconv.Quote(elem.Jid().String())+`,"path":"jawstreeInit","data":{"tree":"tree","options":1}}` {
+			t.Fatalf("unexpected initial tree message: %+v", msg)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial tree initializer")
+	}
+
+	// The generated route remains available to pages that request it directly,
+	// although Tree rendering initializes through the preloaded adapter.
 	initURL := initScriptURL("tree", SearchEnabled)
-	if !strings.Contains(sb.String(), `<script src="`+initURL+`"></script>`) {
-		t.Errorf("missing init script URL: %q", initURL)
-	}
-
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, initURL, nil))
 	if w.Code != http.StatusOK {
@@ -492,9 +534,8 @@ func (fw *failWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-// TestTree_JawsRenderWriteError verifies Tree.JawsRender propagates a write error from
-// both the inner JsVar payload write (the hidden data <div>, write 1) and the trailing
-// init-script <script> tag write (write 2).
+// TestTree_JawsRenderWriteError verifies Tree.JawsRender propagates a write error
+// from the hidden JsVar data element.
 func TestTree_JawsRenderWriteError(t *testing.T) {
 	jw, err := jaws.New()
 	maybeError(t, err)
@@ -511,11 +552,9 @@ func TestTree_JawsRenderWriteError(t *testing.T) {
 	var mu deadlock.RWMutex
 	tree := New("tree", ui.NewJsVar(&mu, rootnode))
 
-	for _, failOn := range []int{1, 2} {
-		elem := rq.NewElement(tree)
-		if err := tree.JawsRender(elem, &failWriter{failOn: failOn}, nil); !errors.Is(err, errWrite) {
-			t.Errorf("failOn=%d: JawsRender err = %v, want %v", failOn, err, errWrite)
-		}
+	elem := rq.NewElement(tree)
+	if err := tree.JawsRender(elem, &failWriter{failOn: 1}, nil); !errors.Is(err, errWrite) {
+		t.Errorf("JawsRender err = %v, want %v", err, errWrite)
 	}
 }
 
@@ -532,13 +571,26 @@ func TestTree_JawsPathSetIgnoresNonSelectedPath(t *testing.T) {
 		t.Fatal("nil test request")
 	}
 	defer rq.Close()
+	<-rq.ReadyCh
 
 	rootnode := &Node{Name: "root", Children: []*Node{{Name: "child"}}}
 	var mu deadlock.RWMutex
 	tree := New("tree", ui.NewJsVar(&mu, rootnode))
 	elem := rq.NewElement(tree)
 	var sb strings.Builder
-	maybeError(t, tree.JawsRender(elem, &sb, nil))
+	maybeError(t, elem.JawsRender(&sb, nil))
+
+	// Flush the initializer queued by rendering so the assertion below isolates
+	// the messages produced by JawsPathSet.
+	rq.InCh <- wire.WsMsg{}
+	select {
+	case <-t.Context().Done():
+		t.Fatal("expected a jawstreeInit message")
+	case msg := <-rq.OutCh:
+		if msg.What != what.Call || msg.Jid != elem.Jid() || msg.Data != `jawsCallWhenReady={"id":`+strconv.Quote(elem.Jid().String())+`,"path":"jawstreeInit","data":{"tree":"tree","options":0}}` {
+			t.Fatalf("unexpected initial tree message: %+v", msg)
+		}
+	}
 
 	child := rootnode.Children[0]
 	// A non-".selected" path must be ignored (no broadcast)...

--- a/jawstree/tree_test.go
+++ b/jawstree/tree_test.go
@@ -207,7 +207,7 @@ func TestTreeRenderEmitsRootDataAndQueuesInitializerForPageContainer(t *testing.
 		if msg.What != what.Call || msg.Jid != elem.Jid() {
 			t.Fatalf("initializer message = %+v, want element-scoped Call for %s", msg, elem.Jid())
 		}
-		if want := `jawsCallWhenReady={"id":` + strconv.Quote(elem.Jid().String()) + `,"path":"jawstreeInit","data":{"tree":"mytree","options":2}}`; msg.Data != want {
+		if want := `jawstreeInit={"tree":"mytree","options":2}`; msg.Data != want {
 			t.Fatalf("initializer data = %q, want %q", msg.Data, want)
 		}
 	case <-time.After(time.Second):
@@ -394,12 +394,11 @@ func TestTree(t *testing.T) {
 		t.Error("unexpected per-render script")
 	}
 
-	// The initial render queues one element-scoped initializer. Wake the request
-	// loop and drain it before testing later tree updates.
+	// Drain the initializer so later assertions isolate update messages.
 	rq.InCh <- wire.WsMsg{}
 	select {
 	case msg := <-rq.OutCh:
-		if msg.What != what.Call || msg.Jid != elem.Jid() || msg.Data != `jawsCallWhenReady={"id":`+strconv.Quote(elem.Jid().String())+`,"path":"jawstreeInit","data":{"tree":"tree","options":1}}` {
+		if msg.What != what.Call || msg.Jid != elem.Jid() || msg.Data != `jawstreeInit={"tree":"tree","options":1}` {
 			t.Fatalf("unexpected initial tree message: %+v", msg)
 		}
 	case <-time.After(2 * time.Second):
@@ -580,14 +579,14 @@ func TestTree_JawsPathSetIgnoresNonSelectedPath(t *testing.T) {
 	var sb strings.Builder
 	maybeError(t, elem.JawsRender(&sb, nil))
 
-	// Flush the initializer queued by rendering so the assertion below isolates
+	// Drain the initializer queued by rendering so the assertion below isolates
 	// the messages produced by JawsPathSet.
 	rq.InCh <- wire.WsMsg{}
 	select {
 	case <-t.Context().Done():
 		t.Fatal("expected a jawstreeInit message")
 	case msg := <-rq.OutCh:
-		if msg.What != what.Call || msg.Jid != elem.Jid() || msg.Data != `jawsCallWhenReady={"id":`+strconv.Quote(elem.Jid().String())+`,"path":"jawstreeInit","data":{"tree":"tree","options":0}}` {
+		if msg.What != what.Call || msg.Jid != elem.Jid() || msg.Data != `jawstreeInit={"tree":"tree","options":0}` {
 			t.Fatalf("unexpected initial tree message: %+v", msg)
 		}
 	}

--- a/lib/assets/jaws.js
+++ b/lib/assets/jaws.js
@@ -13,44 +13,6 @@
 var jaws = null;
 var jawsIdPrefix = 'Jid.';
 var jawsDebug = false;
-var jawsDocumentReady = document.readyState === 'complete';
-var jawsReadyCalls = [];
-
-function jawsInvokeReadyCall(arg) {
-	if (document.getElementById(arg.id) !== null) {
-		jawsVar(arg.path, arg.data, 'Call');
-	}
-}
-
-function jawsCallWhenReady(arg) {
-	if (jawsDocumentReady) {
-		jawsInvokeReadyCall(arg);
-	} else {
-		jawsReadyCalls.push(arg);
-	}
-}
-
-function jawsSetDocumentReady() {
-	if (!jawsDocumentReady) {
-		jawsDocumentReady = true;
-		const calls = jawsReadyCalls;
-		jawsReadyCalls = [];
-		for (let i = 0; i < calls.length; i++) {
-			try {
-				jawsInvokeReadyCall(calls[i]);
-			} catch (err) {
-				console.error("jaws: deferred Call " + calls[i].path + ": " + err);
-			}
-		}
-	}
-}
-
-if (!jawsDocumentReady) {
-	window.addEventListener('DOMContentLoaded', jawsSetDocumentReady);
-	// If jaws.js is loaded after DOMContentLoaded but before load, the load event
-	// still releases calls queued while later scripts finish loading.
-	window.addEventListener('load', jawsSetDocumentReady);
-}
 
 function jawsContains(a, v) {
 	return a.includes(String(v).trim().toLowerCase());
@@ -597,10 +559,17 @@ function jawsConnect() {
 	jaws.addEventListener('error', jawsFailed);
 }
 
+function jawsConnectWhenReady() {
+	window.removeEventListener('DOMContentLoaded', jawsConnectWhenReady);
+	window.removeEventListener('load', jawsConnectWhenReady);
+	jawsConnect();
+}
+
 window.jawsNames = {};
 jawsAttachChildren(document);
-if (document.readyState === 'complete' || document.readyState === 'interactive') {
+if (document.readyState === 'complete') {
 	jawsConnect();
 } else {
-	window.addEventListener('DOMContentLoaded', jawsConnect);
+	window.addEventListener('DOMContentLoaded', jawsConnectWhenReady);
+	window.addEventListener('load', jawsConnectWhenReady);
 }

--- a/lib/assets/jaws.js
+++ b/lib/assets/jaws.js
@@ -13,6 +13,44 @@
 var jaws = null;
 var jawsIdPrefix = 'Jid.';
 var jawsDebug = false;
+var jawsDocumentReady = document.readyState === 'complete';
+var jawsReadyCalls = [];
+
+function jawsInvokeReadyCall(arg) {
+	if (document.getElementById(arg.id) !== null) {
+		jawsVar(arg.path, arg.data, 'Call');
+	}
+}
+
+function jawsCallWhenReady(arg) {
+	if (jawsDocumentReady) {
+		jawsInvokeReadyCall(arg);
+	} else {
+		jawsReadyCalls.push(arg);
+	}
+}
+
+function jawsSetDocumentReady() {
+	if (!jawsDocumentReady) {
+		jawsDocumentReady = true;
+		const calls = jawsReadyCalls;
+		jawsReadyCalls = [];
+		for (let i = 0; i < calls.length; i++) {
+			try {
+				jawsInvokeReadyCall(calls[i]);
+			} catch (err) {
+				console.error("jaws: deferred Call " + calls[i].path + ": " + err);
+			}
+		}
+	}
+}
+
+if (!jawsDocumentReady) {
+	window.addEventListener('DOMContentLoaded', jawsSetDocumentReady);
+	// If jaws.js is loaded after DOMContentLoaded but before load, the load event
+	// still releases calls queued while later scripts finish loading.
+	window.addEventListener('load', jawsSetDocumentReady);
+}
 
 function jawsContains(a, v) {
 	return a.includes(String(v).trim().toLowerCase());

--- a/lib/assets/js_benchmark_test.go
+++ b/lib/assets/js_benchmark_test.go
@@ -1,0 +1,60 @@
+package assets
+
+import (
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"testing"
+)
+
+func BenchmarkJawsJSMessageDispatch(b *testing.B) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		b.Skip("node executable not available")
+	}
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		b.Fatal("runtime.Caller failed")
+	}
+	jsPath := filepath.Join(filepath.Dir(file), "jaws.js")
+	const frame = "RAttr\tJid.1\t\"title\"\n"
+	const script = `
+const fs = require("fs");
+const src = fs.readFileSync(process.argv[1], "utf8");
+const elem = { id: "Jid.1", removeAttribute: function() {} };
+global.window = {
+    location: { protocol: "http:", host: "example.test" },
+    addEventListener: function() {},
+    jawsNames: {}
+};
+global.document = {
+    readyState: "loading",
+    querySelector: function(selector) {
+        return selector === 'meta[name="jawsKey"]' ? { content: "123" } : null;
+    },
+    querySelectorAll: function() { return { forEach: function() {} }; },
+    getElementById: function(id) { return id === elem.id ? elem : null; }
+};
+global.XMLHttpRequest = function() {};
+global.Event = function() {};
+global.Node = function() {};
+global.WebSocket = function() {};
+eval(src);
+if (typeof jawsSetDocumentReady === "function") {
+    jawsSetDocumentReady();
+}
+const event = { data: "RAttr\tJid.1\t\"title\"\n" };
+const count = Number(process.argv[2]);
+for (let i = 0; i < count; i++) {
+    jawsMessage(event);
+}
+`
+
+	cmd := exec.CommandContext(b.Context(), node, "-e", script, jsPath, strconv.Itoa(b.N))
+	b.SetBytes(int64(len(frame)))
+	b.ResetTimer()
+	if output, err := cmd.CombinedOutput(); err != nil {
+		b.Fatalf("node failed: %v\n%s", err, output)
+	}
+}

--- a/lib/assets/js_test.go
+++ b/lib/assets/js_test.go
@@ -189,10 +189,13 @@ func runJawsJSSnippet(t *testing.T, snippet string) string {
 	script := `
 const fs = require("fs");
 const src = fs.readFileSync(process.argv[1], "utf8");
+const windowListeners = {};
 
 global.window = {
 	location: { protocol: "http:", host: "example.test", reload: function(){}, assign: function(){} },
-	addEventListener: function(){},
+	addEventListener: function(name, fn){
+		(windowListeners[name] ||= []).push(fn);
+	},
 	jawsNames: {},
 };
 global.document = {
@@ -211,6 +214,9 @@ global.XMLHttpRequest = function(){};
 global.Event = function(){};
 global.Node = function(){};
 global.WebSocket = function(){};
+global.jawsDispatchWindowEvent = function(name) {
+	(windowListeners[name] || []).slice().forEach(function(fn) { fn({ type: name }); });
+};
 
 eval(src);
 ` + snippet
@@ -223,6 +229,108 @@ eval(src);
 		t.Fatalf("node failed: %v\n%s", err, out.String())
 	}
 	return out.String()
+}
+
+func TestJawsJS_CallWhenReadyRetainsCallUntilDependencyLoads(t *testing.T) {
+	raw := runJawsJSSnippet(t, `
+const elem = { id: "Jid.1" };
+document.getElementById = function(id) { return id === elem.id ? elem : null; };
+// The Node harness keeps window separate from the eval scope; classic browser
+// scripts expose top-level function declarations on window.
+window.jawsCallWhenReady = jawsCallWhenReady;
+
+jawsPerform(
+	"Call",
+	"Jid.1",
+	'jawsCallWhenReady={"id":"Jid.1","path":"late.init","data":{"value":42}}'
+);
+const before = window.late;
+window.late = {
+	init: function(arg) { window.readyValue = arg.value; }
+};
+WebSocket = function() {
+	this.addEventListener = function() {};
+};
+jawsDispatchWindowEvent("DOMContentLoaded");
+
+process.stdout.write(JSON.stringify({ before: before, after: window.readyValue }));
+`)
+
+	var got struct {
+		Before any `json:"before"`
+		After  int `json:"after"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &got); err != nil {
+		t.Fatalf("failed to parse snippet output %q: %v", raw, err)
+	}
+	if got.Before != nil {
+		t.Fatalf("deferred dependency existed before it loaded: %#v", got.Before)
+	}
+	if got.After != 42 {
+		t.Fatalf("deferred call value = %d, want 42", got.After)
+	}
+}
+
+func TestJawsJS_CallWhenReadySkipsRemovedElement(t *testing.T) {
+	raw := runJawsJSSnippet(t, `
+const elements = {};
+const parent = new Node();
+parent.id = "Jid.10";
+parent.removeChild = function(elem) { delete elements[elem.id]; };
+elements[parent.id] = parent;
+function testElement(id, parentElement) {
+	const elem = new Node();
+	elem.id = id;
+	elem.parentElement = parentElement;
+	elem.querySelectorAll = function() { return []; };
+	elements[id] = elem;
+	return elem;
+}
+testElement("Jid.1", parent);
+testElement("Jid.2", parent);
+document.getElementById = function(id) { return elements[id] || null; };
+window.jawsCallWhenReady = jawsCallWhenReady;
+
+jawsPerform(
+	"Call",
+	"Jid.1",
+	'jawsCallWhenReady={"id":"Jid.1","path":"late.removed","data":{"value":42}}'
+);
+jawsPerform(
+	"Call",
+	"Jid.2",
+	'jawsCallWhenReady={"id":"Jid.2","path":"late.retained","data":{"value":84}}'
+);
+jawsPerform("Remove", parent.id, '"Jid.1"');
+
+window.late = {
+	removed: function(arg) { window.removedValue = arg.value; },
+	retained: function(arg) { window.retainedValue = arg.value; }
+};
+WebSocket = function() {
+	this.addEventListener = function() {};
+};
+jawsDispatchWindowEvent("DOMContentLoaded");
+
+process.stdout.write(JSON.stringify({
+	removed: window.removedValue,
+	retained: window.retainedValue
+}));
+`)
+
+	var got struct {
+		Removed  any `json:"removed"`
+		Retained int `json:"retained"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &got); err != nil {
+		t.Fatalf("failed to parse snippet output %q: %v", raw, err)
+	}
+	if got.Removed != nil {
+		t.Fatalf("removed element's deferred call ran: %#v", got.Removed)
+	}
+	if got.Retained != 84 {
+		t.Fatalf("retained element's deferred call value = %d, want 84", got.Retained)
+	}
 }
 
 func TestJawsJS_JsVarNestedPathUsesTopLevelNameRouting(t *testing.T) {

--- a/lib/assets/js_test.go
+++ b/lib/assets/js_test.go
@@ -196,6 +196,11 @@ global.window = {
 	addEventListener: function(name, fn){
 		(windowListeners[name] ||= []).push(fn);
 	},
+	removeEventListener: function(name, fn){
+		windowListeners[name] = (windowListeners[name] || []).filter(function(other) {
+			return other !== fn;
+		});
+	},
 	jawsNames: {},
 };
 global.document = {
@@ -231,105 +236,48 @@ eval(src);
 	return out.String()
 }
 
-func TestJawsJS_CallWhenReadyRetainsCallUntilDependencyLoads(t *testing.T) {
-	raw := runJawsJSSnippet(t, `
-const elem = { id: "Jid.1" };
-document.getElementById = function(id) { return id === elem.id ? elem : null; };
-// The Node harness keeps window separate from the eval scope; classic browser
-// scripts expose top-level function declarations on window.
-window.jawsCallWhenReady = jawsCallWhenReady;
-
-jawsPerform(
-	"Call",
-	"Jid.1",
-	'jawsCallWhenReady={"id":"Jid.1","path":"late.init","data":{"value":42}}'
-);
-const before = window.late;
-window.late = {
-	init: function(arg) { window.readyValue = arg.value; }
-};
-WebSocket = function() {
-	this.addEventListener = function() {};
-};
-jawsDispatchWindowEvent("DOMContentLoaded");
-
-process.stdout.write(JSON.stringify({ before: before, after: window.readyValue }));
-`)
-
-	var got struct {
-		Before any `json:"before"`
-		After  int `json:"after"`
-	}
-	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &got); err != nil {
-		t.Fatalf("failed to parse snippet output %q: %v", raw, err)
-	}
-	if got.Before != nil {
-		t.Fatalf("deferred dependency existed before it loaded: %#v", got.Before)
-	}
-	if got.After != 42 {
-		t.Fatalf("deferred call value = %d, want 42", got.After)
-	}
+func TestJawsJS_ConnectsAfterDeferredAssets(t *testing.T) {
+	for _, readyEvent := range []string{"DOMContentLoaded", "load"} {
+		t.Run(readyEvent, func(t *testing.T) {
+			raw := runJawsJSSnippet(t, `
+let socketCount = 0;
+let connectedAfterAssets = false;
+function FakeSocket() {
+	this.readyState = 1;
+	socketCount++;
+	connectedAfterAssets =
+		typeof window.jawstreeInit === "function" &&
+		typeof window.Treeview === "function";
 }
+FakeSocket.prototype.addEventListener = function() {};
+WebSocket = FakeSocket;
 
-func TestJawsJS_CallWhenReadySkipsRemovedElement(t *testing.T) {
-	raw := runJawsJSSnippet(t, `
-const elements = {};
-const parent = new Node();
-parent.id = "Jid.10";
-parent.removeChild = function(elem) { delete elements[elem.id]; };
-elements[parent.id] = parent;
-function testElement(id, parentElement) {
-	const elem = new Node();
-	elem.id = id;
-	elem.parentElement = parentElement;
-	elem.querySelectorAll = function() { return []; };
-	elements[id] = elem;
-	return elem;
-}
-testElement("Jid.1", parent);
-testElement("Jid.2", parent);
-document.getElementById = function(id) { return elements[id] || null; };
-window.jawsCallWhenReady = jawsCallWhenReady;
-
-jawsPerform(
-	"Call",
-	"Jid.1",
-	'jawsCallWhenReady={"id":"Jid.1","path":"late.removed","data":{"value":42}}'
-);
-jawsPerform(
-	"Call",
-	"Jid.2",
-	'jawsCallWhenReady={"id":"Jid.2","path":"late.retained","data":{"value":84}}'
-);
-jawsPerform("Remove", parent.id, '"Jid.1"');
-
-window.late = {
-	removed: function(arg) { window.removedValue = arg.value; },
-	retained: function(arg) { window.retainedValue = arg.value; }
-};
-WebSocket = function() {
-	this.addEventListener = function() {};
-};
+const before = socketCount;
+window.jawstreeInit = function() {};
+window.Treeview = function() {};
+jawsDispatchWindowEvent("`+readyEvent+`");
 jawsDispatchWindowEvent("DOMContentLoaded");
+jawsDispatchWindowEvent("load");
 
 process.stdout.write(JSON.stringify({
-	removed: window.removedValue,
-	retained: window.retainedValue
+	before: before,
+	after: socketCount,
+	connectedAfterAssets: connectedAfterAssets
 }));
 `)
 
-	var got struct {
-		Removed  any `json:"removed"`
-		Retained int `json:"retained"`
-	}
-	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &got); err != nil {
-		t.Fatalf("failed to parse snippet output %q: %v", raw, err)
-	}
-	if got.Removed != nil {
-		t.Fatalf("removed element's deferred call ran: %#v", got.Removed)
-	}
-	if got.Retained != 84 {
-		t.Fatalf("retained element's deferred call value = %d, want 84", got.Retained)
+			var got struct {
+				Before               int  `json:"before"`
+				After                int  `json:"after"`
+				ConnectedAfterAssets bool `json:"connectedAfterAssets"`
+			}
+			if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &got); err != nil {
+				t.Fatalf("failed to parse snippet output %q: %v", raw, err)
+			}
+			if got.Before != 0 || got.After != 1 || !got.ConnectedAfterAssets {
+				t.Fatalf("connection state = %+v, want one connection after deferred assets", got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replace per-render initializer `<script>` tags with a direct, element-scoped `jawstreeInit` Call through the preloaded browser adapter.
- Open the initial WebSocket at `DOMContentLoaded`, after ordered deferred scripts have executed. A `load` fallback covers `jaws.js` loaded after `DOMContentLoaded`; both listeners are removed before connecting, so they cannot open two sockets.
- Leave WebSocket frame processing sequential and unbuffered, preserving wire order for every JaWS operation.
- Keep the generated initializer route for pages that request it directly.
- Precompute the Tree render parameter and initializer payload to avoid rebuilding them for every render.

## Production reachability

Dirtying the source of a supported live `ui.Container` makes the normal Request processing loop render a newly added `jawstree.Tree`. It produces a parent Append, parent Order, child initializer Call, and subsequent `jawstreeSet` Call. The former per-render `<script>` was inserted by the shipped DOM-update path, where it did not execute, so the Tree remained uninitialized in an ordinary production update.

The regression starts a live Jaws Request/Serve loop, dirties a real Container source, and obtains those genuine server-generated frames. Headless Firefox loads the shipped `jaws.js`, `jawstree.js`, and `treeview.js` as external deferred assets. A deterministic WebSocket substitute records that the connection is constructed only after `jawstreeInit` and `Treeview` exist, delivers the genuine frame, and verifies that both initialization and the queued `Updated` state render.

The initial-render test separately claims a normally rendered Request through `UseRequest` and verifies its initializer is delivered by the Serve loop. Neither regression manufactures a Call by invoking an internal browser API directly.

## Timeout tradeoff

The initial WebSocket now claims the Request only after deferred scripts finish. If they take longer than the configured WebSocket timeout (10 seconds by default), the Request can expire and the page can fail. This is intentional: the timeout is configurable, and an asset set that cannot become ready within it is treated as a failed request.

## Performance and size

`benchstat`, 10 runs, original PR head `2281146` versus this branch:

- `BenchmarkTreeJawsRender`: 1.477 → 1.329 µs/op (`-10.05%`, `p=0.000`), 2.022 → 1.709 KiB/op (`-15.50%`), 33 → 29 allocs/op (`-12.12%`).
- `BenchmarkJawsJSMessageDispatch`: 81.51 → 80.78 ns/op, statistically unchanged (`p=0.404`), with 0 B/op and 0 allocs/op on both sides.

Combined core plus jawstree adapter JavaScript, raw / gzip-6:

- Base (`main` after #100): 18,925 / 5,636 bytes.
- Original PR combined with #100: 20,077 / 5,918 bytes.
- Current: 19,299 / 5,689 bytes.

The cleanup removes 778 raw / 229 gzip bytes from the original PR. The final change is +374 raw / +53 gzip bytes over the base, and adds 15 JS lines rather than 46.

Both benchmarks remain in the tree as regression guards.

## Verification

- `go test -race ./...`
- Firefox production lifecycle regression, 3 consecutive runs
- `gofmt` and `gofumpt`: clean
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run ./...`: 0 issues

## Stack

Base: `main`. Independent PR.
