### PR TITLE
Reject non-reflexive tag keys

### DIFF
--- a/lib/tag/doc.go
+++ b/lib/tag/doc.go
@@ -1,7 +1,7 @@
 // Package tag expands JaWS tag values into comparable keys that identify
 // elements during dirtying, broadcasts and event routing.
 //
-// [TagExpand] rejects values that are not usable as hashable tag keys, including
-// values whose static type is comparable but whose runtime contents are not and
-// values such as NaN that do not equal themselves.
+// [TagExpand] rejects expanded key values that are not usable as hashable tags,
+// including values whose static type is comparable but whose runtime contents
+// are not and values such as NaN that do not equal themselves.
 package tag

--- a/lib/tag/doc.go
+++ b/lib/tag/doc.go
@@ -2,5 +2,6 @@
 // elements during dirtying, broadcasts and event routing.
 //
 // [TagExpand] rejects values that are not usable as hashable tag keys, including
-// values whose static type is comparable but whose runtime contents are not.
+// values whose static type is comparable but whose runtime contents are not and
+// values such as NaN that do not equal themselves.
 package tag

--- a/lib/tag/doc.go
+++ b/lib/tag/doc.go
@@ -1,8 +1,8 @@
 // Package tag expands JaWS tag values into comparable keys that identify
 // elements during dirtying, broadcasts and event routing.
 //
-// [TagExpand] rejects expanded key values that are not usable as hashable tags,
-// including values whose static type is comparable but whose runtime contents
-// are not, and otherwise admissible named or composite values containing NaN
-// that do not equal themselves.
+// [TagExpand] rejects expanded key values that cannot be matched reliably as
+// tags, including values whose static type is comparable but whose runtime
+// contents are not, and otherwise admissible values containing NaN that do not
+// equal themselves.
 package tag

--- a/lib/tag/doc.go
+++ b/lib/tag/doc.go
@@ -3,5 +3,6 @@
 //
 // [TagExpand] rejects expanded key values that are not usable as hashable tags,
 // including values whose static type is comparable but whose runtime contents
-// are not and values such as NaN that do not equal themselves.
+// are not, and otherwise admissible named or composite values containing NaN
+// that do not equal themselves.
 package tag

