### PR TITLE
Release JsVar locks after PathSetter panics

### DIFF
--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -175,13 +175,18 @@ func (jsvar *JsVar[T]) setPathLocked(elem *jaws.Element, jsPath string, value an
 	return
 }
 
+func (jsvar *JsVar[T]) setPathAndGetTag(elem *jaws.Element, jsPath string, value any) (dirtyTag any, err error) {
+	jsvar.Lock()
+	defer jsvar.Unlock()
+	err = jsvar.setPathLocked(elem, jsPath, value)
+	dirtyTag = jsvar.dirtyTag
+	return
+}
+
 func (jsvar *JsVar[T]) setPathLock(elem *jaws.Element, jsPath string, value any) (broadcasted bool, err error) {
 	jsvar.setMu.Lock()
 	defer jsvar.setMu.Unlock()
-	jsvar.Lock()
-	err = jsvar.setPathLocked(elem, jsPath, value)
-	dirtyTag := jsvar.dirtyTag
-	jsvar.Unlock()
+	dirtyTag, err := jsvar.setPathAndGetTag(elem, jsPath, value)
 	// Marshal and broadcast outside the caller-provided lock: value is the
 	// caller-owned argument (not read from Ptr), and jaws.Broadcast can block on
 	// the broadcast channel under backpressure. The private setMu remains held so

--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -49,6 +49,9 @@ type PathSetter interface {
 	// delegates to it while holding the JsVar write lock. Such an
 	// implementation must not lock or unlock the JsVar, nor call its locked
 	// accessors such as [JsVar.JawsGet] or [JsVar.JawsSet].
+	//
+	// If an implementation panics, the calling JsVar releases its write lock
+	// before propagating the panic.
 	JawsSetPath(elem *jaws.Element, jsPath string, value any) (err error)
 }
 

--- a/lib/ui/jsvar_benchmark_test.go
+++ b/lib/ui/jsvar_benchmark_test.go
@@ -65,3 +65,38 @@ func BenchmarkJsVarSetPathBroadcast(b *testing.B) {
 		})
 	})
 }
