### PR TITLE
Clarify active Request routing documentation

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -173,7 +173,7 @@ Tested via WebSocket `Input` and `Click` messages with payloads including:
 | Control | Implementation | Verified |
 |---------|---------------|----------|
 | **jawsKey** | 64-bit `crypto/rand` (2^64 keyspace), encoded as base-32 (up to 13 chars) | Code + empirical |
-| **Single-use keys** | Key removed from map on first WebSocket connection | Empirical: second connection returns 404 |
+| **Single-claim keys** | The first successful WebSocket callback marks its Request claimed; later callbacks for that key are rejected | Empirical: second connection returns 404 |
 | **IP binding** | `claim()` verifies WebSocket remote IP matches original HTTP request IP | Code review (`request.go`, `Request.claim`) |
 | **Origin validation** | Scheme + host must match initial request; cross-origin returns 403 | Empirical: evil.com, null, file:// all rejected |
 

--- a/broadcast.go
+++ b/broadcast.go
@@ -37,8 +37,8 @@ import (
 // destinations that did expand.
 func (jw *Jaws) Broadcast(msg wire.Message) {
 	switch dest := msg.Dest.(type) {
-	case nil: // send to all requests
-	case key.Key: // send to the request with this identity key
+	case nil: // send to all active requests
+	case key.Key: // send to the active request with this identity key
 		if dest == 0 {
 			// A recycled producer captured a zeroed key; no live request can match
 			// (keys are always non-zero), so drop it rather than fall through to
@@ -48,7 +48,7 @@ func (jw *Jaws) Broadcast(msg wire.Message) {
 	case string: // HTML id (accepted by all requests)
 		if msg.What == what.Call && dest == "" {
 			// An empty outbound Jid encodes a request-scoped Call. Reject an empty
-			// HTML-id destination rather than silently widening it to every Request.
+			// HTML-id destination rather than silently widening it to every active Request.
 			jw.reportMisuse(fmt.Errorf("jaws: Broadcast: %w", ErrEmptyCallTarget))
 			return
 		}
@@ -186,7 +186,7 @@ func (jw *Jaws) distributeDirt() int {
 	return len(dirt)
 }
 
-// Reload requests all [Request] values to reload their current page.
+// Reload requests all active [Request] values to reload their current page.
 func (jw *Jaws) Reload() {
 	jw.Broadcast(wire.Message{
 		What: what.Reload,
@@ -235,7 +235,7 @@ func (jw *Jaws) redirectMessage(url string) (msg wire.Message, ok bool) {
 	return
 }
 
-// Redirect requests all [Request] values to navigate to the given URL.
+// Redirect requests all active [Request] values to navigate to the given URL.
 //
 // The URL is validated to be a relative path or an http/https URL; script-bearing
 // schemes such as javascript: and protocol-relative ("//host") URLs are refused
@@ -246,7 +246,7 @@ func (jw *Jaws) Redirect(url string) {
 	}
 }
 
-// Alert sends an alert to all [Request] values.
+// Alert sends an alert to all active [Request] values.
 //
 // The level argument should be one of Bootstrap's alert levels:
 // primary, secondary, success, danger, warning, info, light or dark.

--- a/lib/wire/message.go
+++ b/lib/wire/message.go
@@ -8,9 +8,10 @@ import (
 
 // Message contains the elements of a message to be sent to requests.
 type Message struct {
-	// Dest selects recipients: nil targets every Request, a request key targets a
-	// single Request, an HTML id string targets matching elements in all Requests,
-	// and any other value is expanded into a tag or tag list.
+	// Dest selects recipients among active Requests: nil targets every active
+	// Request, a request key targets the matching active Request, an HTML id string
+	// targets matching elements in all active Requests, and any other value is
+	// expanded into a tag or tag list.
 	Dest any
 	What what.What // command to perform
 	Data string    // payload: inner HTML content or a tag list

--- a/session.go
+++ b/session.go
@@ -234,7 +234,7 @@ func (sess *Session) Requests() (requests []*Request) {
 	return
 }
 
-// Broadcast attempts to send a message to all [Request] values using this session.
+// Broadcast attempts to send a message to all active [Request] values using this session.
 //
 // It must not be called before the JaWS processing loop ([Jaws.Serve] or
 // [Jaws.ServeWithTimeout]) is running. Otherwise this call may block.


### PR DESCRIPTION
## Summary

- Describe broadcast destinations and convenience helpers in terms of active Requests, matching the serving-loop subscription behavior.
- Clarify that Session.Broadcast reaches active Requests belonging to the session.
- Update the security control table to describe the current single-claim key implementation: the Request remains registered while its key is routable, and repeated WebSocket callbacks are rejected by claim state.

## Scope

Documentation only; no executable behavior changes, so no performance benchmark is applicable.

## Verification

- JAWS_REQUIRE_NODE=1 go test -race ./...
- go vet ./...
- staticcheck ./...
- golangci-lint run ./...
- gofmt and git diff --check
- go doc for Jaws.Reload, Jaws.Redirect, Jaws.Alert, Session.Broadcast, and wire.Message