### PR TITLE
Keep Request identities stable after completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,11 +243,10 @@ these invariants before relying on a green build alone:
 
 * Lock order stays `Jaws.mu -> Request.mu -> Session.mu`, with `Request.muQueue`
   and element/widget/value locks remaining leaf locks.
-* Request pooling clears keys, elements, tags, sessions, queues, cancellation
-  state, and pending/request maps before a pointer can be reused.
+* Every public Request keeps a stable identity. Completion releases its elements,
+  tags, sessions and queue storage for reuse without reusing the Request pointer.
 * Dirty dispatch expands tags once, targets only elements registered for those
-  tags, and does not let one request's queued update reach a recycled request
-  with a different key.
+  tags, and discards snapshots for Requests that have finished.
 * Session grace windows remain deliberate for unclaimed, claimed, failed-upgrade,
   and closed-WebSocket requests.
 * WebSocket upgrades keep the single-use key, client-IP binding, and Origin

--- a/broadcast.go
+++ b/broadcast.go
@@ -39,9 +39,8 @@ func (jw *Jaws) Broadcast(msg wire.Message) {
 	case nil: // send to all active requests
 	case key.Key: // send to the active request with this identity key
 		if dest == 0 {
-			// A recycled producer captured a zeroed key; no live request can match
-			// (keys are always non-zero), so drop it rather than fall through to
-			// tag expansion.
+			// No live request can have a zero key, so drop it rather than fall
+			// through to tag expansion.
 			return
 		}
 	default:
@@ -163,15 +162,11 @@ func (jw *Jaws) distributeDirt() int {
 
 	// Appending outside jw.mu is deliberately safe:
 	//   - The snapshot includes pending (not-yet-running) Requests; their todoDirt
-	//     buffers until they connect or are recycled (bounded by the request timeout),
+	//     buffers until they connect or finish (bounded by the request timeout),
 	//     so a value mutated in the render-to-connect window is reflected on the first
 	//     update pass.
-	//   - A Request can be recycled between snapshot and append. appendDirtyTags and
-	//     clearLocked both take rq.mu, so there is no data race, and stale tags in a
-	//     reborn Request resolve to nothing in Request.makeUpdateList against its
-	//     freshly emptied tagMap (at worst a redundant re-render). Applying dirt is
-	//     idempotent, so unlike destKey/cancelIfCurrent this path needs no
-	//     key-identity guard.
+	//   - A Request can finish between snapshot and append. appendDirtyTags checks
+	//     its registered state under rq.mu and discards the stale snapshot.
 	for _, rq := range reqs {
 		rq.appendDirtyTags(dirt)
 	}

--- a/jaws.go
+++ b/jaws.go
@@ -163,7 +163,7 @@ type Jaws struct {
 	serving                 atomic.Bool
 	defaultAuthOnce         sync.Once    // guards lazy creation of defaultAuthVal
 	defaultAuthVal          *DefaultAuth // shared fail-open Auth; see [Jaws.DefaultAuth]
-	reqPool                 sync.Pool
+	requestBufferPool       sync.Pool
 	serveJS                 *staticserve.StaticServe
 	serveCSS                *staticserve.StaticServe
 	mu                      deadlock.RWMutex // protects following
@@ -184,10 +184,11 @@ type Jaws struct {
 // New allocates a JaWS instance with the default configuration.
 //
 // The returned [Jaws] value is ready for use: static assets are embedded, the
-// broadcast channels and update ticker are allocated and the request pool is
-// primed. You must still start the processing loop with [Jaws.Serve] or
-// [Jaws.ServeWithTimeout] on its own goroutine before broadcasting. Call
-// [Jaws.Close] when finished with the instance to free associated resources.
+// broadcast channels and update ticker are allocated and the reusable request
+// buffer pool is primed. You must still start the processing loop with
+// [Jaws.Serve] or [Jaws.ServeWithTimeout] on its own goroutine before
+// broadcasting. Call [Jaws.Close] when finished with the instance to free
+// associated resources.
 func New() (jw *Jaws, err error) {
 	var serveJS, serveCSS *staticserve.StaticServe
 	if serveJS, err = staticserve.New("/jaws/.jaws.js", []byte(assets.JavascriptText)); err == nil {
@@ -214,11 +215,8 @@ func New() (jw *Jaws, err error) {
 			}
 			if err = tmp.GenerateHeadHTML(); err == nil {
 				jw = tmp
-				jw.reqPool.New = func() any {
-					return (&Request{
-						Jaws:   jw,
-						tagMap: make(map[any][]*Element),
-					}).clearLocked()
+				jw.requestBufferPool.New = func() any {
+					return &requestBuffers{tagMap: make(map[any][]*Element)}
 				}
 			}
 		}

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -1715,6 +1715,7 @@ func TestJaws_distributeDirt_AscendingOrder(t *testing.T) {
 	defer jw.Close()
 
 	rq := &Request{}
+	rq.registered = true
 	jw.mu.Lock()
 	jw.requests[1] = rq
 	jw.requestCount++
@@ -2474,15 +2475,13 @@ func TestServeHTTP_TailScript_EndpointIsPerRequest(t *testing.T) {
 	is.Equal(w.Code, http.StatusNoContent)
 }
 
-// TestServeHTTP_TailScript_RejectsRecycledKey covers the recycled-request behavior
-// of the /jaws/.tail endpoint: recycling deletes the key from jw.requests, so a tail
-// fetch for the old key misses the map and returns 404, while the reused pooled
-// object drains only its own freshly queued content (its queue was reset by
-// clearLocked), never the recycled request's. This exercises the map-deletion 404
-// and content isolation; the concurrent drain-under-lock guarantee (holding jw.mu
-// across drainTailScript) is exercised separately, under the race detector, by
+// TestServeHTTP_TailScript_RejectsFinishedKey covers the finished-request behavior
+// of the /jaws/.tail endpoint: completion removes the live map entry, so a fetch
+// for the old key returns 404 while a later Request drains only its own
+// queued content. The concurrent drain-under-lock guarantee (holding jw.mu across
+// drainTailScript) is exercised separately, under the race detector, by
 // TestRequest_TailScriptConcurrentWithRecycle.
-func TestServeHTTP_TailScript_RejectsRecycledKey(t *testing.T) {
+func TestServeHTTP_TailScript_RejectsFinishedKey(t *testing.T) {
 	is := newTestHelper(t)
 	jw, _ := New()
 	go jw.Serve()
@@ -2493,23 +2492,22 @@ func TestServeHTTP_TailScript_RejectsRecycledKey(t *testing.T) {
 	stale.NewElement(&testUi{}).SetClass("stale")
 	staleKey := stale.JawsKeyString()
 
-	// Recycle the request and create a new one under a fresh key. The pool typically
-	// hands back the same struct, so the content check below also guards that a
-	// reused object carries none of the recycled request's queued content; it holds
-	// whether or not the pool reused the struct.
+	// Finish the request and create a distinct one under a fresh key.
 	jw.recycle(stale)
 	rq := jw.NewRequest(hr)
+	if rq == stale {
+		t.Fatal("later request reused finished Request identity")
+	}
 	rq.NewElement(&testUi{}).SetClass("fresh")
 
-	// Old key was deleted from jw.requests on recycle, so the lookup misses and
-	// nothing is drained.
+	// The old key has no live map entry, so nothing is drained.
 	req := httptest.NewRequest(http.MethodGet, "/jaws/.tail/"+staleKey, nil)
 	req.RemoteAddr = hr.RemoteAddr
 	w := httptest.NewRecorder()
 	jw.ServeHTTP(w, req)
 	is.Equal(w.Code, http.StatusNotFound)
 
-	// The reused request's own tail fetch still returns its own content.
+	// The later request's own tail fetch returns only its own content.
 	req = httptest.NewRequest(http.MethodGet, "/jaws/.tail/"+rq.JawsKeyString(), nil)
 	req.RemoteAddr = hr.RemoteAddr
 	w = httptest.NewRecorder()
@@ -2584,17 +2582,17 @@ func TestJaws_cancelIfCurrent_IgnoresStaleRequest(t *testing.T) {
 	stale := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
 	jawsKey := stale.JawsKey
 
-	// The /jaws/.tail handler snapshots the Request before writing the response;
-	// recycle the snapshot and create a new request so the pool can hand the
-	// stale pointer to a different connection, as can happen before a write
-	// error triggers a cancel.
+	// The /jaws/.tail handler can snapshot the Request before writing the response;
+	// finish that snapshot before the write error triggers cancellation.
 	jw.recycle(stale)
 	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	if rq == stale {
+		t.Fatal("later request reused stale Request identity")
+	}
 
 	jw.cancelIfCurrent(jawsKey, stale, errors.New("write failed"))
 
-	// Whether or not the pool reused the object for rq (it normally does here,
-	// which is exactly the stale-cancel scenario), rq must stay live.
+	// The later Request must stay live.
 	is.NoErr(rq.Context().Err())
 }
 
@@ -2695,11 +2693,13 @@ func newUnpooledBenchRequest(jw *Jaws) (rq *Request) {
 		jawsKey := jw.nonZeroRandomLocked()
 		if _, ok := jw.requests[jawsKey]; !ok {
 			rq = &Request{
-				Jaws:   jw,
-				tagMap: make(map[any][]*Element),
+				Jaws:    jw,
+				buffers: &requestBuffers{},
+				tagMap:  make(map[any][]*Element),
 			}
 			rq.mu.Lock()
 			rq.JawsKey = jawsKey
+			rq.registered = true
 			rq.lastWriteSeconds.Store(jw.runtimeSeconds.Load())
 			rq.remoteIP = remoteIP
 			rq.ctx, rq.cancelFn = context.WithCancelCause(jw.BaseContext)
@@ -2716,13 +2716,14 @@ func recycleUnpooledBenchRequest(jw *Jaws, rq *Request) {
 	jw.mu.Lock()
 	defer jw.mu.Unlock()
 	rq.mu.Lock()
-	defer rq.mu.Unlock()
-	if rq.JawsKey != 0 {
+	if rq.JawsKey != 0 && jw.requests[rq.JawsKey] == rq {
+		_ = rq.cancelLocked(nil)
 		jw.removePendingRequestLocked(rq)
 		delete(jw.requests, rq.JawsKey)
 		jw.requestCount--
-		rq.clearLocked()
+		_ = rq.releaseBuffersLocked()
 	}
+	rq.mu.Unlock()
 }
 
 func populateBenchRequest(rq *Request, tags []any) {
@@ -2731,10 +2732,10 @@ func populateBenchRequest(rq *Request, tags []any) {
 	}
 }
 
-// BenchmarkRequestLifecyclePooling compares the current pooled Request lifecycle
-// with a benchmark-only fresh-allocation lifecycle. It isolates the create,
-// optional render-state population and recycle path; it does not measure HTTP or
-// WebSocket serving.
+// BenchmarkRequestLifecyclePooling compares the reusable-buffer Request lifecycle
+// with a benchmark-only lifecycle that allocates fresh buffers. It isolates the
+// create, optional render-state population and completion path; it does not
+// measure HTTP or WebSocket serving.
 func BenchmarkRequestLifecyclePooling(b *testing.B) {
 	for _, c := range []struct {
 		name  string
@@ -2890,7 +2891,7 @@ func BenchmarkDistributeDirt(b *testing.B) {
 			reqs := make([]*Request, c.reqs)
 			jw.mu.Lock()
 			for i := range reqs {
-				rq := &Request{Jaws: jw}
+				rq := &Request{Jaws: jw, registered: true}
 				reqs[i] = rq
 				jw.requests[key.Key(i+1)] = rq
 			}

--- a/request.go
+++ b/request.go
@@ -33,8 +33,19 @@ const webSocketReadLimit = 32 * 1024
 // Returning an error causes the [Request] to abort, and the WebSocket connection to close.
 type ConnectFn = func(rq *Request) error
 
+type requestBuffers struct {
+	todoDirt []any
+	elems    []*Element
+	tagMap   map[any][]*Element
+	wsQueue  []wire.WsMsg
+}
+
 // Request maintains the state for a JaWS WebSocket connection, and handles processing
 // of events and broadcasts.
+//
+// Each Request has a stable identity and is never reused for another connection.
+// After it finishes, its context remains canceled and identity-targeted operations
+// are not retargeted to another Request.
 //
 // Unlike [Session], whose methods are nil-safe, Request methods are not safe to call on a
 // nil *Request: a Request is always obtained from [Jaws.NewRequest] or [Jaws.UseRequest]
@@ -46,6 +57,7 @@ type Request struct {
 	Jaws             *Jaws                   // (read-only) the JaWS instance the Request belongs to
 	JawsKey          key.Key                 // (read-only) random key assigned to this Request; routes JaWS URLs and request-targeted broadcasts only while registered
 	remoteIP         netip.Addr              // (read-only) remote IP, or the zero netip.Addr if unset
+	registered       bool                    // present as a live identity in Jaws.requests; guarded by mu
 	running          atomic.Bool             // if ServeHTTP() is running
 	claimed          atomic.Bool             // if UseRequest() has been called for it
 	lastWriteSeconds atomic.Int32            // [Jaws.runtimeSeconds] value at the most recent RequestWriter write; lock-free, drives pending-eviction recency (oldestEvictablePendingLocked) and idle expiry (maintenance)
@@ -58,6 +70,7 @@ type Request struct {
 	httpDoneCh       <-chan struct{}         // once claimed, set to http.Request.Context().Done()
 	cancelFn         context.CancelCauseFunc // cancel function
 	connectFn        ConnectFn               // a ConnectFn to call before starting message processing for the Request
+	buffers          *requestBuffers         // detached and reused after this Request finishes
 	elems            []*Element              // our Elements
 	tagMap           map[any][]*Element      // maps tags to Elements
 	muQueue          deadlock.Mutex          // protects wsQueue and tailsent
@@ -103,12 +116,13 @@ func (rq *Request) MarkWritten() {
 
 // destKey returns the Request's current identity key, read under rq.mu, for use as
 // a broadcast destination. Targeting the key value rather than the *Request pointer
-// lets the Serve loop reject a message aimed at a request that was recycled and
-// reused before delivery, since the pooled pointer is reused but its key is not. A
-// zero return means the Request has already been recycled and is not a valid target.
+// lets the Serve loop reject messages after the Request is unregistered. A zero
+// return means the Request is no longer a valid target.
 func (rq *Request) destKey() (k key.Key) {
 	rq.mu.RLock()
-	k = rq.JawsKey
+	if rq.registered {
+		k = rq.JawsKey
+	}
 	rq.mu.RUnlock()
 	return
 }
@@ -153,7 +167,7 @@ func (rq *Request) claim(r *http.Request) error {
 			rq.httpDoneCh = httpDoneCh
 			// Refresh the write second so a request claimed long after its initial
 			// render (a throttled or backgrounded tab) is not treated as idle and
-			// recycled in the window before ServeHTTP sets running.
+			// retired in the window before ServeHTTP sets running.
 			rq.lastWriteSeconds.Store(rq.Jaws.runtimeSeconds.Load())
 			return nil
 		}
@@ -175,7 +189,7 @@ func (rq *Request) killSession() {
 }
 
 // deadSession detaches sess and returns the Request identity that belonged to it.
-// A zero return means rq was already recycled or rebound to another Session.
+// A zero return means rq has finished or belongs to another Session.
 func (rq *Request) deadSession(sess *Session) (k key.Key) {
 	rq.mu.Lock()
 	if rq.session == sess {
@@ -208,36 +222,32 @@ func (rq *Request) ensureAutoSession(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// clearLocked resets rq so it can be reused from the [Jaws] request pool: it cancels
-// any live context, drops queued dirt and messages, detaches all elements and tags,
-// and kills any attached session. The caller must ensure no other goroutine is using
-// rq (it runs when rq is freshly allocated or being recycled).
-func (rq *Request) clearLocked() *Request {
-	rq.JawsKey = 0
+// releaseBuffersLocked detaches reusable storage from a finished Request.
+//
+// It releases queued dirt and messages, marks elements deleted, and detaches the
+// Request from its session. The Request keeps its identity and canceled context,
+// so retained pointers remain permanently associated with this lifecycle. The
+// caller must hold rq.mu and ensure request processing has stopped.
+func (rq *Request) releaseBuffersLocked() (buffers *requestBuffers) {
+	if rq.cancelFn != nil {
+		rq.cancelFn(nil)
+	}
 	rq.lastJid = 0
 	rq.connectFn = nil
-	rq.lastWriteSeconds.Store(0)
 	rq.initial = nil
 	rq.killSessionLocked()
 	rq.running.Store(false)
 	rq.claimed.Store(false)
-	// Every field is reset to its zero state except ctx and cancelFn, which keep their
-	// (cancelled) values until getRequestLocked replaces them on reuse.
-	if rq.cancelFn != nil {
-		rq.cancelFn(nil)
-	}
+	rq.registered = false
 	rq.httpDoneCh = nil
-	clear(rq.todoDirt) // release tag references before pooling; mirrors makeUpdateList
+	clear(rq.todoDirt)
 	rq.todoDirt = rq.todoDirt[:0]
 	rq.remoteIP = netip.Addr{}
 	for _, e := range rq.elems {
 		if e != nil {
 			// Nil the GC-reachable fields and set the deleted guard, which makes any
-			// retained *Element inert (see [Element.Deleted]). The Request back-pointer
-			// and frozen flag are deliberately left as-is: Elements are allocated fresh
-			// per newElementLocked and never pooled, so a stale frozen value can never
-			// be observed by a reused Element. Any future move to pool Elements must
-			// also reset frozen, since it gates the lock-free handler read.
+			// retained *Element inert (see [Element.Deleted]). Elements are allocated
+			// fresh per newElementLocked and are never pooled.
 			e.handlers = nil
 			e.ui = nil
 			e.deleted.Store(true)
@@ -252,11 +262,24 @@ func (rq *Request) clearLocked() *Request {
 	// already hold rq.mu.
 	rq.muQueue.Lock()
 	rq.tailsent = false
-	clear(rq.wsQueue) // release queued message payloads before pooling; mirrors todoDirt/elems above
+	clear(rq.wsQueue)
 	rq.wsQueue = rq.wsQueue[:0]
 	rq.muQueue.Unlock()
 	clear(rq.tagMap)
-	return rq
+
+	buffers = rq.buffers
+	if buffers != nil {
+		buffers.todoDirt = rq.todoDirt
+		buffers.elems = rq.elems
+		buffers.tagMap = rq.tagMap
+		buffers.wsQueue = rq.wsQueue
+	}
+	rq.buffers = nil
+	rq.todoDirt = nil
+	rq.elems = nil
+	rq.tagMap = nil
+	rq.wsQueue = nil
+	return
 }
 
 // HeadHTML writes the configured resources and Request key metadata for the page head.
@@ -362,8 +385,8 @@ func (rq *Request) SetContext(fn func(oldCtx context.Context) (newCtx context.Co
 	// that old select wakes. Register outside rq.mu because context.AfterFunc may
 	// synchronously invoke a custom context hook that re-enters the Request.
 	//
-	// Capture only the context and cancel closure: capturing rq would let a delayed
-	// callback cancel an unrelated Request after pool reuse.
+	// Capture only the context and cancel closure so the callback does not retain
+	// the entire Request and its rendered state.
 	context.AfterFunc(newCtx, func() {
 		cancelFn(context.Cause(newCtx))
 	})
@@ -406,14 +429,14 @@ func (rq *Request) maintenance(nowSeconds int32, requestTimeout time.Duration) (
 	return
 }
 
-// cancelLocked cancels the request's context with a wrapped cause, but only for a
-// live request (non-zero key) whose context has not already been cancelled.
+// cancelLocked cancels the Request's context, wrapping a non-nil cause, when the
+// Request has a non-zero identity key and has not already been canceled.
 //
 // It does NOT log. It returns the cancellation cause (already set on the context)
 // so the caller can pass it to [Jaws.Log] AFTER releasing rq.mu and any outer lock;
-// the cause is nil whenever there is nothing to log (no live request to cancel, or
-// a nil err). Logging invokes the user-supplied [Jaws.Logger], which the package
-// locking contract forbids running under a lock. Caller must hold rq.mu.
+// the cause is nil whenever the context was already canceled or err is nil.
+// Logging invokes the user-supplied [Jaws.Logger], which the package locking
+// contract forbids running under a lock. Caller must hold rq.mu.
 func (rq *Request) cancelLocked(err error) (cause error) {
 	if rq.JawsKey != 0 && rq.ctx.Err() == nil {
 		cause = newErrRequestCancelledLocked(rq, err)
@@ -460,7 +483,7 @@ func alertData(level, msg string) string {
 //
 // The default JaWS JavaScript only supports Bootstrap dismissible alerts.
 //
-// It does nothing if the Request has already been recycled, since it then has no
+// It does nothing if the Request has already finished, since it then has no
 // live target. See [Jaws.Broadcast] for processing-loop requirements.
 func (rq *Request) Alert(level, msg string) {
 	if k := rq.destKey(); k != 0 {
@@ -486,7 +509,7 @@ func (rq *Request) AlertError(err error) {
 // schemes such as javascript: and protocol-relative ("//host") URLs are refused
 // and logged rather than sent to the browser.
 //
-// It does nothing if the Request has already been recycled, since it then has no
+// It does nothing if the Request has already finished, since it then has no
 // live target. See [Jaws.Broadcast] for processing-loop requirements.
 func (rq *Request) Redirect(url string) {
 	if msg, ok := rq.Jaws.redirectMessage(url); ok {
@@ -530,8 +553,11 @@ func (rq *Request) wantMessage(msg *wire.Message) (yes bool) {
 	switch dest := msg.Dest.(type) {
 	case key.Key: // the request with this identity key
 		rq.mu.RLock()
-		defer rq.mu.RUnlock()
-		return rq.JawsKey == dest
+		if rq.registered {
+			yes = rq.JawsKey == dest
+		}
+		rq.mu.RUnlock()
+		return
 	case []any: // more than one tag
 		rq.mu.RLock()
 		defer rq.mu.RUnlock()
@@ -624,12 +650,13 @@ func (rq *Request) HasTag(elem *Element, tagValue any) (yes bool) {
 // list. The Serve loop's update tick later drains the list (see makeUpdateList)
 // and re-renders the affected elements. Takes rq.mu.
 //
-// It may run on a Request that was recycled and reused after the caller's dirt
-// snapshot was taken; that is race-free (clearLocked also takes rq.mu) and harmless,
-// as explained on distributeDirt.
+// It may run after the caller's dirt snapshot was unregistered. In that case the
+// tags are discarded rather than retained on the finished Request.
 func (rq *Request) appendDirtyTags(tags []any) {
 	rq.mu.Lock()
-	rq.todoDirt = append(rq.todoDirt, tags...)
+	if rq.registered {
+		rq.todoDirt = append(rq.todoDirt, tags...)
+	}
 	rq.mu.Unlock()
 }
 

--- a/request_identity_test.go
+++ b/request_identity_test.go
@@ -1,0 +1,62 @@
+package jaws
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+func TestRequestLateCancelDoesNotReachNextConnection(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+	go jw.Serve()
+	waitForServeLoop(t, jw)
+
+	server := httptest.NewServer(jw)
+	defer server.Close()
+	newInitialRequest := func(path string) *http.Request {
+		r := httptest.NewRequest(http.MethodGet, server.URL+path, nil)
+		r.RemoteAddr = "127.0.0.1:12345"
+		return r
+	}
+
+	finished := jw.NewRequest(newInitialRequest("/first"))
+	finishedKey := finished.JawsKey
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(server.URL, "http")+"/jaws/"+finished.JawsKeyString(), &websocket.DialOptions{
+		HTTPHeader: http.Header{"Origin": []string{server.URL}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = conn.Close(websocket.StatusNormalClosure, ""); err != nil {
+		t.Fatal(err)
+	}
+	waitForRequestCount(t, jw, 0, time.Second)
+
+	replacement := jw.NewRequest(newInitialRequest("/second"))
+	defer jw.recycle(replacement)
+	if replacement == finished {
+		t.Fatal("NewRequest reused the finished Request identity")
+	}
+	if finished.JawsKey != finishedKey {
+		t.Fatalf("finished Request key = %v, want stable key %v", finished.JawsKey, finishedKey)
+	}
+	replacementCtx := replacement.Context()
+	finished.Cancel(errors.New("background operation completed after disconnect"))
+	select {
+	case <-replacementCtx.Done():
+		t.Fatalf("late Cancel reached the next Request: %v", context.Cause(replacementCtx))
+	default:
+	}
+}

--- a/request_test.go
+++ b/request_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -105,12 +104,9 @@ func TestRequest_wantMessage_KeyDest(t *testing.T) {
 	}
 }
 
-// TestRequest_wantMessage_RejectsRecycledKey is the core broadcast regression:
-// matching on the identity key rather than the *Request pointer lets the loop
-// reject a message aimed at a request that was recycled and reused under a new key,
-// even when it is the very same pooled object. A dest==*Request match could not
-// tell the reused object from the original; a key match can.
-func TestRequest_wantMessage_RejectsRecycledKey(t *testing.T) {
+// TestRequest_wantMessage_RejectsFinishedRequest verifies an unregistered
+// Request cannot receive broadcasts addressed to its former live key.
+func TestRequest_wantMessage_RejectsFinishedRequest(t *testing.T) {
 	is := newTestHelper(t)
 	jw, _ := New()
 	go jw.Serve()
@@ -120,22 +116,13 @@ func TestRequest_wantMessage_RejectsRecycledKey(t *testing.T) {
 	staleKey := rq.JawsKey
 	is.True(rq.wantMessage(&wire.Message{Dest: staleKey}))
 
-	// Recycle zeroes the key, so the same object no longer matches the old key.
 	jw.recycle(rq)
 	is.Equal(rq.wantMessage(&wire.Message{Dest: staleKey}), false)
 
-	// Reuse the same object under a fresh key, as the pool handing it back to a new
-	// connection would. Re-key directly under rq.mu (the lock destKey/wantMessage
-	// use) so the aliasing is deterministic rather than dependent on the pool
-	// returning this struct. A message still aimed at the old key must be rejected
-	// even though rq is the same object it once identified; one aimed at the new
-	// key is accepted.
-	newKey := staleKey + 1
-	rq.mu.Lock()
-	rq.JawsKey = newKey
-	rq.mu.Unlock()
-	is.Equal(rq.wantMessage(&wire.Message{Dest: staleKey}), false)
-	is.True(rq.wantMessage(&wire.Message{Dest: newKey}))
+	replacement := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/next", nil))
+	defer jw.recycle(replacement)
+	is.True(replacement != rq)
+	is.True(replacement.wantMessage(&wire.Message{Dest: replacement.JawsKey}))
 }
 
 func TestRequest_HeadHTML(t *testing.T) {
@@ -362,10 +349,9 @@ func TestRequest_writeTailScript_IsolatesEachFixup(t *testing.T) {
 
 // TestRequest_TailScriptConcurrentWithRecycle exercises a /jaws/.tail fetch
 // racing recycle of the same still-pending request. The handler holds jw.mu (read)
-// across the drainTailScript call and recycle needs the jw.mu write lock, so the
-// drain and recycle are serialized: the fetch can never drain a recycled+reused
-// request. clearLocked also takes muQueue to reset wsQueue/tailsent, the lock
-// drainTailScript holds, so that reset cannot race the drain either. Run with -race.
+// across the drainTailScript call and completion needs the jw.mu write lock, so
+// the drain and completion are serialized. releaseBuffersLocked also takes
+// muQueue, so detaching the buffers cannot race the drain. Run with -race.
 func TestRequest_TailScriptConcurrentWithRecycle(t *testing.T) {
 	jw, _ := New()
 	defer jw.Close()
@@ -394,9 +380,7 @@ func TestRequest_TailScriptConcurrentWithRecycle(t *testing.T) {
 }
 
 // TestRequest_wantMessageConcurrentWithRecycle stresses the broadcast identity
-// check: wantMessage reads rq.JawsKey under rq.mu while recycle zeroes it under the
-// same lock. The read and write must be serialized so there is no data race on the
-// key. Run with -race.
+// check while completion unregisters the Request. Run with -race.
 func TestRequest_wantMessageConcurrentWithRecycle(t *testing.T) {
 	jw, _ := New()
 	defer jw.Close()
@@ -616,7 +600,7 @@ func (ctx *deferredAfterContext) fire() {
 	}
 }
 
-func TestRequest_SetContextDelayedCallbackDoesNotCancelReusedRequest(t *testing.T) {
+func TestRequest_SetContextDelayedCallbackDoesNotCancelNextRequest(t *testing.T) {
 	jw, err := New()
 	if err != nil {
 		t.Fatal(err)
@@ -643,12 +627,9 @@ func TestRequest_SetContextDelayedCallbackDoesNotCancelReusedRequest(t *testing.
 	deferred.cancel()
 	jw.recycle(first)
 
-	poolNew := jw.reqPool.New
-	jw.reqPool.New = func() any { return first }
-	defer func() { jw.reqPool.New = poolNew }()
 	second := jw.NewRequest(nil)
-	if second != first {
-		t.Fatal("request pool did not reuse the Request")
+	if second == first {
+		t.Fatal("NewRequest reused a finished Request identity")
 	}
 	secondCtx := second.Context()
 	callbackArmed.Store(true)
@@ -660,7 +641,7 @@ func TestRequest_SetContextDelayedCallbackDoesNotCancelReusedRequest(t *testing.
 	}
 	select {
 	case <-secondCtx.Done():
-		t.Fatal("delayed SetContext callback canceled the reused Request")
+		t.Fatal("delayed SetContext callback canceled the next Request")
 	default:
 	}
 	jw.recycle(second)
@@ -862,9 +843,8 @@ func TestRequest_EventFnQueueOverflowCancelsRequest(t *testing.T) {
 
 // TestRequest_ClaimRefreshesLastWriteAndStartServeGuards verifies that claim()
 // refreshes lastWrite so a request claimed long after its initial render is not
-// treated as idle and recycled before ServeHTTP sets running, and that startServe()
-// refuses a request that was recycled (clearLocked resets claimed) rather than
-// driving a dead, pooled *Request.
+// treated as idle and retired before ServeHTTP sets running, and that startServe()
+// refuses a Request whose completion released its buffers and reset claimed.
 func TestRequest_ClaimRefreshesLastWriteAndStartServeGuards(t *testing.T) {
 	jw, err := New()
 	if err != nil {
@@ -885,10 +865,10 @@ func TestRequest_ClaimRefreshesLastWriteAndStartServeGuards(t *testing.T) {
 		t.Fatal("a freshly claimed request must not be treated as idle by maintenance")
 	}
 
-	// If a request is recycled anyway, startServe must refuse to drive it.
+	// If a request finishes anyway, startServe must refuse to drive it.
 	jw.recycle(rq)
 	if rq.startServe() {
-		t.Fatal("startServe must refuse a recycled request")
+		t.Fatal("startServe must refuse a finished request")
 	}
 }
 
@@ -1066,7 +1046,7 @@ func TestBroadcast_ZeroKeyDestDropped(t *testing.T) {
 	defer tj.Close()
 	rq := tj.newRequest(nil)
 
-	// A zero key (captured from an already-recycled request) targets no live
+	// A zero key targets no live
 	// request: Broadcast drops it before it reaches the Serve loop rather than
 	// treating it as a tag. A real follow-up still arrives, proving only the
 	// zero-key message was dropped, and no bad-destination misuse is logged.
@@ -1089,12 +1069,12 @@ func TestBroadcast_ZeroKeyDestDropped(t *testing.T) {
 	th.Equal(strings.Contains(tj.log.String(), "jaws: Broadcast"), false)
 }
 
-// TestRequest_ProducersSkipRecycled covers the destKey()==0 branch in Request.Alert
-// and Request.Redirect. Once a Request is recycled it carries the zero key, so both
+// TestRequest_ProducersSkipFinished covers the destKey()==0 branch in Request.Alert
+// and Request.Redirect. Once a Request finishes it is no longer registered, so both
 // take the skip branch and never call Broadcast. A zero-key broadcast would be
 // dropped by Jaws.Broadcast anyway (see TestBroadcast_ZeroKeyDestDropped); the guard
 // avoids the round-trip, and exercising it is the only coverage of the branch.
-func TestRequest_ProducersSkipRecycled(t *testing.T) {
+func TestRequest_ProducersSkipFinished(t *testing.T) {
 	th := newTestHelper(t)
 	jw, _ := New()
 	defer jw.Close()
@@ -1109,7 +1089,7 @@ func TestRequest_ProducersSkipRecycled(t *testing.T) {
 
 	select {
 	case msg := <-jw.bcastCh:
-		t.Fatalf("recycled request must not broadcast, got %#v", msg)
+		t.Fatalf("finished request must not broadcast, got %#v", msg)
 	default:
 	}
 }
@@ -3165,33 +3145,36 @@ func waitForRequestCounts(t *testing.T, jw *Jaws, wantTotal, wantActive int, tim
 	}
 }
 
-// TestClearLockedZeroesWsQueue verifies clearLocked releases the queued wire
-// message payloads before the Request is pooled, mirroring its clear() of todoDirt
-// and elems. A bare [:0] reslice would leave the WsMsg values (including Data,
-// which holds full Inner/Replace/Append HTML payloads) live in the backing array
-// for the pooled Request's idle lifetime.
-func TestClearLockedZeroesWsQueue(t *testing.T) {
-	rq := &Request{tagMap: map[any][]*Element{}}
+// TestReleaseBuffersLockedZeroesWsQueue verifies detached request storage does
+// not retain queued message payloads while it waits in the buffer pool.
+func TestReleaseBuffersLockedZeroesWsQueue(t *testing.T) {
+	rq := &Request{
+		buffers: &requestBuffers{},
+		tagMap:  map[any][]*Element{},
+	}
 	rq.wsQueue = append(
 		rq.wsQueue,
 		wire.WsMsg{Data: "payload-a", Jid: 1, What: what.Inner},
 		wire.WsMsg{Data: "payload-b", Jid: 2, What: what.Inner},
 	)
 
-	rq.clearLocked()
+	buffers := rq.releaseBuffersLocked()
 
-	if len(rq.wsQueue) != 0 {
-		t.Fatalf("wsQueue len = %d, want 0", len(rq.wsQueue))
+	if rq.wsQueue != nil {
+		t.Fatalf("finished Request wsQueue = %#v, want nil", rq.wsQueue)
 	}
-	for i, m := range rq.wsQueue[:cap(rq.wsQueue)] {
+	if len(buffers.wsQueue) != 0 {
+		t.Fatalf("reusable wsQueue len = %d, want 0", len(buffers.wsQueue))
+	}
+	for i, m := range buffers.wsQueue[:cap(buffers.wsQueue)] {
 		if m != (wire.WsMsg{}) {
-			t.Errorf("wsQueue backing slot %d retained data after clearLocked: %+v", i, m)
+			t.Errorf("reusable wsQueue backing slot %d retained data: %+v", i, m)
 		}
 	}
 }
 
 // TestDelRequestNilsVacatedSlot verifies delRequest clears the freed tail slot so a
-// session does not pin an otherwise-recyclable *Request in the slice backing array.
+// session does not pin an otherwise-finished *Request in the slice backing array.
 func TestDelRequestNilsVacatedSlot(t *testing.T) {
 	t.Run("swap remove", func(t *testing.T) {
 		sess := &Session{}
@@ -3224,13 +3207,10 @@ func TestDelRequestNilsVacatedSlot(t *testing.T) {
 	})
 }
 
-// TestRequest_JawsKeyReadsAreLockedDuringRecycle verifies that the request-key
-// readers used while the application renders the initial HTML page
-// (JawsKeyString, String, HeadHTML and TailHTML) read rq.JawsKey under rq.mu, so
-// they do not race the rq.mu-guarded writes to rq.JawsKey that clearLocked and
-// getRequestLocked perform when a Request completes and its pooled storage is
-// reused. Run with -race.
-func TestRequest_JawsKeyReadsAreLockedDuringRecycle(t *testing.T) {
+// TestRequest_IdentityRemainsStableAfterRecycle verifies a retained Request
+// remains associated with its original lifecycle after its reusable storage is
+// released.
+func TestRequest_IdentityRemainsStableAfterRecycle(t *testing.T) {
 	jw, err := New()
 	if err != nil {
 		t.Fatal(err)
@@ -3238,35 +3218,27 @@ func TestRequest_JawsKeyReadsAreLockedDuringRecycle(t *testing.T) {
 	t.Cleanup(jw.Close)
 
 	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	wantKey := rq.JawsKey
+	jw.recycle(rq)
+	if rq.Context().Err() == nil {
+		t.Fatal("finished Request context is not canceled")
+	}
+	replacement := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/next", nil))
+	defer jw.recycle(replacement)
 
-	const iterations = 2000
-	var wg sync.WaitGroup
-	wg.Add(2)
-
-	// Writer: mimic clearLocked / getRequestLocked, which assign rq.JawsKey while
-	// holding rq.mu.
-	go func() {
-		defer wg.Done()
-		for i := range iterations {
-			rq.mu.Lock()
-			rq.JawsKey = key.Key(uint64(i) + 1)
-			rq.mu.Unlock()
-		}
-	}()
-
-	// Reader: the lock-free render-path readers that previously read rq.JawsKey
-	// without holding rq.mu.
-	go func() {
-		defer wg.Done()
-		for range iterations {
-			_ = rq.JawsKeyString()
-			_ = rq.String()
-			_ = rq.HeadHTML(io.Discard)
-			_ = rq.TailHTML(io.Discard)
-		}
-	}()
-
-	wg.Wait()
+	if replacement == rq {
+		t.Fatal("NewRequest reused a finished Request identity")
+	}
+	if rq.JawsKey != wantKey || rq.JawsKeyString() != wantKey.String() {
+		t.Fatalf("finished Request identity changed to %v, want %v", rq.JawsKey, wantKey)
+	}
+	if rq.destKey() != 0 {
+		t.Fatalf("finished Request destination = %v, want zero", rq.destKey())
+	}
+	rq.Cancel(errors.New("late cancellation"))
+	if err := replacement.Context().Err(); err != nil {
+		t.Fatalf("late cancellation reached replacement Request: %v", err)
+	}
 }
 
 // TestServe_MarksRequestRunningSoMaintenanceSkips verifies that TestServe marks

--- a/requestloop.go
+++ b/requestloop.go
@@ -25,10 +25,9 @@ import (
 // process is the main message processing loop. Will unsubscribe broadcastMsgCh and close outboundMsgCh on exit.
 func (rq *Request) process(broadcastMsgCh chan wire.Message, incomingMsgCh <-chan wire.WsMsg, outboundMsgCh chan<- wire.WsMsg) {
 	jawsDoneCh := rq.Jaws.Done()
-	// Snapshot cancelFn under rq.mu, the same way ServeHTTP does: its only writers
-	// (claim, getRequestLocked, clearLocked) run strictly before or after process,
-	// so the captured value is stable for the loop's lifetime and the cleanup defer
-	// avoids a lock-free field read.
+	// Snapshot cancelFn under rq.mu, the same way ServeHTTP does. Initialization and
+	// claim run before process, so the captured value is stable for the loop's
+	// lifetime and the cleanup defer avoids a lock-free field read.
 	rq.mu.RLock()
 	httpDoneCh := rq.httpDoneCh
 	cancelFn := rq.cancelFn

--- a/requestpool.go
+++ b/requestpool.go
@@ -1,9 +1,9 @@
 package jaws
 
-// This file manages the server-side Request pool: NewRequest creates a pending
-// Request, UseRequest claims it when the WebSocket connects, the per-IP pending
-// limit retires the oldest unclaimed Request, the random helpers mint identity
-// keys, and recycle/cancelIfCurrent tear completed Requests down.
+// This file manages server-side Request lifecycles: NewRequest creates a pending
+// Request with fresh identity and reusable buffers, UseRequest claims it when the
+// WebSocket connects, the per-IP pending limit retires the oldest unclaimed
+// Request, and completion releases buffers while preserving public identity.
 
 import (
 	"context"
@@ -35,10 +35,10 @@ import (
 // A Request created after [Jaws.Close] has an already-canceled context and cannot
 // be claimed by [Jaws.UseRequest].
 //
-// When timeout maintenance or the per-IP pending limit retires an unclaimed
-// Request, its key becomes unclaimable. The key also remains unavailable for
-// assignment to another Request while the retired Request is reachable; no
-// deadline is guaranteed for later reuse.
+// Every call returns a distinct Request identity. When timeout maintenance or
+// the per-IP pending limit retires an unclaimed Request, its key remains
+// unavailable for assignment to another Request while the retired Request is
+// reachable; no deadline is guaranteed for later key reuse.
 //
 // NewRequest panics if the system CSPRNG ([crypto/rand]) fails while generating
 // the request key, which does not happen on supported platforms.
@@ -214,20 +214,33 @@ func (jw *Jaws) UseRequest(jawsKey key.Key, r *http.Request) (rq *Request) {
 	return
 }
 
-// getRequestLocked allocates a Request from the pool for jawsKey. remoteIP is the
+// getRequestLocked allocates a fresh Request identity for jawsKey. remoteIP is the
 // already-resolved client IP for r (see NewRequest, the sole caller), passed in to
-// avoid recomputing jw.clientIP(r). attachSession is false after Jaws.Close, when
+// avoid recomputing jw.clientIP(r). registered is false after Jaws.Close, when
 // the canceled Request is returned without registration. Caller must hold jw.mu.
-func (jw *Jaws) getRequestLocked(jawsKey key.Key, r *http.Request, remoteIP netip.Addr, attachSession bool) (rq *Request) {
-	rq = jw.reqPool.Get().(*Request)
+func (jw *Jaws) getRequestLocked(jawsKey key.Key, r *http.Request, remoteIP netip.Addr, registered bool) (rq *Request) {
+	buffers := jw.requestBufferPool.Get().(*requestBuffers)
+	rq = &Request{
+		Jaws:     jw,
+		buffers:  buffers,
+		todoDirt: buffers.todoDirt,
+		elems:    buffers.elems,
+		tagMap:   buffers.tagMap,
+		wsQueue:  buffers.wsQueue,
+	}
+	buffers.todoDirt = nil
+	buffers.elems = nil
+	buffers.tagMap = nil
+	buffers.wsQueue = nil
 	rq.mu.Lock()
 	defer rq.mu.Unlock()
 	rq.JawsKey = jawsKey
+	rq.registered = registered
 	rq.lastWriteSeconds.Store(jw.runtimeSeconds.Load())
 	rq.initial = r
 	rq.remoteIP = remoteIP
 	rq.ctx, rq.cancelFn = context.WithCancelCause(jw.BaseContext)
-	if attachSession && r != nil {
+	if registered && r != nil {
 		if sess := jw.getSessionLocked(getCookieSessionsIDs(r.Header, jw.CookieName), rq.remoteIP); sess != nil {
 			sess.addRequest(rq)
 			rq.session = sess
@@ -288,6 +301,7 @@ func (jw *Jaws) retireNonRunningRequestCoreLocked(rq *Request, err error, causeO
 		// WebSocket that never reached ServeHTTP still earns the session grace
 		// period granted by Session.delRequest.
 		rq.killSessionLocked()
+		rq.registered = false
 		rq.claimed.Store(false)
 		runtime.AddCleanup(rq, releaseRetiredRequestKey, retiredRequestKey{jw: weak.Make(jw), jawsKey: jawsKey})
 	}
@@ -295,22 +309,25 @@ func (jw *Jaws) retireNonRunningRequestCoreLocked(rq *Request, err error, causeO
 	runtime.KeepAlive(rq)
 }
 
-// recycleLockedWithCause cancels and recycles rq.
+// recycleLockedWithCause finishes rq and releases its reusable buffers.
 //
 // It uses err as the cancellation cause when non-nil.
 // It returns the cancellation cause (or nil) instead of logging it, so the caller
 // can log it after releasing jw.mu (see the package locking contract). Caller must
 // hold jw.mu.
 func (jw *Jaws) recycleLockedWithCause(rq *Request, err error) (cause error) {
+	var buffers *requestBuffers
 	rq.mu.Lock()
-	defer rq.mu.Unlock()
 	if rq.JawsKey != 0 && jw.requests[rq.JawsKey] == rq {
 		cause = rq.cancelLocked(err)
 		jw.removePendingRequestLocked(rq)
 		delete(jw.requests, rq.JawsKey)
 		jw.requestCount--
-		rq.clearLocked()
-		jw.reqPool.Put(rq)
+		buffers = rq.releaseBuffersLocked()
+	}
+	rq.mu.Unlock()
+	if buffers != nil {
+		jw.requestBufferPool.Put(buffers)
 	}
 	return
 }
@@ -328,10 +345,8 @@ func (jw *Jaws) recycle(rq *Request) {
 // cancelIfCurrent cancels rq only if it is still the [Request] registered for
 // jawsKey. A caller that looks up a Request and later cancels it without holding
 // jw.mu in between (the /jaws/.tail write-error path in [Jaws.ServeHTTP]) holds
-// a pointer that may have been recycled and reused for a different connection,
-// and cancelling such a stale pointer would kill the unrelated new request.
-// Holding jw.mu across the cancel keeps the identity check valid, since
-// recycling requires the jw.mu write lock.
+// a pointer whose Request may have finished. Holding jw.mu across the cancel
+// keeps the identity check valid while completion unregisters the Request.
 func (jw *Jaws) cancelIfCurrent(jawsKey key.Key, rq *Request, err error) {
 	var cause error
 	jw.mu.RLock()

--- a/session.go
+++ b/session.go
@@ -75,7 +75,7 @@ func (sess *Session) delRequest(rq *Request) {
 			if l > 1 {
 				sess.requests[i] = sess.requests[l-1]
 			}
-			sess.requests[l-1] = nil // release the freed tail slot so it doesn't pin a recycled *Request
+			sess.requests[l-1] = nil // release the freed tail slot so it doesn't pin a finished *Request
 			sess.requests = sess.requests[:l-1]
 			break
 		}
@@ -88,7 +88,7 @@ func (sess *Session) delRequest(rq *Request) {
 		// would be reaped with its stale deadline despite recent live activity.
 		sess.deadline = time.Now().Add(time.Minute)
 	}
-	// For an unclaimed request (its bootstrap render was recycled before the
+	// For an unclaimed request (its bootstrap render finished before the
 	// WebSocket connected) leave the existing deadline intact: the creation-time
 	// grace window (see newSession), or the window left by a claimed request that
 	// departed earlier, governs the session's lifetime until a WebSocket attaches.

--- a/session_test.go
+++ b/session_test.go
@@ -329,10 +329,10 @@ func TestSession_Broadcast(t *testing.T) {
 	jw.recycle(rq2)
 }
 
-// TestSession_ProducersSkipRecycled covers stale Request pointers retained by a
-// Session snapshot while the Request is recycled or rebound. Both producers must
-// target only Requests that still belong to the Session.
-func TestSession_ProducersSkipRecycled(t *testing.T) {
+// TestSession_ProducersSkipDetached covers finished Request pointers retained by
+// a Session snapshot. Both producers target only Requests that still belong to
+// the Session.
+func TestSession_ProducersSkipDetached(t *testing.T) {
 	th := newTestHelper(t)
 	jw, _ := New()
 	defer jw.Close()
@@ -346,15 +346,15 @@ func TestSession_ProducersSkipRecycled(t *testing.T) {
 	th.True(live.Session() == sess)
 
 	// Session methods operate on a snapshot after releasing sess.mu. These entries
-	// model pointers that were recycled after that snapshot: one has been cleared,
-	// and one has already acquired an unrelated nonzero identity.
-	cleared := &Request{Jaws: jw}
-	rebound := &Request{Jaws: jw, JawsKey: key.Key(0x9876)}
+	// model finished pointers already detached from the Session; a finished Request
+	// retains its original nonzero identity.
+	detachedZero := &Request{Jaws: jw}
+	detachedKey := &Request{Jaws: jw, JawsKey: key.Key(0x9876)}
 	sess.mu.Lock()
-	sess.requests = append(sess.requests, cleared, rebound)
+	sess.requests = append(sess.requests, detachedZero, detachedKey)
 	sess.mu.Unlock()
 
-	// Session.Broadcast targets only the live request, never the rebound identity.
+	// Session.Broadcast targets only the live request, never detached identities.
 	done := make(chan struct{})
 	go func() {
 		sess.Broadcast(wire.Message{What: what.Alert, Data: "info\nhi"})
@@ -369,11 +369,11 @@ func TestSession_ProducersSkipRecycled(t *testing.T) {
 	}
 	select {
 	case extra := <-jw.bcastCh:
-		t.Fatalf("recycled request must not broadcast, got %#v", extra)
+		t.Fatalf("detached request must not broadcast, got %#v", extra)
 	default:
 	}
 
-	// Session.Close reloads only the live request, never the rebound identity.
+	// Session.Close reloads only the live request, never detached identities.
 	closeDone := make(chan struct{})
 	go func() {
 		sess.Close()
@@ -389,18 +389,17 @@ func TestSession_ProducersSkipRecycled(t *testing.T) {
 	}
 	select {
 	case extra := <-jw.bcastCh:
-		t.Fatalf("recycled request must not broadcast, got %#v", extra)
+		t.Fatalf("detached request must not broadcast, got %#v", extra)
 	default:
 	}
 
 	jw.recycle(live)
 }
 
-// TestSessionCloseRejectsReusedRequest covers the race between Session.Close's
-// Request snapshot and Request pooling. A pointer removed from the Session may be
-// recycled for another client before Close detaches it; that new identity must not
-// receive the old Session's reload.
-func TestSessionCloseRejectsReusedRequest(t *testing.T) {
+// TestSessionCloseDoesNotReachLaterRequest covers a Request finishing after
+// Session.Close snapshots it and before Close detaches it. A later Request must
+// retain a distinct identity and must not receive the old Session's reload.
+func TestSessionCloseDoesNotReachLaterRequest(t *testing.T) {
 	jw, err := New()
 	if err != nil {
 		t.Fatal(err)
@@ -420,7 +419,7 @@ func TestSessionCloseRejectsReusedRequest(t *testing.T) {
 
 	// Close snapshots [first, stale], clears sess.requests, then blocks trying
 	// to detach first. Observing the cleared Session proves stale is already in
-	// Close's private snapshot before it is recycled.
+	// Close's private snapshot before it finishes.
 	firstLocked := make(chan struct{})
 	releaseFirst := make(chan struct{})
 	firstReleased := make(chan struct{})
@@ -458,20 +457,14 @@ func TestSessionCloseRejectsReusedRequest(t *testing.T) {
 		time.Sleep(time.Millisecond)
 	}
 
-	// sync.Pool may discard entries at any time. Keep the production reuse path
-	// deterministic by using stale as the allocation fallback as well.
-	poolNew := jw.reqPool.New
-	jw.reqPool.New = func() any { return stale }
-	defer func() { jw.reqPool.New = poolNew }()
-
 	// Drive the stale Request through the real capability endpoint. The missing
 	// WebSocket upgrade headers make ServeHTTP fail the upgrade and execute its
-	// normal stopServe/recycle path, placing stale in the production Request pool.
+	// normal stopServe completion path after Session.Close has snapshotted it.
 	staleEndpoint := httptest.NewRequest(http.MethodGet, "/jaws/"+stale.JawsKeyString(), nil)
 	staleEndpoint.RemoteAddr = sessionHTTP.RemoteAddr
 	jw.ServeHTTP(httptest.NewRecorder(), staleEndpoint)
-	if stale.JawsKey != 0 {
-		t.Fatalf("failed WebSocket upgrade did not recycle stale Request: key %v", stale.JawsKey)
+	if stale.Context().Err() == nil {
+		t.Fatal("failed WebSocket upgrade left stale Request live")
 	}
 
 	server := httptest.NewServer(jw)
@@ -479,11 +472,11 @@ func TestSessionCloseRejectsReusedRequest(t *testing.T) {
 	unrelatedHTTP := httptest.NewRequest(http.MethodGet, server.URL+"/unrelated", nil)
 	unrelatedHTTP.RemoteAddr = "127.0.0.1:2000"
 	unrelated := jw.NewRequest(unrelatedHTTP)
-	if unrelated != stale {
-		t.Fatal("request pool did not reuse stale pointer")
+	if unrelated == stale {
+		t.Fatal("later client reused stale Request identity")
 	}
 	if unrelated.Session() != nil {
-		t.Fatal("reused Request retained old Session")
+		t.Fatal("later Request retained old Session")
 	}
 	unrelatedKey := unrelated.JawsKey
 	connected := make(chan struct{})
@@ -504,7 +497,7 @@ func TestSessionCloseRejectsReusedRequest(t *testing.T) {
 	select {
 	case <-connected:
 	case <-time.After(time.Second):
-		t.Fatal("unrelated reused Request did not start its WebSocket")
+		t.Fatal("unrelated Request did not start its WebSocket")
 	}
 
 	close(releaseFirst)
@@ -525,7 +518,7 @@ func TestSessionCloseRejectsReusedRequest(t *testing.T) {
 		t.Fatalf("reading marker from unrelated Request: %v", err)
 	}
 	if strings.Contains(string(data), what.Reload.String()+"\t") {
-		t.Fatalf("old Session close reached unrelated reused Request: %q", data)
+		t.Fatalf("old Session close reached unrelated later Request: %q", data)
 	}
 	if !strings.Contains(string(data), marker) {
 		t.Fatalf("WebSocket message = %q, want marker %q", data, marker)
@@ -779,7 +772,7 @@ func TestSession_Cleanup(t *testing.T) {
 	})
 }
 
-// TestSession_UnclaimedRequestRecycleKeepsGraceDeadline verifies that recycling the
+// TestSession_UnclaimedRequestRecycleKeepsGraceDeadline verifies that finishing the
 // bootstrap render Request (unclaimed, because its WebSocket has not connected yet)
 // does not immediately expire the freshly issued session, so a slightly-slow client
 // keeps the session it was just given.
@@ -799,11 +792,11 @@ func TestSession_UnclaimedRequestRecycleKeepsGraceDeadline(t *testing.T) {
 		t.Fatal("expected request bound to session")
 	}
 
-	// Recycle the unclaimed bootstrap request (its WebSocket never connected).
+	// Finish the unclaimed bootstrap request (its WebSocket never connected).
 	jw.recycle(r1)
 
 	if sess.isDead() {
-		t.Fatal("session expired when an unclaimed bootstrap request was recycled")
+		t.Fatal("session expired when an unclaimed bootstrap request finished")
 	}
 	if got := jw.GetSession(hr); got != sess {
 		t.Fatalf("expected session still retrievable within its grace window, got %v", got)
@@ -864,7 +857,7 @@ func TestSession_ClaimedNonLastLeaveKeepsGrace(t *testing.T) {
 		// claimed request leaving non-last, so delRequest must still refresh the grace.
 		rqA.killSession()
 
-		// The second tab's bootstrap is then recycled before its WebSocket connects:
+		// The second tab's bootstrap then finishes before its WebSocket connects:
 		// an unclaimed request leaving last, which leaves the refreshed deadline intact.
 		rqB.killSession()
 

--- a/tailscript.go
+++ b/tailscript.go
@@ -64,12 +64,12 @@ var jsInlineScriptEscaper = strings.NewReplacer(
 // Request (subsequent calls return sent=false so the response is 204).
 func (rq *Request) drainTailScript() (b []byte, sent bool) {
 	// Takes only muQueue and never touches the network. Jaws.ServeHTTP calls it while
-	// holding jw.mu (read), which blocks recycling (which needs the jw.mu write lock),
-	// so this Request cannot be recycled and reused under a different key mid-drain: the
-	// bytes returned always belong to the identity the handler looked up. The slow
+	// holding jw.mu (read), which blocks completion (which needs the jw.mu write lock),
+	// so this Request cannot be unregistered mid-drain: the bytes returned always
+	// belong to the identity the handler looked up. The slow
 	// network write happens afterwards in writeTailResponse with no lock held, so a
-	// stalled client cannot block recycling or the Serve loop. The data race on
-	// wsQueue/tailsent is prevented because clearLocked also takes muQueue to reset them.
+	// stalled client cannot block completion or the Serve loop. The data race on
+	// wsQueue/tailsent is prevented because releaseBuffersLocked also takes muQueue.
 	rq.muQueue.Lock()
 	defer rq.muQueue.Unlock()
 	if !rq.tailsent {
@@ -121,7 +121,7 @@ func (rq *Request) drainTailScript() (b []byte, sent bool) {
 }
 
 // writeTailResponse writes the tail script response built by drainTailScript. It
-// holds no locks, so the network write cannot stall recycling or the Serve loop.
+// holds no locks, so the network write cannot stall completion or the Serve loop.
 //
 // A sent=false drain (the tail was already fetched on an earlier request) responds
 // 204 No Content. A first drain finding nothing queued reports sent=true with empty
@@ -164,17 +164,17 @@ func (jw *Jaws) serveTailScript(w http.ResponseWriter, r *http.Request) (handled
 	if jawsKeyString, ok := strings.CutPrefix(r.URL.Path, "/jaws/.tail/"); ok {
 		if jawsKey, tail := key.Parse(jawsKeyString); tail == "" {
 			remoteIP := jw.clientIP(r)
-			// Hold jw.mu (read) across both the lookup and the drain: recycling needs
-			// the jw.mu write lock, so rq cannot be recycled and reused under a different
-			// key while we drain its queue. A stale key either misses the map (404) or
+			// Hold jw.mu (read) across both the lookup and the drain: completion needs
+			// the jw.mu write lock, so rq cannot be unregistered while we drain its
+			// queue. A stale key either misses the live map entry (404) or
 			// drains its own genuine content. The network write is done after releasing
-			// jw.mu so a slow client cannot stall recycling or the Serve loop.
+			// jw.mu so a slow client cannot stall completion or the Serve loop.
 			jw.mu.RLock()
 			rq := jw.requests[jawsKey]
 			// Bind the tail fetch to the client like the WebSocket claim path
 			// (Request.claim): the one-shot tail is drained only when the fetch comes from
 			// the same client IP the initial request was issued to (loopback-aware, see
-			// equalIP). rq.remoteIP is stable here because recycling requires the jw.mu
+			// equalIP). rq.remoteIP is stable here because completion requires the jw.mu
 			// write lock. A mismatch is treated as not found, so a leaked key cannot drain
 			// (and thereby deny) another client's tail. The WebSocket carries all live
 			// data, so this only closes the cross-IP read of the already-rendered

--- a/testhelpers_test.go
+++ b/testhelpers_test.go
@@ -3,6 +3,7 @@ package jaws
 import (
 	"bytes"
 	"cmp"
+	"context"
 	"errors"
 	"fmt"
 	"html/template"
@@ -733,14 +734,9 @@ func TestNewRequestHarness_ReturnsNilOnClaimFailure(t *testing.T) {
 	}
 	t.Cleanup(jw.Close)
 
-	jw.reqPool.New = func() any {
-		rq := (&Request{
-			Jaws:   jw,
-			tagMap: make(map[any][]*Element),
-		}).clearLocked()
-		rq.claimed.Store(true)
-		return rq
-	}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	jw.BaseContext = ctx
 
 	hr := httptest.NewRequest(http.MethodGet, "/", nil)
 	if rh := newRequestHarness(jw, hr); rh != nil {

--- a/testserve.go
+++ b/testserve.go
@@ -67,7 +67,7 @@ func (jw *Jaws) TestServe(rq *Request, onPanic func(recovered any)) (inCh chan w
 		// process iterates its elements would let an idle or context-cancelled
 		// request be canceled and unregistered mid-loop. Take jw.mu so the
 		// transition is serialized with the maintenance pass, which reads running
-		// under jw.mu; the final recycle resets running via clearLocked.
+		// under jw.mu; final completion resets running via releaseBuffersLocked.
 		jw.mu.Lock()
 		rq.running.Store(true)
 		jw.mu.Unlock()


### PR DESCRIPTION
## Problem

JaWS pooled the exported `*Request` object itself. Correct production code can retain a Request in a background operation and call `Cancel` after its WebSocket has finished. If the pool had already assigned that pointer to a later client, the late cancellation terminated the unrelated connection.

## Fix

- Allocate a distinct public Request identity for every lifecycle.
- Reuse only detached element, tag, dirt, and WebSocket queue buffers.
- Keep the completed Request key and canceled context stable while making identity-targeted producers inert after unregistration.
- Preserve request/session teardown, key reservation for retired initial renders, and buffer zeroing.

## Tests

- Added a real WebSocket regression proving a late `Cancel` cannot reach the next connection.
- Updated lifecycle, session, tail-script, delayed-context, and buffer-reuse coverage for stable identities.
- `JAWS_REQUIRE_NODE=1 go test -race ./... -count=1`
- `go generate`, `go vet`, `staticcheck`, `golangci-lint`, `gosec`, `go build`, and formatting checks all pass.

## Allocation impact

The existing lifecycle benchmark remains in-tree as a regression guard. Six-run `benchstat` measurements show one fresh wrapper allocation per request: the empty lifecycle changes from 172.4 ns / 112 B / 4 allocs to 208.1 ns / 368 B / 5 allocs. Rendered lifecycles remain time-neutral (`elems=100`: 13.13 µs to 13.10 µs; `elems=1000`: 138.0 µs to 137.8 µs) with one additional allocation. Reusing the detached buffers remains materially cheaper than fresh buffers for rendered requests.
