### PR TITLE
chore: remove retired Go Report Card badge and action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,10 +74,6 @@ jobs:
           path: coveragereport.html.out
           retention-days: 1
 
-      - name: Go report card
-        uses: creekorful/goreportcard-action@1f35ced8cdac2cba28c9a2f2288a16aacfd507f9 # v1.0
-        continue-on-error: true
-
       - name: Build
         run: go build -v ./...
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![build](https://github.com/linkdata/jaws/actions/workflows/build.yml/badge.svg)](https://github.com/linkdata/jaws/actions/workflows/build.yml)
 [![coverage](https://github.com/linkdata/jaws/blob/gitcoverage/main/badge.svg)](https://html-preview.github.io/?url=https://github.com/linkdata/jaws/blob/gitcoverage/main/report.html)
-[![goreport](https://goreportcard.com/badge/github.com/linkdata/jaws)](https://goreportcard.com/report/github.com/linkdata/jaws)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/linkdata/jaws/badge)](https://scorecard.dev/viewer/?uri=github.com/linkdata/jaws)
 [![Docs](https://godoc.org/github.com/linkdata/jaws?status.svg)](https://godoc.org/github.com/linkdata/jaws)
 


### PR DESCRIPTION
The Go Report Card GitHub Action (`creekorful/goreportcard-action`) and the `goreportcard.com` README badge are retired. This removes the CI step from `.github/workflows/build.yml` and the badge from `README.md`. No other badges or CI steps are touched.