--- a/lib/tag/errnotusableastag.go
+++ b/lib/tag/errnotusableastag.go
@@ -8,8 +8,8 @@ import (
 
 // ErrNotUsableAsTag is returned when a value cannot be used as a tag.
 //
-// It also matches [ErrNotComparable] via [errors.Is], because a non-comparable
-// value is one reason a value cannot be used as a tag.
+// A tag must be comparable and equal to itself so that it remains reachable as a
+// map key. This error also matches [ErrNotComparable] via [errors.Is].
 var ErrNotUsableAsTag errNotUsableAsTag
 
 type errNotUsableAsTag struct {
@@ -26,7 +26,7 @@ func (e errNotUsableAsTag) Error() (s string) {
 	if e.tagGetterType != nil {
 		return s + fmt.Sprintf("; found nested TagGetter at %s (%s); hint: implement JawsGetTag(tag.Context) on this type to delegate to that value, or pass that nested TagGetter directly", e.tagGetterPath, e.tagGetterType)
 	}
-	return s + "; found no nested TagGetter; hint: use a comparable tag value, or implement JawsGetTag(tag.Context) and return a comparable tag"
+	return s + "; found no nested TagGetter; hint: use a comparable tag value that equals itself, or implement JawsGetTag(tag.Context) and return one"
 }
 
 func (errNotUsableAsTag) Is(target error) bool {
@@ -34,16 +34,24 @@ func (errNotUsableAsTag) Is(target error) bool {
 }
 
 // NewErrNotUsableAsTag returns [ErrNotUsableAsTag] if x cannot be used as a tag.
+//
+// Nil, comparable and reflexive values return nil. Primitive values that
+// [TagExpand] classifies as [ErrIllegalTagType] are otherwise outside this
+// constructor's validation.
 func NewErrNotUsableAsTag(x any) error {
-	if err := NewErrNotComparable(x); err != nil {
-		retErr := errNotUsableAsTag{t: reflect.TypeOf(x)}
-		if path, tgType, ok := FindTagGetter(x); ok {
-			retErr.tagGetterPath = path
-			retErr.tagGetterType = tgType
-		}
-		return retErr
+	if x == nil || usableAsTag(x) {
+		return nil
 	}
-	return nil
+	return newErrNotUsableAsTag(x)
+}
+
+func newErrNotUsableAsTag(x any) (err error) {
+	retErr := errNotUsableAsTag{t: reflect.TypeOf(x)}
+	if path, tgType, ok := FindTagGetter(x); ok {
+		retErr.tagGetterPath = path
+		retErr.tagGetterType = tgType
+	}
+	return retErr
 }
 
 var tagGetterType = reflect.TypeFor[TagGetter]()

--- a/lib/tag/errnotusableastag.go
+++ b/lib/tag/errnotusableastag.go
@@ -33,11 +33,12 @@ func (errNotUsableAsTag) Is(target error) bool {
 	return target == ErrNotUsableAsTag || target == ErrNotComparable
 }
 
-// NewErrNotUsableAsTag returns [ErrNotUsableAsTag] if x cannot be used as a tag.
+// NewErrNotUsableAsTag returns [ErrNotUsableAsTag] for an unusable tag key.
 //
-// Nil, comparable and reflexive values return nil. Primitive values that
-// [TagExpand] classifies as [ErrIllegalTagType] are otherwise outside this
-// constructor's validation.
+// It returns nil for nil and for values that are comparable at runtime and equal
+// themselves. It only validates key usability; it does not apply [TagExpand]'s
+// tag-type policy, so a value may pass this check and still be rejected with
+// [ErrIllegalTagType].
 func NewErrNotUsableAsTag(x any) error {
 	if x == nil || usableAsTag(x) {
 		return nil

--- a/lib/tag/errnotusableastag.go
+++ b/lib/tag/errnotusableastag.go
@@ -37,7 +37,7 @@ func (errNotUsableAsTag) Is(target error) bool {
 // NewErrNotUsableAsTag returns [ErrNotUsableAsTag] for an unusable tag key.
 //
 // It returns nil for nil and for values that are comparable at runtime and equal
-// themselves. It only validates key usability; it does not apply [TagExpand]'s
+// to themselves. It only validates key usability; it does not apply [TagExpand]'s
 // tag-type policy, so a value may pass this check and still be rejected with
 // [ErrIllegalTagType].
 func NewErrNotUsableAsTag(x any) error {

--- a/lib/tag/errnotusableastag.go
+++ b/lib/tag/errnotusableastag.go
@@ -8,8 +8,9 @@ import (
 
 // ErrNotUsableAsTag is returned when a value cannot be used as a tag.
 //
-// A tag must be comparable and equal to itself so that it remains reachable as a
-// map key. This error also matches [ErrNotComparable] via [errors.Is].
+// A tag key must be comparable at runtime and equal to itself so later dirtying,
+// broadcasts and event routing can match it reliably. This error also matches
+// [ErrNotComparable] via [errors.Is].
 var ErrNotUsableAsTag errNotUsableAsTag
 
 type errNotUsableAsTag struct {

--- a/lib/tag/nonreflexive_test.go
+++ b/lib/tag/nonreflexive_test.go
@@ -6,10 +6,12 @@ import (
 	"testing"
 )
 
-type testFloat32Tag float32
-type testFloat64Tag float64
-type testComplex64Tag complex64
-type testComplex128Tag complex128
+type (
+	testFloat32Tag    float32
+	testFloat64Tag    float64
+	testComplex64Tag  complex64
+	testComplex128Tag complex128
+)
 
 func TestTagExpandRejectsNonReflexiveTags(t *testing.T) {
 	tests := []struct {

--- a/lib/tag/nonreflexive_test.go
+++ b/lib/tag/nonreflexive_test.go
@@ -1,0 +1,87 @@
+package tag
+
+import (
+	"errors"
+	"math"
+	"testing"
+)
+
+type testFloat32Tag float32
+type testFloat64Tag float64
+type testComplex64Tag complex64
+type testComplex128Tag complex128
+
+func TestTagExpandRejectsNonReflexiveTags(t *testing.T) {
+	tests := []struct {
+		name string
+		tag  any
+	}{
+		{name: "named float32", tag: testFloat32Tag(float32(math.NaN()))},
+		{name: "named float64", tag: testFloat64Tag(math.NaN())},
+		{name: "named complex64 real", tag: testComplex64Tag(complex(float32(math.NaN()), 0))},
+		{name: "named complex64 imaginary", tag: testComplex64Tag(complex(0, float32(math.NaN())))},
+		{name: "named complex128 real", tag: testComplex128Tag(complex(math.NaN(), 0))},
+		{name: "named complex128 imaginary", tag: testComplex128Tag(complex(0, math.NaN()))},
+		{name: "struct", tag: struct{ Value float64 }{Value: math.NaN()}},
+		{name: "array", tag: [1]float64{math.NaN()}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := TagExpand(nil, tt.tag)
+			if !errors.Is(err, ErrNotUsableAsTag) {
+				t.Fatalf("TagExpand() error = %v, want %v", err, ErrNotUsableAsTag)
+			}
+			if !errors.Is(err, ErrNotComparable) {
+				t.Fatalf("TagExpand() error = %v, want compatibility with %v", err, ErrNotComparable)
+			}
+			if result != nil {
+				t.Fatalf("TagExpand() result = %#v, want nil", result)
+			}
+		})
+	}
+}
+
+func TestNewErrNotUsableAsTagRejectsNonReflexiveTags(t *testing.T) {
+	tests := []struct {
+		name string
+		tag  any
+	}{
+		{name: "named float", tag: testFloat64Tag(math.NaN())},
+		{name: "named complex", tag: testComplex128Tag(complex(0, math.NaN()))},
+		{name: "struct", tag: struct{ Value float64 }{Value: math.NaN()}},
+		{name: "array", tag: [1]float64{math.NaN()}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := NewErrNotUsableAsTag(tt.tag); !errors.Is(err, ErrNotUsableAsTag) {
+				t.Fatalf("NewErrNotUsableAsTag() = %v, want %v", err, ErrNotUsableAsTag)
+			}
+		})
+	}
+}
+
+func TestNonReflexiveKindsAcceptFiniteTags(t *testing.T) {
+	tests := []any{
+		testFloat32Tag(1.25),
+		testFloat64Tag(2.5),
+		testComplex64Tag(complex(3, 4)),
+		testComplex128Tag(complex(5, 6)),
+		struct{ Value float64 }{Value: 7.5},
+		[1]float64{8.5},
+	}
+
+	for _, tag := range tests {
+		result, err := TagExpand(nil, tag)
+		if err != nil {
+			t.Fatalf("TagExpand(%#v) error = %v", tag, err)
+		}
+		if len(result) != 1 || result[0] != tag {
+			t.Fatalf("TagExpand(%#v) = %#v, want the input tag", tag, result)
+		}
+		if err = NewErrNotUsableAsTag(tag); err != nil {
+			t.Fatalf("NewErrNotUsableAsTag(%#v) = %v, want nil", tag, err)
+		}
+	}
+}

--- a/lib/tag/tag.go
+++ b/lib/tag/tag.go
@@ -43,43 +43,16 @@ func ensureUsableTag(tag any) error {
 	return newErrNotUsableAsTag(tag)
 }
 
-func usableAsTag(tag any) bool {
-	if tag == nil {
-		return false
-	}
-	t := reflect.TypeOf(tag)
-	if !t.Comparable() {
-		return false
-	}
-	// reflect.Type.Comparable reports static comparability. Struct and array
-	// values can still hold a non-comparable value in an interface field, while
-	// floats, complex values and composites containing them can be non-reflexive.
-	// Either property makes a map entry unreachable or unsafe, so probe just the
-	// kinds that can have one of those properties. Pointers, channels and ordinary
-	// scalar values always compare equal to themselves.
-	switch t.Kind() {
-	case reflect.Float32, reflect.Float64,
-		reflect.Complex64, reflect.Complex128:
+// usableAsTag reports whether tag is non-nil, comparable, and equal to itself.
+func usableAsTag(tag any) (ok bool) {
+	if tag != nil {
+		// Interface equality panics when the dynamic value is not comparable. If it
+		// does, recover leaves the named result at its false zero value.
+		defer func() { _ = recover() }()
 		other := tag
-		return tag == other
-	case reflect.Struct, reflect.Array:
-		return comparableAtRuntime(tag)
+		ok = tag == other
 	}
-	return true
-}
-
-// comparableAtRuntime reports whether tag is comparable and equals itself.
-//
-// A statically comparable struct or array can still hold a non-comparable value
-// (for example a func in an interface field); comparing such a value panics with
-// "comparing uncomparable type". A float, complex value or composite containing
-// one can also compare unequal to itself when it contains NaN, making its map key
-// unreachable. This probe handles both cases and is guarded by
-// BenchmarkComparableAtRuntime.
-func comparableAtRuntime(tag any) (ok bool) {
-	defer func() { _ = recover() }()
-	other := tag
-	return tag == other
+	return
 }
 
 func appendUniqueTag(result []any, tag any) ([]any, error) {

--- a/lib/tag/tag.go
+++ b/lib/tag/tag.go
@@ -192,19 +192,19 @@ func expand(depth int, ctx Context, tag any, result []any, active []any) ([]any,
 	}
 }
 
-// TagExpand expands tag into a flat list of unique comparable tag values.
+// TagExpand expands tag into a flat list of unique, usable tag keys.
 //
-// tag may be nil, a [Tag], a slice of tags, a [TagGetter] or another comparable
-// value. Primitive HTML/value types are rejected with [ErrIllegalTagType] to catch
-// common accidental tags. An expanded key value that is not comparable at runtime
-// or does not equal itself is rejected with [ErrNotUsableAsTag] (which also matches
-// [ErrNotComparable] via [errors.Is]).
+// tag may be nil, a [Tag], a slice of tags, a [TagGetter] or another value that is
+// comparable at runtime and equals itself. Primitive HTML/value types are
+// rejected with [ErrIllegalTagType] to catch common accidental tags. An expanded
+// key value that is not comparable at runtime or does not equal itself is rejected
+// with [ErrNotUsableAsTag] (which also matches [ErrNotComparable] via [errors.Is]).
 // Expansion that exceeds the nesting-depth or total-count limits is rejected with
 // [ErrTooManyTags].
 //
-// On error, result holds the tags expanded before the failure; the exception is a
-// expanded key value that is not usable as a map key, for which
-// [ErrNotUsableAsTag] is returned with a nil result.
+// On error, result contains the tags expanded before the failure. If an expanded
+// key is not usable as a map key, result is nil and err matches
+// [ErrNotUsableAsTag].
 //
 // Expansion reads tag and any values returned by [TagGetter.JawsGetTag] by
 // reference, so tag and those values must not be mutated concurrently with the

--- a/lib/tag/tag.go
+++ b/lib/tag/tag.go
@@ -196,15 +196,15 @@ func expand(depth int, ctx Context, tag any, result []any, active []any) ([]any,
 //
 // tag may be nil, a [Tag], a slice of tags, a [TagGetter] or another comparable
 // value. Primitive HTML/value types are rejected with [ErrIllegalTagType] to catch
-// common accidental tags. A value that is not comparable at runtime or does not
-// equal itself is rejected with [ErrNotUsableAsTag] (which also matches
+// common accidental tags. An expanded key value that is not comparable at runtime
+// or does not equal itself is rejected with [ErrNotUsableAsTag] (which also matches
 // [ErrNotComparable] via [errors.Is]).
 // Expansion that exceeds the nesting-depth or total-count limits is rejected with
 // [ErrTooManyTags].
 //
 // On error, result holds the tags expanded before the failure; the exception is a
-// value that is not usable as a map key, for which [ErrNotUsableAsTag] is returned
-// with a nil result.
+// expanded key value that is not usable as a map key, for which
+// [ErrNotUsableAsTag] is returned with a nil result.
 //
 // Expansion reads tag and any values returned by [TagGetter.JawsGetTag] by
 // reference, so tag and those values must not be mutated concurrently with the
@@ -226,8 +226,7 @@ func TagExpand(ctx Context, tag any) (result []any, err error) {
 }
 
 // recoverComparabilityPanic maps a panic recovered from tag expansion to a
-// [TagExpand] result. A "comparing uncomparable type" runtime error — a value that
-// passed the static comparability check but is not comparable at runtime — becomes
+// [TagExpand] result. A "comparing uncomparable type" runtime error becomes
 // [ErrNotUsableAsTag] with a nil result; any other panic value is re-raised.
 func recoverComparabilityPanic(r any, tag any) (result []any, err error) {
 	if re, ok := r.(runtime.Error); ok && strings.Contains(re.Error(), "comparing uncomparable type") {

--- a/lib/tag/tag.go
+++ b/lib/tag/tag.go
@@ -195,15 +195,17 @@ func expand(depth int, ctx Context, tag any, result []any, active []any) ([]any,
 // TagExpand expands tag into a flat list of unique, usable tag keys.
 //
 // tag may be nil, a [Tag], a slice of tags, a [TagGetter] or another value that is
-// comparable at runtime and equals itself. Primitive HTML/value types are
-// rejected with [ErrIllegalTagType] to catch common accidental tags. An expanded
-// key value that is not comparable at runtime or does not equal itself is rejected
-// with [ErrNotUsableAsTag] (which also matches [ErrNotComparable] via [errors.Is]).
+// comparable at runtime and equals itself. The predeclared string, bool, signed
+// integer, unsigned integer other than uintptr, and floating-point types are
+// rejected with [ErrIllegalTagType], as are [template.HTML], [template.HTMLAttr]
+// and [key.Key]. This catches common accidental tags. An expanded key value that
+// is not comparable at runtime or does not equal itself is rejected with
+// [ErrNotUsableAsTag] (which also matches [ErrNotComparable] via [errors.Is]).
 // Expansion that exceeds the nesting-depth or total-count limits is rejected with
 // [ErrTooManyTags].
 //
 // On error, result contains the tags expanded before the failure. If an expanded
-// key is not usable as a map key, result is nil and err matches
+// value is not usable as a tag key, result is nil and err matches
 // [ErrNotUsableAsTag].
 //
 // Expansion reads tag and any values returned by [TagGetter.JawsGetTag] by

--- a/lib/tag/tag.go
+++ b/lib/tag/tag.go
@@ -37,36 +37,45 @@ const (
 )
 
 func ensureUsableTag(tag any) error {
-	if tag != nil {
-		if t := reflect.TypeOf(tag); t != nil && t.Comparable() {
-			// reflect.Type.Comparable reports STATIC comparability: a comparable
-			// struct or array can still hold a non-comparable value in an interface
-			// field, making it panic when compared or used as an rq.tagMap key. Only
-			// struct and array values can differ between static and runtime
-			// comparability (scalars, strings, pointers and channels are always
-			// comparable when their type is), so probe just those kinds with
-			// comparableAtRuntime and reject such tags here, rather than deferring a
-			// panic to appendUniqueTag's dedup or to rq.tagMap on the event goroutine.
-			switch t.Kind() {
-			case reflect.Struct, reflect.Array:
-				if !comparableAtRuntime(tag) {
-					return NewErrNotUsableAsTag(tag)
-				}
-			}
-			return nil
-		}
+	if usableAsTag(tag) {
+		return nil
 	}
-	return NewErrNotUsableAsTag(tag)
+	return newErrNotUsableAsTag(tag)
 }
 
-// comparableAtRuntime reports whether tag can be compared with == without
-// panicking.
+func usableAsTag(tag any) bool {
+	if tag == nil {
+		return false
+	}
+	t := reflect.TypeOf(tag)
+	if !t.Comparable() {
+		return false
+	}
+	// reflect.Type.Comparable reports static comparability. Struct and array
+	// values can still hold a non-comparable value in an interface field, while
+	// floats, complex values and composites containing them can be non-reflexive.
+	// Either property makes a map entry unreachable or unsafe, so probe just the
+	// kinds that can have one of those properties. Pointers, channels and ordinary
+	// scalar values always compare equal to themselves.
+	switch t.Kind() {
+	case reflect.Float32, reflect.Float64,
+		reflect.Complex64, reflect.Complex128:
+		other := tag
+		return tag == other
+	case reflect.Struct, reflect.Array:
+		return comparableAtRuntime(tag)
+	}
+	return true
+}
+
+// comparableAtRuntime reports whether tag is comparable and equals itself.
 //
 // A statically comparable struct or array can still hold a non-comparable value
 // (for example a func in an interface field); comparing such a value panics with
-// "comparing uncomparable type". This probe is allocation-free, unlike
-// [reflect.Value.Comparable], which allocates while walking the value;
-// BenchmarkComparableAtRuntime guards that difference.
+// "comparing uncomparable type". A float, complex value or composite containing
+// one can also compare unequal to itself when it contains NaN, making its map key
+// unreachable. This probe handles both cases and is guarded by
+// BenchmarkComparableAtRuntime.
 func comparableAtRuntime(tag any) (ok bool) {
 	defer func() { _ = recover() }()
 	other := tag
@@ -214,13 +223,14 @@ func expand(depth int, ctx Context, tag any, result []any, active []any) ([]any,
 //
 // tag may be nil, a [Tag], a slice of tags, a [TagGetter] or another comparable
 // value. Primitive HTML/value types are rejected with [ErrIllegalTagType] to catch
-// common accidental tags, and a value that is not comparable at runtime is rejected
-// with [ErrNotUsableAsTag] (which also matches [ErrNotComparable] via [errors.Is]).
+// common accidental tags. A value that is not comparable at runtime or does not
+// equal itself is rejected with [ErrNotUsableAsTag] (which also matches
+// [ErrNotComparable] via [errors.Is]).
 // Expansion that exceeds the nesting-depth or total-count limits is rejected with
 // [ErrTooManyTags].
 //
 // On error, result holds the tags expanded before the failure; the exception is a
-// value that is not comparable at runtime, for which [ErrNotUsableAsTag] is returned
+// value that is not usable as a map key, for which [ErrNotUsableAsTag] is returned
 // with a nil result.
 //
 // Expansion reads tag and any values returned by [TagGetter.JawsGetTag] by

--- a/lib/tag/tag_benchmark_test.go
+++ b/lib/tag/tag_benchmark_test.go
@@ -31,6 +31,8 @@ type benchID struct {
 	n int
 }
 
+type benchFloatTag float64
+
 var tagExpandBenchSink []any
 
 func benchmarkTagExpandCase(b *testing.B, tag any) {
@@ -91,6 +93,7 @@ func BenchmarkTagExpand(b *testing.B) {
 		// ensureUsableTag runs (scalar/pointer tags skip it); benchID is a small
 		// comparable struct value, not a pointer.
 		{name: "StructTag", tag: benchID{n: 1}},
+		{name: "NamedFloatTag", tag: benchFloatTag(1.25)},
 		{name: "FlatTags8", tag: flatTags8},
 		{name: "FlatAny16", tag: flatAny},
 		{name: "NestedAnyTree", tag: nestedAny},
@@ -115,10 +118,9 @@ type benchComparableField struct {
 
 var comparableProbeSink bool
 
-// BenchmarkComparableAtRuntime guards the comparableAtRuntime doc claim that the
-// recover-based == probe is allocation-free, unlike [reflect.Value.Comparable],
-// which allocates while walking the value. Run with -benchmem; the Probe case
-// must report 0 allocs/op and the ReflectComparable case is the contrast.
+// BenchmarkComparableAtRuntime guards the cost of the runtime comparability and
+// reflexivity probe. ReflectComparable is retained as a reference point for the
+// static comparability check alone.
 func BenchmarkComparableAtRuntime(b *testing.B) {
 	tag := any(benchComparableField{v: 42})
 

--- a/lib/tag/tag_benchmark_test.go
+++ b/lib/tag/tag_benchmark_test.go
@@ -1,9 +1,6 @@
 package tag
 
-import (
-	"reflect"
-	"testing"
-)
+import "testing"
 
 type benchSelfTagger struct{}
 
@@ -89,9 +86,6 @@ func BenchmarkTagExpand(b *testing.B) {
 		tag  any
 	}{
 		{name: "SingleTag", tag: Tag("single")},
-		// StructTag exercises the struct-kind runtime comparability check that
-		// ensureUsableTag runs (scalar/pointer tags skip it); benchID is a small
-		// comparable struct value, not a pointer.
 		{name: "StructTag", tag: benchID{n: 1}},
 		{name: "NamedFloatTag", tag: benchFloatTag(1.25)},
 		{name: "FlatTags8", tag: flatTags8},
@@ -107,34 +101,4 @@ func BenchmarkTagExpand(b *testing.B) {
 			benchmarkTagExpandCase(b, bm.tag)
 		})
 	}
-}
-
-// benchComparableField is a statically comparable struct whose comparability
-// genuinely has to be resolved at runtime through an interface field, which is the
-// case ensureUsableTag's probe defends against.
-type benchComparableField struct {
-	v any
-}
-
-var comparableProbeSink bool
-
-// BenchmarkComparableAtRuntime guards the cost of the runtime comparability and
-// reflexivity probe. ReflectComparable is retained as a reference point for the
-// static comparability check alone.
-func BenchmarkComparableAtRuntime(b *testing.B) {
-	tag := any(benchComparableField{v: 42})
-
-	b.Run("Probe", func(b *testing.B) {
-		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			comparableProbeSink = comparableAtRuntime(tag)
-		}
-	})
-
-	b.Run("ReflectComparable", func(b *testing.B) {
-		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			comparableProbeSink = reflect.ValueOf(tag).Comparable()
-		}
-	})
 }

--- a/lib/tag/tag_test.go
+++ b/lib/tag/tag_test.go
@@ -255,12 +255,9 @@ func TestTagExpand_TagGetterNonComparable(t *testing.T) {
 
 // TestTagExpand_RuntimeNonComparable covers the gap between static and runtime
 // comparability: a struct whose static type is comparable but that holds a
-// non-comparable value in an interface field (here a func) passes
-// reflect.Type.Comparable() yet panics on == / as a map key. ensureUsableTag runs
-// the runtime comparability check for struct and array kinds in all builds, so tag
-// expansion must reject even a single such tag with ErrNotUsableAsTag rather than
-// accepting it and deferring a panic to jw.dirty / rq.tagMap on the event
-// goroutine.
+// non-comparable value in an interface field (here a func) panics on == or as a
+// map key. Tag expansion must reject even a single such tag with
+// ErrNotUsableAsTag rather than deferring that panic to jw.dirty or rq.tagMap.
 func TestTagExpand_RuntimeNonComparable(t *testing.T) {
 	if _, err := TagExpand(nil, testRuntimeNonComparable{v: func() {}}); !errors.Is(err, ErrNotUsableAsTag) {
 		t.Fatalf("expected ErrNotUsableAsTag, got %v", err)
@@ -298,12 +295,9 @@ func TestTagExpand_ValidThenRuntimeNonComparable(t *testing.T) {
 	}
 }
 
-// TestTagExpand_RuntimeNonComparableArray pins the reflect.Array arm of
-// ensureUsableTag independently of the struct arm. An array whose static type is
-// comparable ([1]any) but whose element holds a non-comparable value (a func)
-// passes reflect.Type.Comparable() yet panics on ==; expansion must reject it with
-// ErrNotUsableAsTag. Without an actual array value the arm is only statement-covered
-// via the case label it shares with reflect.Struct.
+// TestTagExpand_RuntimeNonComparableArray covers an array whose static type is
+// comparable ([1]any) but whose element holds a non-comparable value (a func).
+// Comparing it panics, so expansion must reject it with ErrNotUsableAsTag.
 func TestTagExpand_RuntimeNonComparableArray(t *testing.T) {
 	if _, err := TagExpand(nil, [1]any{func() {}}); !errors.Is(err, ErrNotUsableAsTag) {
 		t.Fatalf("expected ErrNotUsableAsTag, got %v", err)

--- a/tag_render_production_test.go
+++ b/tag_render_production_test.go
@@ -1,0 +1,43 @@
+package jaws
+
+import (
+	"errors"
+	"io"
+	"math"
+	"testing"
+
+	"github.com/linkdata/jaws/lib/tag"
+)
+
+type productionTagRenderUI struct {
+	getter any
+	elem   *Element
+}
+
+func (ui *productionTagRenderUI) JawsRender(elem *Element, _ io.Writer, _ []any) (err error) {
+	ui.elem = elem
+	_, _, err = elem.ApplyGetter(ui.getter)
+	return
+}
+
+func (*productionTagRenderUI) JawsUpdate(*Element) {}
+
+type productionNamedFloatTag float64
+
+func TestUIRenderRejectsUnreachableTag(t *testing.T) {
+	tr := newTestRequest(t)
+	logger := &captureErrorLogger{}
+	tr.Jaws.Logger = logger
+	tagValue := productionNamedFloatTag(math.NaN())
+	ui := &productionTagRenderUI{getter: tagValue}
+
+	if err := tr.UI(ui); err != nil {
+		t.Fatal(err)
+	}
+	if ui.elem == nil {
+		t.Fatal("UI renderer was not called")
+	}
+	if !errors.Is(logger.err, tag.ErrNotUsableAsTag) {
+		t.Fatalf("UI rendering error = %v, want %v", logger.err, tag.ErrNotUsableAsTag)
+	}
+}


### PR DESCRIPTION
## Summary

- Reject expanded tag keys that do not equal themselves, including NaN-bearing floats, complex values, structs, and arrays.
- Check the complete map-key invariant with one recovered interface self-comparison in `usableAsTag`; non-comparable values panic and recover to false, while non-reflexive values compare false.
- Return stable `ErrNotUsableAsTag` while retaining `errors.Is(err, ErrNotComparable)` compatibility.
- Continue accepting finite values of the same types.

## Production reachability

Normal UI rendering calls `Element.ApplyGetter` to register parameter-derived tags. A named NaN float is otherwise an accepted tag type, but its map key cannot be retrieved even with the same value, so the rendered Element becomes unreachable for dirtying, broadcasts, and event routing.

`TestUIRenderRejectsUnreachableTag` exercises the public Request UI renderer and ApplyGetter path, proving the invalid production tag is rejected before registration. Unit coverage includes floats, complex values, structs, arrays, runtime-non-comparable interface payloads, and finite controls.

## Performance

Valid `BenchmarkTagExpand` cases, interleaved `benchstat`, n=10, 300ms, cpu1, `main` versus this branch:

- Single `tag.Tag`: 20.12 → 20.27 ns/op (`+0.75%`).
- Comparable struct: 25.44 → 24.92 ns/op (`-2.04%`).
- Named finite float: 22.38 → 25.05 ns/op (`+11.98%`).
- Sixteen-pointer batch: 276.2 → 314.5 ns/op (`+13.85%`).
- Valid-suite geomean: 76.04 → 80.51 ns/op (`+5.88%`).

Bytes and allocations are unchanged for every valid case. The accepted cost buys one uniform map-key predicate and removes the reflection/kind dispatch plus its helper-specific benchmark; `BenchmarkTagExpand` remains in the tree as the production-path regression guard.

Rejected-tag performance is not treated as a production concern because rejection identifies a programmer error during development.

## Verification

- `go test -race ./...`
- `gofmt` and `gofumpt`: clean
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run ./...`: 0 issues

## Stack

Base: `main`. First PR in the tag stack; #103 is restacked on this head.
