### PR TITLE
Reject the reserved __proto__ JsVar name

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,9 @@ client/server protocol code:
 * `jawsVar(name, ...)` resolves properties from `window`, but WebSocket routing
   uses the top-level symbol name only. Register JaWS `JsVar` names as top-level
   identifiers (example: `app`), and use dotted suffixes as the JSON path
-  (example: `jawsVar("app.state", value)` sends path `state`).
+  (example: `jawsVar("app.state", value)` sends path `state`). The exact
+  top-level name `__proto__` is reserved because it cannot be used as a browser
+  routing key.
 
 ### HTTP request flow and associating the WebSocket
 

--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ client/server protocol code:
   uses the top-level symbol name only. Register JaWS `JsVar` names as top-level
   identifiers (example: `app`), and use dotted suffixes as the JSON path
   (example: `jawsVar("app.state", value)` sends path `state`). The exact
-  top-level name `__proto__` is reserved because it cannot be used as a browser
-  routing key.
+  top-level name `__proto__` is reserved; rendering it as a `JsVar` returns
+  `ui.ErrIllegalJsVarName`.
 
 ### HTTP request flow and associating the WebSocket
 

--- a/lib/assets/js_test.go
+++ b/lib/assets/js_test.go
@@ -258,6 +258,60 @@ process.stdout.write(jaws.sent[0] || "");
 	}
 }
 
