### PR TITLE
Avoid false tag cycles for function getters

### DIFF
--- a/lib/tag/function_tagger_test.go
+++ b/lib/tag/function_tagger_test.go
@@ -1,0 +1,56 @@
+package tag
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+type testFunctionTagGetter func(Context) any
+
+func (fn testFunctionTagGetter) JawsGetTag(ctx Context) any {
+	return fn(ctx)
+}
+
+func TestTagExpandDoesNotConflateDistinctFunctionTagGetters(t *testing.T) {
+	want := Tag("leaf")
+	next := []any{want, nil}
+	getters := make([]testFunctionTagGetter, len(next))
+	for i := range next {
+		i := i
+		getters[i] = func(Context) any { return next[i] }
+	}
+	leafGetter := getters[0]
+	rootGetter := getters[1]
+	next[1] = leafGetter
+
+	if rootPtr, leafPtr := reflect.ValueOf(rootGetter).Pointer(), reflect.ValueOf(leafGetter).Pointer(); rootPtr != leafPtr {
+		t.Skipf("compiler emitted distinct code pointers %#x and %#x", rootPtr, leafPtr)
+	}
+
+	got, err := TagExpand(nil, rootGetter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertTagSetEqual(t, got, []any{want})
+}
+
+func TestTagExpandRecursiveFunctionTagGetterHitsDepthLimit(t *testing.T) {
+	var recursive testFunctionTagGetter
+	recursive = func(Context) any { return recursive }
+
+	result, err := TagExpand(nil, recursive)
+	if !errors.Is(err, ErrTooManyTags) {
+		t.Fatalf("TagExpand() error = %v, want %v", err, ErrTooManyTags)
+	}
+	if result != nil {
+		t.Fatalf("TagExpand() result = %#v, want nil", result)
+	}
+}
+
+func TestSameActiveNodeDoesNotIdentifyFunctions(t *testing.T) {
+	fn := testFunctionTagGetter(func(Context) any { return Tag("leaf") })
+	if sameActiveNode(fn, fn) {
+		t.Fatal("function code pointers do not identify function values")
+	}
+}

--- a/lib/tag/tag.go
+++ b/lib/tag/tag.go
@@ -93,10 +93,8 @@ func sameActiveNode(a, b any) bool {
 	vb := reflect.ValueOf(b)
 	switch va.Kind() {
 	case reflect.Func:
-		// Value.Pointer identifies function code, not a closure and its captured
-		// state. Function values therefore have no usable identity here. Recursive
-		// function TagGetters terminate through maxTagDepth instead of cycle
-		// detection.
+		// Value.Pointer identifies shared function code, not closure identity, so it
+		// cannot detect cycles. maxTagDepth still bounds recursive function getters.
 		return false
 	case reflect.Pointer, reflect.Slice, reflect.Map, reflect.Chan, reflect.UnsafePointer:
 		// For slices, Pointer() is the address of the first element, so two

--- a/lib/tag/tag.go
+++ b/lib/tag/tag.go
@@ -92,7 +92,13 @@ func sameActiveNode(a, b any) bool {
 	va := reflect.ValueOf(a)
 	vb := reflect.ValueOf(b)
 	switch va.Kind() {
-	case reflect.Pointer, reflect.Slice, reflect.Map, reflect.Chan, reflect.Func, reflect.UnsafePointer:
+	case reflect.Func:
+		// Value.Pointer identifies function code, not a closure and its captured
+		// state. Function values therefore have no usable identity here. Recursive
+		// function TagGetters terminate through maxTagDepth instead of cycle
+		// detection.
+		return false
+	case reflect.Pointer, reflect.Slice, reflect.Map, reflect.Chan, reflect.UnsafePointer:
 		// For slices, Pointer() is the address of the first element, so two
 		// distinct slices aliasing the same backing array at the same start
 		// compare equal here. That can only over-detect a cycle and truncate

--- a/lib/tag/tag_benchmark_test.go
+++ b/lib/tag/tag_benchmark_test.go
@@ -24,6 +24,20 @@ func (t *benchSliceTagger) JawsGetTag(Context) any {
 	return t.tags
 }
 
+type benchFunctionTagger func(Context) any
+
+func (fn benchFunctionTagger) JawsGetTag(ctx Context) any {
+	return fn(ctx)
+}
+
+func benchFunctionLeaf(Context) any {
+	return Tag("leaf")
+}
+
+func benchFunctionRoot(Context) any {
+	return benchFunctionTagger(benchFunctionLeaf)
+}
+
 type benchID struct {
 	n int
 }
@@ -94,6 +108,7 @@ func BenchmarkTagExpand(b *testing.B) {
 		{name: "SelfTagger", tag: &benchSelfTagger{}},
 		{name: "SliceTagger4", tag: sliceTagger},
 		{name: "ChainTaggers8", tag: chainRoot},
+		{name: "FunctionTaggers2", tag: benchFunctionTagger(benchFunctionRoot)},
 	}
 
 	for _, bm := range cases {

--- a/lib/tag/taggetter.go
+++ b/lib/tag/taggetter.go
@@ -1,10 +1,6 @@
 package tag
 
 // TagGetter exposes dynamic tags during [TagExpand].
-//
-// Function values may implement TagGetter, but Go does not expose closure
-// identity. Recursive function-valued implementations are therefore stopped by
-// [TagExpand]'s depth limit and return [ErrTooManyTags].
 type TagGetter interface {
 	// JawsGetTag returns the dynamic tag or tags for the implementing object.
 	//

--- a/lib/tag/taggetter.go
+++ b/lib/tag/taggetter.go
@@ -1,6 +1,10 @@
 package tag
 
 // TagGetter exposes dynamic tags during [TagExpand].
+//
+// Function values may implement TagGetter, but Go does not expose closure
+// identity. Recursive function-valued implementations are therefore stopped by
+// [TagExpand]'s depth limit and return [ErrTooManyTags].
 type TagGetter interface {
 	// JawsGetTag returns the dynamic tag or tags for the implementing object.
 	//

--- a/tag_render_production_test.go
+++ b/tag_render_production_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"math"
+	"reflect"
 	"testing"
 
 	"github.com/linkdata/jaws/lib/tag"
@@ -24,6 +25,20 @@ func (*productionTagRenderUI) JawsUpdate(*Element) {}
 
 type productionNamedFloatTag float64
 
+type productionFunctionTagGetter func(tag.Context) any
+
+func (fn productionFunctionTagGetter) JawsGetTag(ctx tag.Context) any {
+	return fn(ctx)
+}
+
+type productionTagGetterWrapper struct {
+	value any
+}
+
+func (wrapper productionTagGetterWrapper) JawsGetTag(tag.Context) any {
+	return wrapper.value
+}
+
 func TestUIRenderRejectsUnreachableTag(t *testing.T) {
 	tr := newTestRequest(t)
 	logger := &captureErrorLogger{}
@@ -39,5 +54,37 @@ func TestUIRenderRejectsUnreachableTag(t *testing.T) {
 	}
 	if !errors.Is(logger.err, tag.ErrNotUsableAsTag) {
 		t.Fatalf("UI rendering error = %v, want %v", logger.err, tag.ErrNotUsableAsTag)
+	}
+}
+
+func TestUIRenderResolvesDistinctFunctionTagGetters(t *testing.T) {
+	want := tag.Tag("leaf")
+	next := []any{want, nil}
+	getters := make([]productionFunctionTagGetter, len(next))
+	for i := range next {
+		i := i
+		getters[i] = func(tag.Context) any { return next[i] }
+	}
+	leafGetter := getters[0]
+	rootGetter := getters[1]
+	next[1] = leafGetter
+	if rootPtr, leafPtr := reflect.ValueOf(rootGetter).Pointer(), reflect.ValueOf(leafGetter).Pointer(); rootPtr != leafPtr {
+		t.Skipf("compiler emitted distinct code pointers %#x and %#x", rootPtr, leafPtr)
+	}
+
+	tr := newTestRequest(t)
+	logger := &captureErrorLogger{}
+	tr.Jaws.Logger = logger
+	ui := &productionTagRenderUI{
+		getter: productionTagGetterWrapper{value: rootGetter},
+	}
+	if err := tr.UI(ui); err != nil {
+		t.Fatal(err)
+	}
+	if logger.err != nil {
+		t.Fatalf("UI rendering error = %v", logger.err)
+	}
+	if ui.elem == nil || !ui.elem.HasTag(want) {
+		t.Fatal("UI rendering did not register the function TagGetter's leaf tag")
 	}
 }


### PR DESCRIPTION
## Summary

- Stop treating a function code pointer as function-value identity during TagGetter cycle detection.
- Allow distinct closures sharing compiler-generated code to expand independently.
- Bound recursive function TagGetters through the existing depth limit and `ErrTooManyTags`.

## Production reachability

Function types may implement the supported `tag.TagGetter` interface and be supplied through normal UI parameters. Distinct closures can share the same `reflect.Value.Pointer` code address while capturing different state. The old detector conflated them, truncated expansion, and omitted the leaf tag during Request UI rendering.

`TestUIRenderResolvesDistinctFunctionTagGetters` exercises Request UI → ApplyGetter → TagExpand and proves the leaf tag is registered. Separate tests prove recursive function getters still terminate at the documented depth limit.

## Verification

- Distinct-closure, recursion-depth, and active-node tests
- Public UI-render regression
- Full race suite and all generation/lint/security gates

## Performance

Interleaved benchstat, n=10, 300ms, cpu1:

- FunctionTaggers2: 37.44 → 35.64 ns/op (`-4.79%`, `p=0.001`).
- Memory remains 16 B/op and one allocation/op.

## Stack

Base: `fix/nonreflexive-tags`. It builds directly on tag-usability validation.