+
+func BenchmarkJsVarPathSetterMutation(b *testing.B) {
+	jw, err := jaws.New()
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(jw.Close)
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	if rq == nil {
+		b.Fatal("nil request")
+	}
+	var mu sync.Mutex
+	state := benchmarkJsVarState{}
+	jsvar := NewJsVar(&mu, &state)
+	elem := rq.NewElement(jsvar)
+
+	b.Run("Serial", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if err := jsvar.JawsSetPath(elem, "value", i); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("Parallel", func(b *testing.B) {
+		b.ReportAllocs()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				if err := jsvar.JawsSetPath(elem, "value", 1); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	})
+}

--- a/lib/ui/jsvar_panic_test.go
+++ b/lib/ui/jsvar_panic_test.go
@@ -1,0 +1,202 @@
+package ui
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/linkdata/jaws"
+	"github.com/linkdata/jaws/lib/what"
+	"github.com/linkdata/jaws/lib/wire"
+)
+
+var errPathSetterPanic = errors.New("path setter panic")
+
+type panicSafePathState struct {
+	Value string `json:"value"`
+}
+
+func (state *panicSafePathState) JawsSetPath(_ *jaws.Element, jsPath string, value any) (err error) {
+	switch jsPath {
+	case "":
+		var next panicSafePathState
+		var ok bool
+		if next, ok = value.(panicSafePathState); !ok {
+			return fmt.Errorf("unexpected root value type %T", value)
+		}
+		if *state == next {
+			return jaws.ErrValueUnchanged
+		}
+		*state = next
+	case "value":
+		var next string
+		var ok bool
+		if next, ok = value.(string); !ok {
+			return fmt.Errorf("unexpected value type %T", value)
+		}
+		if next == "panic" {
+			panic(errPathSetterPanic)
+		}
+		if state.Value == next {
+			return jaws.ErrValueUnchanged
+		}
+		state.Value = next
+	default:
+		return fmt.Errorf("unexpected path %q", jsPath)
+	}
+	return
+}
+
+func awaitJsVarOperation[T any](t *testing.T, operation string, ch <-chan T) (value T) {
+	t.Helper()
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case value = <-ch:
+	case <-timer.C:
+		t.Fatalf("%s remained blocked after the PathSetter panic", operation)
+	}
+	return
+}
+
+func TestJsVarPathSetterPanicReleasesValueLock(t *testing.T) {
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+	go jw.Serve()
+
+	var mu sync.Mutex
+	state := panicSafePathState{Value: "initial"}
+	jsvar := NewJsVar(&mu, &state)
+	type renderedJsVar struct {
+		rq   *jaws.Request
+		elem *jaws.Element
+		err  error
+	}
+	renderedCh := make(chan renderedJsVar, 1)
+	mux := http.NewServeMux()
+	mux.Handle("GET /jaws/", jw)
+	mux.HandleFunc("GET /", func(w http.ResponseWriter, r *http.Request) {
+		rendered := renderedJsVar{rq: jw.NewRequest(r)}
+		rw := RequestWriter{Request: rendered.rq, Writer: w}
+		if rendered.err = rw.HeadHTML(); rendered.err == nil {
+			rendered.err = rw.JsVar("panicSafe", jsvar)
+		}
+		if rendered.err == nil {
+			elems := rendered.rq.GetElements(&state)
+			if len(elems) == 1 {
+				rendered.elem = elems[0]
+			} else {
+				rendered.err = fmt.Errorf("rendered JsVar element count %d, want 1", len(elems))
+			}
+		}
+		if rendered.err == nil {
+			rendered.err = rw.TailHTML()
+		}
+		renderedCh <- rendered
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	httpResp, err := srv.Client().Do(httpReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = io.Copy(io.Discard, httpResp.Body); err != nil {
+		t.Fatal(err)
+	}
+	if err = httpResp.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if httpResp.StatusCode != http.StatusOK {
+		t.Fatalf("initial page status = %d, want %d", httpResp.StatusCode, http.StatusOK)
+	}
+	rendered := <-renderedCh
+	if rendered.err != nil {
+		t.Fatal(rendered.err)
+	}
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/jaws/" + rendered.rq.JawsKeyString()
+	header := http.Header{}
+	header.Set("Origin", srv.URL)
+	conn, wsResp, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{HTTPHeader: header})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.CloseNow() })
+	if wsResp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("WebSocket status = %d, want %d", wsResp.StatusCode, http.StatusSwitchingProtocols)
+	}
+
+	// Send the exact what.Set frame that jaws.js emits for a browser-side write
+	// over the production HTTP-upgraded WebSocket. Request event dispatch calls
+	// CallEventHandlers, which recovers the panic and reports it to the browser
+	// without terminating the request loop.
+	incoming := wire.WsMsg{
+		Jid:  rendered.elem.Jid(),
+		What: what.Set,
+		Data: `value="panic"`,
+	}
+	if err = conn.Write(ctx, websocket.MessageText, incoming.Append(nil)); err != nil {
+		t.Fatal(err)
+	}
+	messageType, raw, err := conn.Read(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if messageType != websocket.MessageText {
+		t.Fatalf("panic response type = %v, want text", messageType)
+	}
+	alert, ok := wire.Parse(raw)
+	if !ok || alert.What != what.Alert || !strings.Contains(alert.Data, errPathSetterPanic.Error()) {
+		t.Fatalf("recovered PathSetter panic frame = %q, want Alert containing %q", raw, errPathSetterPanic)
+	}
+
+	getDone := make(chan panicSafePathState, 1)
+	go func() {
+		getDone <- jsvar.JawsGet(rendered.elem)
+	}()
+	if got := awaitJsVarOperation(t, "JawsGet", getDone); got != state {
+		t.Fatalf("JawsGet after panic = %#v, want %#v", got, state)
+	}
+
+	want := panicSafePathState{Value: "recovered"}
+	setDone := make(chan error, 1)
+	go func() {
+		setDone <- jsvar.JawsSet(rendered.elem, want)
+	}()
+	if err = awaitJsVarOperation(t, "JawsSet", setDone); err != nil {
+		t.Fatal(err)
+	}
+	messageType, raw, err = conn.Read(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if messageType != websocket.MessageText {
+		t.Fatalf("JawsSet response type = %v, want text", messageType)
+	}
+	wantSet := wire.WsMsg{Jid: rendered.elem.Jid(), What: what.Set, Data: `={"value":"recovered"}`}
+	if !bytes.Equal(raw, wantSet.Append(nil)) {
+		t.Fatalf("JawsSet frame after panic = %q, want %q", raw, wantSet.Append(nil))
+	}
+	if got := jsvar.JawsGet(rendered.elem); got != want {
+		t.Fatalf("bound value after recovery = %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Scope the caller-provided JsVar lock in a helper with deferred unlock.
- Keep mutation, dirty-tag capture, JSON encoding, and ordered broadcast semantics unchanged.
- Allow framework panic recovery to continue without leaving every later JsVar access deadlocked.

## Production reachability

A shipped-browser Set frame reaches `Request.handleIncoming` → event dispatch → `CallEventHandlers` → `JsVar.JawsInput` → an application `PathSetter`. `CallEventHandlers` intentionally recovers an application panic and returns an Alert, but the old explicit unlock was skipped, permanently holding the caller's RWLocker.

`TestJsVarPathSetterPanicReleasesValueLock` renders the JsVar through a real initial HTTP GET, dials the real `/jaws/<key>` WebSocket, writes the exact browser Set wire frame, and reads the recovered Alert from that socket. It then proves JawsGet and JawsSet finish and reads the exact outbound Set frame from the same socket. Replacing the fix with the old explicit unlock makes the test time out after recovery.

## Verification

- Real HTTP/WebSocket production regression, race-tested 20 times
- Full Node-required race suite
- Generation, gofmt, vet, build, staticcheck, golangci-lint, and gosec all clean

## Performance

Interleaved benchstat, n=6, 300ms, `-cpu=1,18`:

- The panic-safe scoped defer adds about 1.8–2.0 ns/op.
- Serial: +7.80% at cpu1 and +7.50% at cpu18.
- Parallel: +9.02% at cpu1 and +6.79% at cpu18.
- All cases remain at zero allocations.

This small normal-path cost is the required deferred unlock that guarantees recovery cannot strand the user-provided lock.

## Stack

Base: `fix/jsvar-broadcast-order`. It builds on that PR's setter critical section and remains a distinct bug fix.