+func TestJawsJS_PrototypeNameCannotFormJsVarRoute(t *testing.T) {
+	raw := runJawsJSSnippet(t, `
+function FakeSocket() { this.readyState = 1; this.sent = []; }
+FakeSocket.prototype.send = function(msg) { this.sent.push(msg); };
+WebSocket = FakeSocket;
+jaws = new FakeSocket();
+
+function jsVarElement(name, id) {
+	return {
+		id: id,
+		dataset: { jawsname: name },
+		hasAttribute: function(attr) { return attr === "data-jawsname"; },
+	};
+}
+
+jawsAttach(jsVarElement("__proto__", "Jid.9"));
+jawsAttach(jsVarElement("__proto", "Jid.10"));
+jawsVar("__proto__");
+jawsVar("__proto", 42);
+
+process.stdout.write(JSON.stringify({
+	prototypeOwnRoute: Object.hasOwn(window.jawsNames, "__proto__"),
+	prototypeRouteType: typeof window.jawsNames["__proto__"],
+	nearOwnRoute: Object.hasOwn(window.jawsNames, "__proto"),
+	nearRoute: window.jawsNames["__proto"],
+	frames: jaws.sent,
+}));
+`)
+
+	var got struct {
+		PrototypeOwnRoute  bool     `json:"prototypeOwnRoute"`
+		PrototypeRouteType string   `json:"prototypeRouteType"`
+		NearOwnRoute       bool     `json:"nearOwnRoute"`
+		NearRoute          string   `json:"nearRoute"`
+		Frames             []string `json:"frames"`
+	}
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unexpected JSON output %q: %v", raw, err)
+	}
+	if got.PrototypeOwnRoute || got.PrototypeRouteType == "string" {
+		t.Fatalf("__proto__ unexpectedly formed an own string route: %+v", got)
+	}
+	if !got.NearOwnRoute || got.NearRoute != "Jid.10" {
+		t.Fatalf("nearby identifier route = own %t, %q; want own Jid.10", got.NearOwnRoute, got.NearRoute)
+	}
+	if len(got.Frames) != 1 {
+		t.Fatalf("JsVar frames = %q, want only the nearby identifier frame", got.Frames)
+	}
+	msg, ok := wire.Parse([]byte(got.Frames[0]))
+	if !ok || msg.What != what.Set || msg.Jid != 10 || msg.Data != "=42" {
+		t.Fatalf("nearby identifier frame = %+v, parseable %t; want Set Jid.10 =42", msg, ok)
+	}
+}
+
 func TestJawsJS_JsVarNestedPathHandlesShadowedHasOwnProperty(t *testing.T) {
 	raw := runJawsJSSnippet(t, `
 	function FakeSocket() { this.readyState = 1; this.sent = []; }

--- a/lib/ui/errjsvar.go
+++ b/lib/ui/errjsvar.go
@@ -2,8 +2,10 @@ package ui
 
 import "errors"
 
-// ErrIllegalJsVarName is returned when a JsVar name is missing, not a string,
-// or does not follow valid top-level identifier syntax.
+// ErrIllegalJsVarName reports an invalid or reserved JsVar name.
+//
+// A valid name is a non-empty top-level JavaScript identifier other than the
+// reserved browser routing name "__proto__".
 var ErrIllegalJsVarName errIllegalJsVarName
 
 type errIllegalJsVarName string

--- a/lib/ui/errjsvar.go
+++ b/lib/ui/errjsvar.go
@@ -2,10 +2,12 @@ package ui
 
 import "errors"
 
-// ErrIllegalJsVarName reports an invalid or reserved JsVar name.
+// ErrIllegalJsVarName is returned when a JsVar name is missing, is not a
+// string, has invalid syntax, or is reserved.
 //
-// A valid name is a non-empty top-level JavaScript identifier other than the
-// reserved browser routing name "__proto__".
+// Valid names begin with an ASCII letter, underscore, or dollar sign, and
+// contain only ASCII letters, digits, underscores, and dollar signs. The exact
+// name "__proto__" is reserved.
 var ErrIllegalJsVarName errIllegalJsVarName
 
 type errIllegalJsVarName string

--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -33,6 +33,8 @@ func validateJsVarName(value []any) (name string, err error) {
 			err = errIllegalJsVarName("illegal syntax")
 			return
 		}
+		// jaws.js stores top-level routes on a plain object. Assigning "__proto__"
+		// changes its prototype rather than creating an own route.
 		if name == "__proto__" {
 			err = errIllegalJsVarName("reserved")
 		}
@@ -265,6 +267,9 @@ func (jsvar *JsVar[T]) JawsSet(elem *jaws.Element, value T) (err error) {
 
 // JawsRender writes the hidden element that seeds and routes the JavaScript variable.
 //
+// params[0] must be a valid JsVar name. Otherwise, JawsRender returns
+// [ErrIllegalJsVarName] without writing markup.
+//
 // The bound value's [tag.TagGetter.JawsGetTag] and [jaws.InitHandler.JawsInit]
 // callbacks run while the JsVar write lock is held, so they must not re-enter this
 // JsVar (for example call JawsGet or JawsSet on it), which would self-deadlock the
@@ -366,6 +371,8 @@ func isNilUI(ui jaws.UI) (yes bool) {
 }
 
 // JsVar binds a [JsVar] to a named JavaScript variable.
+//
+// It returns [ErrIllegalJsVarName] if jsvarName is invalid or reserved.
 //
 // You can also pass a [JsVarMaker] instead of a [JsVar].
 func (rw RequestWriter) JsVar(jsvarName string, jsvar any, params ...any) (err error) {

--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -31,6 +31,10 @@ func validateJsVarName(value []any) (name string, err error) {
 		}
 		if !jsVarNameRx.MatchString(name) {
 			err = errIllegalJsVarName("illegal syntax")
+			return
+		}
+		if name == "__proto__" {
+			err = errIllegalJsVarName("reserved")
 		}
 	}
 	if name == "" {

--- a/lib/ui/jsvar_benchmark_test.go
+++ b/lib/ui/jsvar_benchmark_test.go
@@ -100,3 +100,14 @@ func BenchmarkJsVarPathSetterMutation(b *testing.B) {
 		})
 	})
 }
+
+func BenchmarkValidateJsVarName(b *testing.B) {
+	params := []any{"state"}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		name, err := validateJsVarName(params)
+		if err != nil || name != "state" {
+			b.Fatalf("validateJsVarName() = %q, %v", name, err)
+		}
+	}
+}

--- a/lib/ui/jsvar_name_test.go
+++ b/lib/ui/jsvar_name_test.go
@@ -1,0 +1,69 @@
+package ui
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestValidateJsVarNameRejectsOnlyReservedPrototypeName(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{name: "__proto__", wantErr: true},
+		{name: "__proto"},
+		{name: "__proto__$"},
+		{name: "$__proto__"},
+		{name: "constructor"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := validateJsVarName([]any{tc.name})
+			if tc.wantErr {
+				if !errors.Is(err, ErrIllegalJsVarName) {
+					t.Fatalf("validateJsVarName(%q) error = %v, want ErrIllegalJsVarName", tc.name, err)
+				}
+				return
+			}
+			if err != nil || got != tc.name {
+				t.Fatalf("validateJsVarName(%q) = %q, %v", tc.name, got, err)
+			}
+		})
+	}
+}
+
+func TestJsVarRenderRejectsReservedPrototypeName(t *testing.T) {
+	_, rq := newCoreRequest(t)
+	var mu sync.Mutex
+	value := jsVarData{Text: "value"}
+	jsvar := NewJsVar(&mu, &value)
+	elem := rq.NewElement(jsvar)
+	var output strings.Builder
+
+	err := jsvar.JawsRender(elem, &output, []any{"__proto__"})
+	if !errors.Is(err, ErrIllegalJsVarName) {
+		t.Fatalf("JawsRender error = %v, want ErrIllegalJsVarName", err)
+	}
+	if output.Len() != 0 {
+		t.Fatalf("JawsRender wrote rejected JsVar markup %q", output.String())
+	}
+}
+
+func TestRequestWriterJsVarRejectsReservedPrototypeName(t *testing.T) {
+	_, rq := newCoreRequest(t)
+	var mu sync.Mutex
+	value := jsVarData{Text: "value"}
+	jsvar := NewJsVar(&mu, &value)
+	var output strings.Builder
+	rw := RequestWriter{Request: rq, Writer: &output}
+
+	err := rw.JsVar("__proto__", jsvar)
+	if !errors.Is(err, ErrIllegalJsVarName) {
+		t.Fatalf("RequestWriter.JsVar error = %v, want ErrIllegalJsVarName", err)
+	}
+	if output.Len() != 0 {
+		t.Fatalf("RequestWriter.JsVar wrote rejected markup %q", output.String())
+	}
+}


### PR DESCRIPTION
## Summary

- Reject the exact JsVar name `__proto__` with `ErrIllegalJsVarName`.
- Enforce the validation through both direct JsVar rendering and RequestWriter.JsVar.
- Continue accepting nearby ordinary names.

## Production reachability

Shipped `jaws.js` stores top-level JsVar routes in an ordinary JavaScript object. Assigning the special `__proto__` property changes that object's prototype instead of creating an own string route. The Go render boundary previously accepted the name, so the page appeared valid while later browser Set routing could never resolve the intended managed Element.

The shipped-client regression executes the actual bundled `jaws.js`, calls `jawsAttach` and `jawsVar`, and proves `__proto__` cannot form an own route/frame while a nearby name does. Go regressions prove both public render paths reject the unusable name before emitting markup.

## Verification

- `TestJawsJS_PrototypeNameCannotFormJsVarRoute`
- Exact-name/near-name validation tests for direct rendering and RequestWriter
- Full Node-required race suite and all generation/lint/security gates

## Performance

Final-topology validation benchmark, n=6, 300ms:

- Ordinary name validation: 57.81 → 56.87 ns/op; no regression observed.
- Bytes and allocations remain zero.
- An earlier interleaved n=10 run was also statistically unchanged.

## Stack

Base: `fix/jsvar-pathsetter-panic`. This is the top of the JsVar stack.
