### PR TITLE
Honor subsecond request timeouts

### DIFF
--- a/jaws.go
+++ b/jaws.go
@@ -154,8 +154,8 @@ type Jaws struct {
 	MaxPendingRequestsPerIP int             // Maximum number of unclaimed Requests per client IP. Defaults to DefaultMaxPendingRequestsPerIP. Set <=0 to disable the cap.
 	webSocketTimeout        time.Duration   // timeout duration passed to ServeWith
 	maintenanceInterval     time.Duration   // Serve maintenance tick interval; set by ServeWithTimeout and read under mu, zero until Serve starts
-	created                 time.Time       // monotonic base captured in New(); read-only after construction, basis for runtimeSeconds
-	runtimeSeconds          atomic.Int32    // whole seconds since created; refreshed during request allocation and by the Serve loop, read lock-free by MarkWritten and the eviction/idle checks
+	created                 time.Time       // monotonic base captured in New(); read-only after construction, basis for runtimeNanos
+	runtimeNanos            atomic.Int64    // nanoseconds since created; refreshed during request allocation and by the Serve loop, read lock-free by MarkWritten and the eviction/idle checks
 	bcastCh                 chan wire.Message
 	subCh                   chan subscription
 	unsubCh                 chan chan wire.Message

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -194,7 +194,7 @@ func TestJaws_CloseHandlesRetiredKeyReservation(t *testing.T) {
 	jw.MaxPendingRequestsPerIP = 1
 
 	retired := jw.NewRequest(newPendingLimitRequest("192.0.2.1:1000"))
-	setPendingLimitLastWrite(t, retired, 3600)
+	setPendingLimitLastWrite(t, retired, time.Hour)
 	replacement := jw.NewRequest(newPendingLimitRequest("192.0.2.1:1001"))
 
 	jw.Close()
@@ -367,12 +367,12 @@ func TestJaws_MaxPendingRequestsPerIPEvictsOldestPending(t *testing.T) {
 	oldReq := newPendingLimitRequest("192.0.2.1:1000")
 	oldRq := jw.NewRequest(oldReq)
 	oldKey := oldRq.JawsKey
-	setPendingLimitLastWrite(t, oldRq, 7200)
+	setPendingLimitLastWrite(t, oldRq, 2*time.Hour)
 
 	midReq := newPendingLimitRequest("192.0.2.1:1001")
 	midRq := jw.NewRequest(midReq)
 	midKey := midRq.JawsKey
-	setPendingLimitLastWrite(t, midRq, 3600)
+	setPendingLimitLastWrite(t, midRq, time.Hour)
 
 	newReq := newPendingLimitRequest("192.0.2.1:1002")
 	newRq := jw.NewRequest(newReq)
@@ -407,7 +407,7 @@ func TestJaws_MaxPendingRequestsPerIPUsesLiveElapsedBeforeServe(t *testing.T) {
 	oldRq := jw.NewRequest(oldReq)
 	oldKey := oldRq.JawsKey
 
-	// Simulate an hour passing before Serve starts. runtimeSeconds still holds
+	// Simulate an hour passing before Serve starts. runtimeNanos still holds
 	// the value used for oldRq, so NewRequest must refresh it before deciding
 	// whether the pending cap may evict oldRq.
 	jw.created = time.Now().Add(-time.Hour)
@@ -464,7 +464,7 @@ func TestJaws_MaintenanceLogsCancelOutsideLock(t *testing.T) {
 
 	// A pending request idle long enough for the maintenance pass to retire it.
 	rq := jw.NewRequest(newPendingLimitRequest("192.0.2.1:1000"))
-	setPendingLimitLastWrite(t, rq, 3600)
+	setPendingLimitLastWrite(t, rq, time.Hour)
 
 	done := make(chan struct{})
 	go func() {
@@ -554,7 +554,7 @@ func TestJaws_RetiredPendingRequestRemainsOwnedByInitialHTTPHandler(t *testing.T
 
 			first := <-started
 			firstKey := first.rq.JawsKey
-			setPendingLimitLastWrite(t, first.rq, 3600)
+			setPendingLimitLastWrite(t, first.rq, time.Hour)
 			if tc.maintenance {
 				// This is the callback the production Serve loop runs on every
 				// maintenance tick; the old timestamp only avoids a wall-clock wait.
@@ -637,7 +637,7 @@ func TestJaws_RetiredRequestKeyRemainsReserved(t *testing.T) {
 	if retired.JawsKey != retiredKey {
 		t.Fatalf("first key = %v, want %v", retired.JawsKey, retiredKey)
 	}
-	setPendingLimitLastWrite(t, retired, 3600)
+	setPendingLimitLastWrite(t, retired, time.Hour)
 
 	replacement := jw.NewRequest(newPendingLimitRequest("192.0.2.1:1001"))
 	if replacement.JawsKey != replacementKey {
@@ -733,7 +733,7 @@ func TestJaws_MaxPendingRequestsPerIPSparesRenderingRequest(t *testing.T) {
 	idleRq := jw.NewRequest(idleReq)
 	idleKey := idleRq.JawsKey
 	// Age the idle Request well past the spare window so it is the eviction victim.
-	setPendingLimitLastWrite(t, idleRq, 3600)
+	setPendingLimitLastWrite(t, idleRq, time.Hour)
 
 	// Creating a third same-IP Request trips the cap (pending == 2).
 	newReq := newPendingLimitRequest("192.0.2.1:1002")
@@ -780,7 +780,7 @@ func TestJaws_MaxPendingRequestsPerIPSparesRecentlyRenderedRequest(t *testing.T)
 	idleReq := newPendingLimitRequest("192.0.2.1:1001")
 	idleRq := jw.NewRequest(idleReq)
 	idleKey := idleRq.JawsKey
-	setPendingLimitLastWrite(t, idleRq, 3600)
+	setPendingLimitLastWrite(t, idleRq, time.Hour)
 
 	// A third same-IP Request trips the cap (pending == 2).
 	newReq := newPendingLimitRequest("192.0.2.1:1002")
@@ -830,7 +830,7 @@ func TestJaws_MaxPendingRequestsPerIPSparesStalledLiveRender(t *testing.T) {
 	idleReq := newPendingLimitRequest("192.0.2.1:1001")
 	idleRq := jw.NewRequest(idleReq)
 	idleKey := idleRq.JawsKey
-	setPendingLimitLastWrite(t, idleRq, 3600)
+	setPendingLimitLastWrite(t, idleRq, time.Hour)
 
 	// A third same-IP Request trips the cap (pending == 2).
 	newReq := newPendingLimitRequest("192.0.2.1:1002")
@@ -859,8 +859,8 @@ func TestJaws_MaxPendingRequestsPerIPSparesFutureWriteTimestamp(t *testing.T) {
 	renderingReq := newPendingLimitRequest("192.0.2.1:1000")
 	renderingRq := jw.NewRequest(renderingReq)
 	renderingKey := renderingRq.JawsKey
-	nowSeconds := jw.runtimeSeconds.Load()
-	renderingRq.lastWriteSeconds.Store(nowSeconds + 1)
+	nowNanos := jw.runtimeNanos.Load()
+	renderingRq.lastWriteNanos.Store(nowNanos + time.Nanosecond.Nanoseconds())
 
 	newReq := newPendingLimitRequest("192.0.2.1:1001")
 	newRq := jw.NewRequest(newReq)
@@ -980,7 +980,7 @@ func TestJaws_MaxPendingRequestsPerIPKeepsLoopbackAddressesSeparate(t *testing.T
 
 	oldReq := newPendingLimitRequest("127.0.0.1:1000")
 	oldRq := jw.NewRequest(oldReq)
-	setPendingLimitLastWrite(t, oldRq, 3600)
+	setPendingLimitLastWrite(t, oldRq, time.Hour)
 
 	newReq := newPendingLimitRequest("[::1]:1000")
 	newRq := jw.NewRequest(newReq)
@@ -1036,7 +1036,7 @@ func TestJaws_MaxPendingRequestsPerIPEvictionCause(t *testing.T) {
 
 	oldReq := newPendingLimitRequest("192.0.2.1:1000")
 	oldRq := jw.NewRequest(oldReq)
-	setPendingLimitLastWrite(t, oldRq, 3600)
+	setPendingLimitLastWrite(t, oldRq, time.Hour)
 	jw.NewRequest(newPendingLimitRequest("192.0.2.1:1001"))
 
 	if logger.err == nil {
@@ -1163,7 +1163,7 @@ func TestJaws_MaxPendingRequestsPerIPMaintenanceRemovesPendingIndex(t *testing.T
 	jw.MaxPendingRequestsPerIP = 1
 
 	rq := jw.NewRequest(newPendingLimitRequest("192.0.2.1:1000"))
-	setPendingLimitLastWrite(t, rq, 3600)
+	setPendingLimitLastWrite(t, rq, time.Hour)
 	jw.maintenance(time.Second)
 
 	if got := jw.Pending(); got != 0 {
@@ -1180,13 +1180,12 @@ func newPendingLimitRequest(remoteAddr string) *http.Request {
 	return r
 }
 
-func setPendingLimitLastWrite(t *testing.T, rq *Request, secondsAgo int32) {
+func setPendingLimitLastWrite(t *testing.T, rq *Request, ago time.Duration) {
 	t.Helper()
-	// lastWriteSeconds holds the Jaws.runtimeSeconds value at the last write. Store
-	// runtimeSeconds-secondsAgo so the eviction/idle check (runtimeSeconds-lastWrite)
-	// reads back as secondsAgo. In tests where Serve has not started, runtimeSeconds
-	// is often zero, so old timestamps are represented as negative seconds.
-	rq.lastWriteSeconds.Store(rq.Jaws.runtimeSeconds.Load() - secondsAgo)
+	// lastWriteNanos holds the Jaws.runtimeNanos value at the last write. Store an
+	// earlier relative instant so the eviction/idle check reads back ago. In tests
+	// where Serve has not started, old timestamps may be negative.
+	rq.lastWriteNanos.Store(rq.Jaws.runtimeNanos.Load() - ago.Nanoseconds())
 }
 
 func setRandomKeys(t *testing.T, jw *Jaws, keys ...key.Key) {
@@ -2700,7 +2699,7 @@ func newUnpooledBenchRequest(jw *Jaws) (rq *Request) {
 			rq.mu.Lock()
 			rq.JawsKey = jawsKey
 			rq.registered = true
-			rq.lastWriteSeconds.Store(jw.runtimeSeconds.Load())
+			rq.lastWriteNanos.Store(jw.runtimeNanos.Load())
 			rq.remoteIP = remoteIP
 			rq.ctx, rq.cancelFn = context.WithCancelCause(jw.BaseContext)
 			rq.mu.Unlock()

--- a/lib/ui/requestwriter_test.go
+++ b/lib/ui/requestwriter_test.go
@@ -71,8 +71,8 @@ func TestRequestWriter_MethodsAndWidgetHelpers(t *testing.T) {
 	if got := buf.String(); got != "prefix" {
 		t.Fatalf("unexpected write output %q", got)
 	}
-	// Write records the current second via Request.MarkWritten (covered by the core
-	// package's pending-eviction tests); lastWriteSeconds is unexported here.
+	// Write records the current instant via Request.MarkWritten (covered by the core
+	// package's pending-eviction tests); lastWriteNanos is unexported here.
 
 	if rw.Initial() == nil {
 		t.Fatal("expected initial request")

--- a/request.go
+++ b/request.go
@@ -54,28 +54,28 @@ type requestBuffers struct {
 // [Request.Log] and [Request.MustLog] let it forward to the logger; both exist only for
 // that diagnostic use, not as a public nil-safe contract.
 type Request struct {
-	Jaws             *Jaws                   // (read-only) the JaWS instance the Request belongs to
-	JawsKey          key.Key                 // (read-only) random key assigned to this Request; routes JaWS URLs and request-targeted broadcasts only while registered
-	remoteIP         netip.Addr              // (read-only) remote IP, or the zero netip.Addr if unset
-	registered       bool                    // present as a live identity in Jaws.requests; guarded by mu
-	running          atomic.Bool             // if ServeHTTP() is running
-	claimed          atomic.Bool             // if UseRequest() has been called for it
-	lastWriteSeconds atomic.Int32            // [Jaws.runtimeSeconds] value at the most recent RequestWriter write; lock-free, drives pending-eviction recency (oldestEvictablePendingLocked) and idle expiry (maintenance)
-	mu               deadlock.RWMutex        // protects following
-	lastJid          Jid                     // last element Jid allocated within this Request
-	initial          *http.Request           // initial HTTP request passed to Jaws.NewRequest
-	session          *Session                // session, if established
-	todoDirt         []any                   // dirty tags
-	ctx              context.Context         // current context, derived from either Jaws or WS HTTP req; stored in the struct because there is no call chain between Request creation and its use once the WebSocket exists
-	httpDoneCh       <-chan struct{}         // once claimed, set to http.Request.Context().Done()
-	cancelFn         context.CancelCauseFunc // cancel function
-	connectFn        ConnectFn               // a ConnectFn to call before starting message processing for the Request
-	buffers          *requestBuffers         // detached and reused after this Request finishes
-	elems            []*Element              // our Elements
-	tagMap           map[any][]*Element      // maps tags to Elements
-	muQueue          deadlock.Mutex          // protects wsQueue and tailsent
-	wsQueue          []wire.WsMsg            // queued messages to send
-	tailsent         bool
+	Jaws           *Jaws                   // (read-only) the JaWS instance the Request belongs to
+	JawsKey        key.Key                 // (read-only) random key assigned to this Request; routes JaWS URLs and request-targeted broadcasts only while registered
+	remoteIP       netip.Addr              // (read-only) remote IP, or the zero netip.Addr if unset
+	registered     bool                    // present as a live identity in Jaws.requests; guarded by mu
+	running        atomic.Bool             // if ServeHTTP() is running
+	claimed        atomic.Bool             // if UseRequest() has been called for it
+	lastWriteNanos atomic.Int64            // [Jaws.runtimeNanos] value at the most recent RequestWriter write; lock-free, drives pending-eviction recency (oldestEvictablePendingLocked) and idle expiry (maintenance)
+	mu             deadlock.RWMutex        // protects following
+	lastJid        Jid                     // last element Jid allocated within this Request
+	initial        *http.Request           // initial HTTP request passed to Jaws.NewRequest
+	session        *Session                // session, if established
+	todoDirt       []any                   // dirty tags
+	ctx            context.Context         // current context, derived from either Jaws or WS HTTP req; stored in the struct because there is no call chain between Request creation and its use once the WebSocket exists
+	httpDoneCh     <-chan struct{}         // once claimed, set to http.Request.Context().Done()
+	cancelFn       context.CancelCauseFunc // cancel function
+	connectFn      ConnectFn               // a ConnectFn to call before starting message processing for the Request
+	buffers        *requestBuffers         // detached and reused after this Request finishes
+	elems          []*Element              // our Elements
+	tagMap         map[any][]*Element      // maps tags to Elements
+	muQueue        deadlock.Mutex          // protects wsQueue and tailsent
+	wsQueue        []wire.WsMsg            // queued messages to send
+	tailsent       bool
 }
 
 type eventFnCall struct {
@@ -108,10 +108,10 @@ func (rq *Request) String() string {
 // [RequestWriter.Write] calls it on every write. It is lock-free and safe to call
 // concurrently.
 func (rq *Request) MarkWritten() {
-	// A single atomic store of the cached runtimeSeconds; no clock read. The recorded
-	// second drives the recency window in oldestEvictablePendingLocked and the idle
+	// A single atomic store of the cached runtimeNanos; no clock read. The recorded
+	// instant drives the recency window in oldestEvictablePendingLocked and the idle
 	// expiry in maintenance.
-	rq.lastWriteSeconds.Store(rq.Jaws.runtimeSeconds.Load())
+	rq.lastWriteNanos.Store(rq.Jaws.runtimeNanos.Load())
 }
 
 // destKey returns the Request's current identity key, read under rq.mu, for use as
@@ -165,10 +165,10 @@ func (rq *Request) claim(r *http.Request) error {
 				}
 			}
 			rq.httpDoneCh = httpDoneCh
-			// Refresh the write second so a request claimed long after its initial
+			// Refresh the write instant so a request claimed long after its initial
 			// render (a throttled or backgrounded tab) is not treated as idle and
 			// retired in the window before ServeHTTP sets running.
-			rq.lastWriteSeconds.Store(rq.Jaws.runtimeSeconds.Load())
+			rq.lastWriteNanos.Store(rq.Jaws.runtimeNanos.Load())
 			return nil
 		}
 	}
@@ -406,20 +406,20 @@ func (rq *Request) replaceContext(fn func(oldCtx context.Context) (newCtx contex
 // maintenance reports whether rq has expired and should be retired. For a
 // request that never went live it cancels and reports expiry once it has been
 // idle (no [RequestWriter] write) longer than requestTimeout, or immediately if its
-// context is already done. nowSeconds is the reference instant ([Jaws.runtimeSeconds]).
+// context is already done. nowNanos is the reference instant ([Jaws.runtimeNanos]).
 // Called from the Serve loop's maintenance pass while jw.mu is held.
 //
 // It returns the cancellation cause (or nil) rather than logging it, so the caller
 // can log it after releasing jw.mu — logging runs the user [Jaws.Logger], which
 // must not be invoked under a lock.
-func (rq *Request) maintenance(nowSeconds int32, requestTimeout time.Duration) (expired bool, cause error) {
+func (rq *Request) maintenance(nowNanos int64, requestTimeout time.Duration) (expired bool, cause error) {
 	if !rq.running.Load() {
 		rq.mu.Lock()
 		if rq.ctx.Err() != nil {
 			expired = true
 		} else {
-			elapsedSeconds := nowSeconds - rq.lastWriteSeconds.Load()
-			if elapsedSeconds > 0 && time.Duration(elapsedSeconds)*time.Second > requestTimeout {
+			elapsed := time.Duration(nowNanos - rq.lastWriteNanos.Load())
+			if elapsed > 0 && elapsed > requestTimeout {
 				cause = rq.cancelLocked(newErrNoWebSocketRequest(rq))
 				expired = true
 			}

--- a/request_test.go
+++ b/request_test.go
@@ -855,13 +855,13 @@ func TestRequest_ClaimRefreshesLastWriteAndStartServeGuards(t *testing.T) {
 	rq := jw.NewRequest(hr)
 
 	// Simulate a page that rendered long ago (idle) before its WebSocket connects.
-	rq.lastWriteSeconds.Store(jw.runtimeSeconds.Load() - 3600)
+	rq.lastWriteNanos.Store(jw.runtimeNanos.Load() - time.Hour.Nanoseconds())
 
 	if jw.UseRequest(rq.JawsKey, hr) != rq {
 		t.Fatal("expected claim to succeed")
 	}
-	// claim refreshed the write second, so the just-claimed request is not idle.
-	if expired, _ := rq.maintenance(jw.runtimeSeconds.Load(), time.Second); expired {
+	// claim refreshed the write instant, so the just-claimed request is not idle.
+	if expired, _ := rq.maintenance(jw.runtimeNanos.Load(), time.Second); expired {
 		t.Fatal("a freshly claimed request must not be treated as idle by maintenance")
 	}
 
@@ -1976,7 +1976,7 @@ func TestCoverage_PendingSubscribeMaintenanceAndParse(t *testing.T) {
 	<-unsubDone
 
 	// Request timeout path.
-	rq.lastWriteSeconds.Store(jw.runtimeSeconds.Load() - 3600)
+	rq.lastWriteNanos.Store(jw.runtimeNanos.Load() - time.Hour.Nanoseconds())
 	jw.maintenance(time.Second)
 	if got := jw.RequestCount(); got != 0 {
 		t.Fatalf("expected request recycled, got %d", got)
@@ -2027,25 +2027,25 @@ func TestCoverage_RequestMaintenanceClaimAndErrors(t *testing.T) {
 		t.Fatalf("unexpected error text: %v", err)
 	}
 
-	nowSeconds := jw.runtimeSeconds.Load()
+	nowNanos := jw.runtimeNanos.Load()
 	rqM := jw.NewRequest(httptest.NewRequest("GET", "/", nil))
-	rqM.lastWriteSeconds.Store(nowSeconds - 3600)
-	if expired, _ := rqM.maintenance(nowSeconds, time.Second); !expired {
+	rqM.lastWriteNanos.Store(nowNanos - time.Hour.Nanoseconds())
+	if expired, _ := rqM.maintenance(nowNanos, time.Second); !expired {
 		t.Fatal("expected maintenance timeout")
 	}
 	rqR := jw.NewRequest(httptest.NewRequest("GET", "/", nil))
 	rqR.MarkWritten()
-	if expired, _ := rqR.maintenance(jw.runtimeSeconds.Load(), time.Hour); expired {
+	if expired, _ := rqR.maintenance(jw.runtimeNanos.Load(), time.Hour); expired {
 		t.Fatal("a freshly written request must not be idle-expired")
 	}
 	rqC := jw.NewRequest(httptest.NewRequest("GET", "/", nil))
 	rqC.cancel(errors.New("cancelled"))
-	if expired, _ := rqC.maintenance(jw.runtimeSeconds.Load(), time.Hour); !expired {
+	if expired, _ := rqC.maintenance(jw.runtimeNanos.Load(), time.Hour); !expired {
 		t.Fatal("expected maintenance cancellation")
 	}
 	rqOK := jw.NewRequest(httptest.NewRequest("GET", "/", nil))
 	rqOK.MarkWritten()
-	if expired, _ := rqOK.maintenance(jw.runtimeSeconds.Load(), time.Hour); expired {
+	if expired, _ := rqOK.maintenance(jw.runtimeNanos.Load(), time.Hour); expired {
 		t.Fatal("expected maintenance keepalive")
 	}
 
@@ -2074,19 +2074,19 @@ func TestNewRequest_SeedsLastWriteFromLiveElapsed(t *testing.T) {
 	defer jw.Close()
 
 	// Simulate an hour of startup before Serve runs. Serve is deliberately not
-	// started, so runtimeSeconds is never advanced by its maintenance loop.
+	// started, so runtimeNanos is never advanced by its maintenance loop.
 	jw.created = time.Now().Add(-time.Hour)
 
 	rq := jw.NewRequest(httptest.NewRequest("GET", "/", nil))
 
-	// The seed must reflect true elapsed time (~3600s), not the stale zero that
-	// runtimeSeconds still holds before Serve seeds it.
-	if got := rq.lastWriteSeconds.Load(); got < 3595 || got > 3605 {
-		t.Fatalf("expected lastWriteSeconds seeded to ~3600, got %d", got)
+	// The seed must reflect true elapsed time (~1h), not the stale zero that
+	// runtimeNanos still holds before Serve seeds it.
+	if got := time.Duration(rq.lastWriteNanos.Load()); got < time.Hour-5*time.Second || got > time.Hour+5*time.Second {
+		t.Fatalf("lastWriteNanos = %v, want approximately 1h", got)
 	}
 
 	// A brand-new request must not be idle-expired by the first maintenance pass.
-	if expired, _ := rq.maintenance(jw.runtimeSeconds.Load(), time.Hour); expired {
+	if expired, _ := rq.maintenance(jw.runtimeNanos.Load(), time.Hour); expired {
 		t.Fatal("a brand-new pre-Serve request must not be idle-expired")
 	}
 }
@@ -3271,7 +3271,7 @@ func TestServe_MarksRequestRunningSoMaintenanceSkips(t *testing.T) {
 
 	// Make the request look long-idle, then run a maintenance pass directly. A
 	// running request must remain registered while process is using it.
-	tr.lastWriteSeconds.Store(jw.runtimeSeconds.Load() - 3600)
+	tr.lastWriteNanos.Store(jw.runtimeNanos.Load() - time.Hour.Nanoseconds())
 	jw.maintenance(time.Millisecond)
 
 	if got := jw.RequestCount(); got != 1 {

--- a/requestpool.go
+++ b/requestpool.go
@@ -53,7 +53,7 @@ func (jw *Jaws) NewRequest(r *http.Request) (rq *Request) {
 		// new Request. Before Serve starts there is no maintenance loop to advance
 		// the counter, so a stale value could otherwise make an old pending Request
 		// look freshly written and briefly overshoot the cap.
-		jw.refreshRuntimeSeconds()
+		jw.refreshRuntimeNanos()
 		closed := false
 		select {
 		case <-jw.closeCh:
@@ -83,19 +83,17 @@ func (jw *Jaws) NewRequest(r *http.Request) (rq *Request) {
 	return
 }
 
-// refreshRuntimeSeconds updates runtimeSeconds to the whole seconds elapsed since
-// the [Jaws] was created.
+// refreshRuntimeNanos updates runtimeNanos to the nanoseconds elapsed since the
+// [Jaws] was created.
 //
 // Request allocation calls it before pending-request eviction and timestamp
 // seeding. The Serve loop also calls it once at start and on every maintenance
 // tick, so per-write [Request.MarkWritten] only does an atomic load rather than
 // reading the clock.
-func (jw *Jaws) refreshRuntimeSeconds() {
-	// time.Since on a monotonic base is never negative and keeps the counter immune to
-	// wall-clock and NTP adjustments. The int32 conversion is intentionally
-	// modulo-style: recency checks compare nearby samples, and their windows are far
-	// smaller than 2^31 seconds.
-	jw.runtimeSeconds.Store(int32(time.Since(jw.created) / time.Second)) // #nosec G115 -- intentional relative-time counter
+func (jw *Jaws) refreshRuntimeNanos() {
+	// time.Since on a monotonic base is never negative and keeps the counter immune
+	// to wall-clock and NTP adjustments.
+	jw.runtimeNanos.Store(time.Since(jw.created).Nanoseconds())
 }
 
 // limitPendingRequestsLocked evicts pending Requests for remoteIP until the cap is
@@ -104,9 +102,9 @@ func (jw *Jaws) refreshRuntimeSeconds() {
 func (jw *Jaws) limitPendingRequestsLocked(remoteIP netip.Addr) (toLog []error) {
 	limit := jw.MaxPendingRequestsPerIP
 	if limit > 0 {
-		nowSeconds := jw.runtimeSeconds.Load()
+		nowNanos := jw.runtimeNanos.Load()
 		for len(jw.pending[remoteIP]) >= limit {
-			victim := jw.oldestEvictablePendingLocked(remoteIP, nowSeconds)
+			victim := jw.oldestEvictablePendingLocked(remoteIP, nowNanos)
 			if victim == nil {
 				// Every pending Request for this IP was written recently. Prefer a
 				// brief, self-correcting overshoot of the cap to invalidating a page
@@ -123,37 +121,30 @@ func (jw *Jaws) limitPendingRequestsLocked(remoteIP netip.Addr) (toLog []error) 
 
 // oldestEvictablePendingLocked returns the oldest pending [Request] for remoteIP
 // eligible for eviction, or nil if every one was written too recently to evict.
-// nowSeconds is the reference instant ([Jaws.runtimeSeconds]), passed in so all
+// nowNanos is the reference instant ([Jaws.runtimeNanos]), passed in so all
 // candidates are judged against the same instant. Caller must hold jw.mu.
-func (jw *Jaws) oldestEvictablePendingLocked(remoteIP netip.Addr, nowSeconds int32) *Request {
+func (jw *Jaws) oldestEvictablePendingLocked(remoteIP netip.Addr, nowNanos int64) *Request {
 	// A Request is spared while its initial HTML may still be in flight.
-	// RequestWriter.Write records the current second on every write via
+	// RequestWriter.Write records the current cached instant on every write via
 	// Request.MarkWritten, so a Request is treated as possibly rendering while its
-	// last write is within 2*maintenanceInterval (rounded to whole seconds, with a
-	// one-second floor). The recorded second advances only while the Request keeps
-	// writing, so an actively writing render stays fresh while one idle for the
-	// window becomes evictable.
+	// last write is within 2*maintenanceInterval. The recorded instant advances only
+	// while the Request keeps writing, so an actively writing render stays fresh
+	// while one idle for the window becomes evictable.
 	//
 	// maintenanceInterval is zero until ServeWithTimeout starts; fall back to
 	// DefaultUpdateInterval so an in-flight render is still protected before the
-	// maintenance pass begins running. The exact fallback value need not match the
-	// steady-state maintenanceInterval: the one-second floor below dominates for any
-	// sub-second interval, and a NewRequest before Serve is in any case unusual.
+	// maintenance pass begins running.
 	interval := jw.maintenanceInterval
 	if interval <= 0 {
 		interval = DefaultUpdateInterval
 	}
 	spareWindow := 2 * interval
-	if spareWindow < time.Second {
-		spareWindow = time.Second // floor: the seconds counter advances at most once per second
-	}
 	for _, rq := range jw.pending[remoteIP] {
-		// Compare as durations (elapsed whole seconds vs the window) to avoid a
-		// lossy time.Duration conversion. A write timestamp newer than this scan's
-		// nowSeconds is fresh; that can happen when a render records a write while
-		// the Serve loop's runtimeSeconds snapshot is briefly stale.
-		elapsedSeconds := nowSeconds - rq.lastWriteSeconds.Load()
-		if elapsedSeconds <= 0 || time.Duration(elapsedSeconds)*time.Second <= spareWindow {
+		// A write timestamp newer than this scan's nowNanos is fresh; that can happen
+		// when a render records a write while the Serve loop's runtimeNanos snapshot
+		// is briefly stale.
+		elapsed := time.Duration(nowNanos - rq.lastWriteNanos.Load())
+		if elapsed <= 0 || elapsed <= spareWindow {
 			continue
 		}
 		return rq
@@ -236,7 +227,7 @@ func (jw *Jaws) getRequestLocked(jawsKey key.Key, r *http.Request, remoteIP neti
 	defer rq.mu.Unlock()
 	rq.JawsKey = jawsKey
 	rq.registered = registered
-	rq.lastWriteSeconds.Store(jw.runtimeSeconds.Load())
+	rq.lastWriteNanos.Store(jw.runtimeNanos.Load())
 	rq.initial = r
 	rq.remoteIP = remoteIP
 	rq.ctx, rq.cancelFn = context.WithCancelCause(jw.BaseContext)

--- a/requestpool.go
+++ b/requestpool.go
@@ -93,7 +93,16 @@ func (jw *Jaws) NewRequest(r *http.Request) (rq *Request) {
 func (jw *Jaws) refreshRuntimeNanos() {
 	// time.Since on a monotonic base is never negative and keeps the counter immune
 	// to wall-clock and NTP adjustments.
-	jw.runtimeNanos.Store(time.Since(jw.created).Nanoseconds())
+	jw.advanceRuntimeNanos(time.Since(jw.created).Nanoseconds())
+}
+
+// advanceRuntimeNanos raises the cached runtime to now without moving it backward.
+func (jw *Jaws) advanceRuntimeNanos(now int64) {
+	for previous := jw.runtimeNanos.Load(); now > previous; previous = jw.runtimeNanos.Load() {
+		if jw.runtimeNanos.CompareAndSwap(previous, now) {
+			return
+		}
+	}
 }
 
 // limitPendingRequestsLocked evicts pending Requests for remoteIP until the cap is

--- a/serve.go
+++ b/serve.go
@@ -30,6 +30,9 @@ func (jw *Jaws) getWebSocketTimeout() (t time.Duration) {
 }
 
 // ServeWithTimeout begins processing requests with the given timeout.
+//
+// Pending Requests idle longer than requestTimeout are retired by periodic
+// maintenance, which may observe the threshold up to one maintenance tick later.
 // It is intended to run on its own goroutine.
 // It returns when [Jaws.Close] is called.
 func (jw *Jaws) ServeWithTimeout(requestTimeout time.Duration) {
@@ -50,9 +53,9 @@ func (jw *Jaws) ServeWithTimeout(requestTimeout time.Duration) {
 	jw.webSocketTimeout = requestTimeout
 	jw.maintenanceInterval = maintenanceInterval
 	jw.mu.Unlock()
-	// Seed the seconds counter so it is accurate from the first request, then keep
+	// Seed the runtime counter so it is accurate from the first request, then keep
 	// it fresh on every maintenance tick (see the case below).
-	jw.refreshRuntimeSeconds()
+	jw.refreshRuntimeNanos()
 
 	defer func() {
 		t.Stop()
@@ -101,7 +104,7 @@ func (jw *Jaws) ServeWithTimeout(requestTimeout time.Duration) {
 				mustBroadcast(wire.Message{What: what.Update})
 			}
 		case <-t.C:
-			jw.refreshRuntimeSeconds()
+			jw.refreshRuntimeNanos()
 			jw.maintenance(requestTimeout)
 		case sub := <-jw.subCh:
 			if sub.msgCh != nil {
@@ -145,12 +148,12 @@ func (jw *Jaws) unsubscribe(msgCh chan wire.Message) {
 func (jw *Jaws) maintenance(requestTimeout time.Duration) {
 	var toLog []error
 	jw.mu.Lock()
-	nowSeconds := jw.runtimeSeconds.Load()
+	nowNanos := jw.runtimeNanos.Load()
 	for _, rq := range jw.requests {
 		if rq == nil {
 			continue
 		}
-		if expired, cause := rq.maintenance(nowSeconds, requestTimeout); expired {
+		if expired, cause := rq.maintenance(nowNanos, requestTimeout); expired {
 			if cause != nil {
 				toLog = append(toLog, cause)
 			}

--- a/serve_test.go
+++ b/serve_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -48,7 +49,7 @@ func TestJaws_MaintenanceRetiresExpiredRequestOnce(t *testing.T) {
 	initial := httptest.NewRequest(http.MethodGet, "/", nil)
 	rq := jw.NewRequest(initial)
 	key := rq.JawsKey
-	jw.runtimeSeconds.Store(rq.lastWriteSeconds.Load() + 2)
+	jw.runtimeNanos.Store(rq.lastWriteNanos.Load() + (2 * time.Second).Nanoseconds())
 
 	jw.maintenance(time.Second)
 
@@ -71,4 +72,40 @@ func TestJaws_MaintenanceRetiresExpiredRequestOnce(t *testing.T) {
 	if !errors.Is(logged[0], ErrNoWebSocketRequest) {
 		t.Fatalf("logged error = %v, want ErrNoWebSocketRequest", logged[0])
 	}
+}
+
+func TestJaws_ServeWithTimeoutHonorsSubsecondTimeout(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		jw, err := New()
+		if err != nil {
+			t.Fatal(err)
+		}
+		const requestTimeout = 50 * time.Millisecond
+		done := make(chan struct{})
+		go func() {
+			jw.ServeWithTimeout(requestTimeout)
+			close(done)
+		}()
+		waitForServeLoop(t, jw)
+
+		initial := httptest.NewRequest(http.MethodGet, "/", nil)
+		rq := jw.NewRequest(initial)
+		time.Sleep(requestTimeout)
+		synctest.Wait()
+		if got := jw.RequestCount(); got != 1 {
+			t.Fatalf("RequestCount at timeout threshold = %d, want 1", got)
+		}
+
+		time.Sleep(requestTimeout / 2)
+		synctest.Wait()
+		if got := jw.RequestCount(); got != 0 {
+			t.Fatalf("RequestCount after subsecond timeout = %d, want 0", got)
+		}
+		if cause := context.Cause(rq.Context()); !errors.Is(cause, ErrNoWebSocketRequest) {
+			t.Fatalf("cancellation cause = %v, want ErrNoWebSocketRequest", cause)
+		}
+
+		jw.Close()
+		<-done
+	})
 }

--- a/serve_test.go
+++ b/serve_test.go
@@ -74,6 +74,15 @@ func TestJaws_MaintenanceRetiresExpiredRequestOnce(t *testing.T) {
 	}
 }
 
+func TestJaws_AdvanceRuntimeNanosDoesNotMoveBackward(t *testing.T) {
+	jw := &Jaws{}
+	jw.advanceRuntimeNanos(2)
+	jw.advanceRuntimeNanos(1)
+	if got := jw.runtimeNanos.Load(); got != 2 {
+		t.Fatalf("runtimeNanos = %d, want 2", got)
+	}
+}
+
 func TestJaws_ServeWithTimeoutHonorsSubsecondTimeout(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		jw, err := New()


### PR DESCRIPTION
## Problem

`ServeWithTimeout` tracked request activity in whole seconds. A supported subsecond timeout such as 50 ms therefore left an idle pending Request alive for roughly a second instead of retiring it near the configured threshold.

## Fix

- Track cached monotonic runtime and last-write instants in nanoseconds.
- Compare idle durations without whole-second truncation.
- Retain the lock-free cached-clock write path and make concurrent refreshes atomic-max so the cached time cannot move backward.
- Document that retirement can be observed up to one maintenance tick after the threshold.

## Tests

- Added a deterministic `testing/synctest` regression at a 50 ms timeout, checking that the Request is live at the threshold and retired on the next maintenance tick.
- Added direct coverage that an older clock sample cannot replace a newer cached instant.
- Updated pending-eviction and maintenance tests to use duration-precise timestamps.
- `JAWS_REQUIRE_NODE=1 go test -race ./... -count=1`
- `go generate`, `go vet`, `staticcheck`, `golangci-lint`, `gosec`, `go build`, and formatting checks all pass.

Stacked on #109 because both fixes edit the Request lifecycle and timing fields. This PR contains only timeout-related changes relative to that base.
