### PR TITLE
Log browser event handler errors

### DIFF
--- a/request_test.go
+++ b/request_test.go
@@ -32,6 +32,33 @@ import (
 
 const testTimeout = time.Second * 3
 
+type eventErrorLogger struct {
+	mu   sync.Mutex
+	errs []error
+}
+
+func (*eventErrorLogger) Info(string, ...any) {}
+func (*eventErrorLogger) Warn(string, ...any) {}
+
+func (l *eventErrorLogger) Error(_ string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for i := 0; i+1 < len(args); i += 2 {
+		if args[i] == "err" {
+			if err, ok := args[i+1].(error); ok {
+				l.errs = append(l.errs, err)
+			}
+		}
+	}
+}
+
+func (l *eventErrorLogger) loggedErrors() (errs []error) {
+	l.mu.Lock()
+	errs = append(errs, l.errs...)
+	l.mu.Unlock()
+	return
+}
+
 func fillWsCh(ch chan wire.WsMsg) {
 	for {
 		select {
@@ -2549,17 +2576,23 @@ func (ctx *observedDoneContext) Done() <-chan struct{} {
 
 func newTestServer(t *testing.T) (ts *testServer) {
 	t.Helper()
-	return newTestServerWithSession(t, true)
+	return newTestServerWithSession(t, true, nil)
+}
+
+func newTestServerWithLogger(t *testing.T, logger Logger) (ts *testServer) {
+	t.Helper()
+	return newTestServerWithSession(t, true, logger)
 }
 
 func newTestServerNoSession(t *testing.T) (ts *testServer) {
 	t.Helper()
-	return newTestServerWithSession(t, false)
+	return newTestServerWithSession(t, false, nil)
 }
 
-func newTestServerWithSession(t *testing.T, withSession bool) (ts *testServer) {
+func newTestServerWithSession(t *testing.T, withSession bool, logger Logger) (ts *testServer) {
 	t.Helper()
 	jw, _ := New()
+	jw.Logger = logger
 	ctx, cancel := context.WithTimeout(t.Context(), time.Hour)
 	rr := httptest.NewRecorder()
 	hr := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
@@ -2958,7 +2991,8 @@ func TestWS_ConnectFnFailureRefreshesClaimedSessionGrace(t *testing.T) {
 
 func TestWS_NormalExchange(t *testing.T) {
 	th := newTestHelper(t)
-	ts := newTestServer(t)
+	logger := &eventErrorLogger{}
+	ts := newTestServerWithLogger(t, logger)
 	defer ts.Close()
 
 	fooError := errors.New("this foo failed")
@@ -2978,6 +3012,7 @@ func TestWS_NormalExchange(t *testing.T) {
 		t.Error(resp.StatusCode)
 	}
 	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "") }()
+	loggedBeforeEvent := len(logger.loggedErrors())
 
 	msg := wire.WsMsg{Jid: jidForTag(ts.rq, fooItem), What: what.Input}
 	ctx, cancel := context.WithTimeout(ts.ctx, testTimeout)
@@ -3004,6 +3039,14 @@ func TestWS_NormalExchange(t *testing.T) {
 	m2.FillAlert(fooError)
 	if !bytes.Equal(b, m2.Append(nil)) {
 		t.Error(b)
+	}
+
+	logged := logger.loggedErrors()
+	if len(logged) != loggedBeforeEvent+1 {
+		t.Fatalf("new logged errors = %v, want only the handler error", logged[loggedBeforeEvent:])
+	}
+	if !errors.Is(logged[loggedBeforeEvent], fooError) {
+		t.Fatalf("logged error = %v, want %v", logged[loggedBeforeEvent], fooError)
 	}
 }
 

--- a/requestloop.go
+++ b/requestloop.go
@@ -441,13 +441,13 @@ func (rq *Request) eventCaller(eventCallCh <-chan eventFnCall, outboundMsgCh cha
 			continue
 		default:
 		}
-		if err := rq.callAllEventHandlers(call.jid, call.wht, call.data); err != nil {
+		if err := rq.Jaws.Log(rq.callAllEventHandlers(call.jid, call.wht, call.data)); err != nil {
 			var m wire.WsMsg
 			m.FillAlert(err)
 			// This error alert is best-effort: unlike queueEvent, which cancels the
 			// Request with ErrRequestOverloaded when its channel fills (dropping a
 			// queued event could desync browser and backend state), a dropped alert
-			// loses no state — the underlying error is already logged below — so a
+			// loses no state — the underlying error is already logged above — so a
 			// full outbound channel here is logged and the alert is discarded rather
 			// than tearing down the Request.
 			select {


### PR DESCRIPTION
## Problem

When a normal browser Input/Click/Set handler returned an error, JaWS sent the error alert to the browser but never passed the underlying error to the configured server logger. Operators therefore lost the server-side diagnostic for a supported production event path.

## Fix

Log the handler error exactly once before best-effort alert delivery. If alert delivery itself is saturated, the existing separate delivery-failure diagnostic remains intact.

## Tests

- Extended the real WebSocket normal-exchange test to configure a logger before serving starts.
- Verifies the browser still receives its alert and the logger receives exactly one matching handler error.
- `JAWS_REQUIRE_NODE=1 go test -race ./... -count=1`
- Vet, static analysis, lint, security, build, generation, and formatting gates pass.
