### PR TITLE
Enforce shared tree single selection on the server

### DIFF
--- a/jawstree/README.md
+++ b/jawstree/README.md
@@ -155,3 +155,11 @@ all rendered clients by dirtying the JsVar's bound pointer:
 tree.SetSelected([][]string{{"Documents", "report.pdf"}})
 jw.Dirty(root)
 ```
+
+Without `MultiSelectEnabled` or `CascadeSelectChildren`, browser selection
+events enforce at most one selected node in the shared server state, including
+when multiple clients select concurrently. `Tree.SetSelected` remains an exact
+programmatic selection API and may set multiple nodes regardless of browser
+options; dirty the root afterward to publish that programmatic state. Peer
+clients reconcile browser selections in place, preserving their expanded nodes
+and active search state.

--- a/jawstree/assets/jawstree.js
+++ b/jawstree/assets/jawstree.js
@@ -70,12 +70,14 @@ function jawstreeInit(arg) {
     if (container) {
         container.hidden = false;
     }
-    window["jawstree_"+arg.key] = jawstreeNew(
+    var t = jawstreeNew(
         arg.key,
         arg.jid,
         window["jawstreeroot_"+arg.key],
         arg.options
     );
+    t.jawsSelectionVersion = arg.selectionVersion || 0;
+    window["jawstree_"+arg.key] = t;
 }
 
 function jawstreeSet(arg) {

--- a/jawstree/assets/jawstree.js
+++ b/jawstree/assets/jawstree.js
@@ -41,6 +41,30 @@ function jawstreeSetData(t, data) {
     t.setData(jawstreeViewChildren(data, t.options.multiSelectEnabled, t.options.cascadeSelectChildren));
 }
 
+function jawstreeNodeID(path, node) {
+    return typeof node.id == 'string' ? node.id : path;
+}
+
+function jawstreeSelectedIDs(data) {
+    var selected = [];
+    jawstreeForEachNode("", data, function(path, node) {
+        if (node.selected) {
+            selected.push(jawstreeNodeID(path, node));
+        }
+    });
+    return selected;
+}
+
+function jawstreeApplySelection(data, selected) {
+    jawstreeForEachNode("", data, function(path, node) {
+        if (selected.indexOf(jawstreeNodeID(path, node)) != -1) {
+            node.selected = true;
+        } else {
+            delete node.selected;
+        }
+    });
+}
+
 function jawstreeInit(arg) {
     var container = document.getElementById(arg.jid);
     if (container) {
@@ -56,11 +80,58 @@ function jawstreeInit(arg) {
 
 function jawstreeSet(arg) {
     var t = window["jawstree_"+arg.key];
+    var currentVersion = t.jawsSelectionVersion || 0;
+    var nextVersion = arg.selectionVersion || 0;
     var wasApplyingSet = t.jawsApplyingSet;
+    if (nextVersion < currentVersion) {
+        // A full update may have been rendered just before a newer browser
+        // selection was accepted. Keep that newer selection while still applying
+        // the full update's non-selection fields.
+        jawstreeApplySelection(arg.data, jawstreeSelectedIDs(window["jawstreeroot_"+arg.key]));
+    } else {
+        t.jawsSelectionVersion = nextVersion;
+    }
     window["jawstreeroot_"+arg.key] = arg.data;
     t.jawsApplyingSet = true;
     try {
         jawstreeSetData(t, arg.data);
+    } finally {
+        t.jawsApplyingSet = wasApplyingSet;
+    }
+}
+
+function jawstreeSetSelection(arg) {
+    var t = window["jawstree_"+arg.key];
+    var currentVersion = t.jawsSelectionVersion || 0;
+    if (arg.selectionVersion <= currentVersion) {
+        return;
+    }
+
+    var selected = Array.isArray(arg.selected) ? arg.selected : [];
+    var root = window["jawstreeroot_"+arg.key];
+    jawstreeApplySelection(root, selected);
+
+    // Quercus's ordinary single-select operation updates only selection classes
+    // and checkboxes. Unlike setData, it preserves expansion and search state.
+    var selectedID = null;
+    for (var i = 0; i < selected.length; i++) {
+        if (selected[i] !== "") {
+            selectedID = selected[i];
+        }
+    }
+    var selectedNodes = t.getSelectedNodes();
+    var alreadySelected = selectedID !== null && selectedNodes.length == 1 && selectedNodes[0].id == selectedID;
+    var wasApplyingSet = t.jawsApplyingSet;
+    t.jawsSelectionVersion = arg.selectionVersion;
+    t.jawsApplyingSet = true;
+    try {
+        if (selectedID === null) {
+            selectedNodes.forEach(function(node) {
+                t.selectNodeById(node.id, false);
+            });
+        } else if (!alreadySelected) {
+            t.selectNodeById(selectedID, true);
+        }
     } finally {
         t.jawsApplyingSet = wasApplyingSet;
     }

--- a/jawstree/dynamic_insert_production_regression_test.go
+++ b/jawstree/dynamic_insert_production_regression_test.go
@@ -94,7 +94,7 @@ func TestTreeDynamicInitializationWithClientAssets(t *testing.T) {
 		t.Fatalf("second dynamic message = %+v, want parent Order", frames[1])
 	}
 	if frames[2].What != what.Call || frames[2].Jid <= containerElem.Jid() ||
-		frames[2].Data != "jawstreeInit="+string(tree.appendInitCallData(nil, frames[2].Jid)) {
+		frames[2].Data != "jawstreeInit="+string(tree.appendInitCallData(nil, frames[2].Jid, 0)) {
 		t.Fatalf("third dynamic message = %+v, want child initializer Call", frames[2])
 	}
 	if strings.Contains(frames[0].Data, "<script") ||

--- a/jawstree/js_test.go
+++ b/jawstree/js_test.go
@@ -220,6 +220,181 @@ process.stdout.write(JSON.stringify(window["jawstree_tree"].selected));
 	}
 }
 
+func TestJawstreeJS_SetSelectionPreservesViewStateAndRejectsStaleUpdates(t *testing.T) {
+	raw := runJawstreeJSSnippet(t, `
+var root = { children: [
+	{ id: "children.0", name: "a", selected: true, children: [] },
+	{ id: "children.1", name: "b", children: [] }
+] };
+var tree = {
+	options: { multiSelectEnabled: false, cascadeSelectChildren: false },
+	jawsApplyingSet: false,
+	jawsSelectionVersion: 0,
+	expanded: ["children.0"],
+	searchQuery: "needle",
+	selected: ["children.0"],
+	setDataCalls: 0,
+	calls: [],
+	getSelectedNodes: function() {
+		return this.selected.map(function(id) { return { id: id }; });
+	},
+	selectNodeById: function(id, set) {
+		this.calls.push({ id: id, set: set, applying: this.jawsApplyingSet });
+		if (set) {
+			this.selected = [id];
+		} else {
+			this.selected = this.selected.filter(function(selectedID) { return selectedID != id; });
+		}
+	},
+	setData: function() { this.setDataCalls++; }
+};
+window["jawstreeroot_tree"] = root;
+window["jawstree_tree"] = tree;
+
+jawstreeSetSelection({ key: "tree", selectionVersion: 2, selected: ["children.1"] });
+var afterNew = {
+	selected: tree.selected.slice(),
+	a: Boolean(root.children[0].selected),
+	b: Boolean(root.children[1].selected)
+};
+jawstreeSetSelection({ key: "tree", selectionVersion: 1, selected: ["children.0"] });
+var afterStale = {
+	selected: tree.selected.slice(),
+	a: Boolean(root.children[0].selected),
+	b: Boolean(root.children[1].selected)
+};
+jawstreeSetSelection({ key: "tree", selectionVersion: 3, selected: [] });
+
+process.stdout.write(JSON.stringify({
+	afterNew: afterNew,
+	afterStale: afterStale,
+	finalSelected: tree.selected,
+	finalA: Boolean(root.children[0].selected),
+	finalB: Boolean(root.children[1].selected),
+	version: tree.jawsSelectionVersion,
+	expanded: tree.expanded,
+	searchQuery: tree.searchQuery,
+	setDataCalls: tree.setDataCalls,
+	calls: tree.calls,
+	applying: tree.jawsApplyingSet
+}));
+`)
+
+	var got struct {
+		AfterNew struct {
+			Selected []string `json:"selected"`
+			A        bool     `json:"a"`
+			B        bool     `json:"b"`
+		} `json:"afterNew"`
+		AfterStale struct {
+			Selected []string `json:"selected"`
+			A        bool     `json:"a"`
+			B        bool     `json:"b"`
+		} `json:"afterStale"`
+		FinalSelected []string `json:"finalSelected"`
+		FinalA        bool     `json:"finalA"`
+		FinalB        bool     `json:"finalB"`
+		Version       uint64   `json:"version"`
+		Expanded      []string `json:"expanded"`
+		SearchQuery   string   `json:"searchQuery"`
+		SetDataCalls  int      `json:"setDataCalls"`
+		Calls         []struct {
+			ID       string `json:"id"`
+			Set      bool   `json:"set"`
+			Applying bool   `json:"applying"`
+		} `json:"calls"`
+		Applying bool `json:"applying"`
+	}
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unexpected JSON output %q: %v", raw, err)
+	}
+	selectedB := []string{"children.1"}
+	if !reflect.DeepEqual(got.AfterNew.Selected, selectedB) || got.AfterNew.A || !got.AfterNew.B {
+		t.Fatalf("new selection = %+v, want only children.1", got.AfterNew)
+	}
+	if !reflect.DeepEqual(got.AfterStale.Selected, selectedB) || got.AfterStale.A || !got.AfterStale.B {
+		t.Fatalf("selection after stale update = %+v, want unchanged children.1", got.AfterStale)
+	}
+	if len(got.FinalSelected) != 0 || got.FinalA || got.FinalB || got.Version != 3 {
+		t.Fatalf("final selection = %v flags [%t %t] version %d, want empty at version 3", got.FinalSelected, got.FinalA, got.FinalB, got.Version)
+	}
+	if !reflect.DeepEqual(got.Expanded, []string{"children.0"}) || got.SearchQuery != "needle" || got.SetDataCalls != 0 {
+		t.Fatalf("view state changed: expanded=%v search=%q setDataCalls=%d", got.Expanded, got.SearchQuery, got.SetDataCalls)
+	}
+	if len(got.Calls) != 2 || got.Calls[0].ID != "children.1" || !got.Calls[0].Set ||
+		got.Calls[1].ID != "children.1" || got.Calls[1].Set || !got.Calls[0].Applying || !got.Calls[1].Applying {
+		t.Fatalf("targeted selection calls = %+v", got.Calls)
+	}
+	if got.Applying {
+		t.Fatal("jawsApplyingSet was not restored")
+	}
+}
+
+func TestJawstreeJS_StaleFullUpdatePreservesNewerSelection(t *testing.T) {
+	raw := runJawstreeJSSnippet(t, `
+function selectedIDs(data) {
+	return data.children.filter(function(node) { return Boolean(node.selected); }).map(function(node) { return node.id; });
+}
+var current = { marker: "current", children: [
+	{ id: "children.0", name: "a", children: [] },
+	{ id: "children.1", name: "b", selected: true, children: [] }
+] };
+var tree = {
+	options: { multiSelectEnabled: false, cascadeSelectChildren: false },
+	jawsApplyingSet: false,
+	jawsSelectionVersion: 2,
+	sets: [],
+	setData: function(data) { this.sets.push({ marker: data[0].marker, selected: selectedIDs({ children: data }) }); }
+};
+window["jawstreeroot_tree"] = current;
+window["jawstree_tree"] = tree;
+
+jawstreeSet({ key: "tree", selectionVersion: 1, data: { marker: "stale", children: [
+	{ id: "children.0", name: "a", selected: true, children: [] },
+	{ id: "children.1", name: "b", children: [] }
+] } });
+var afterStale = window["jawstreeroot_tree"];
+jawstreeSet({ key: "tree", selectionVersion: 2, data: { marker: "current-version", children: [
+	{ id: "children.0", name: "a", selected: true, children: [] },
+	{ id: "children.1", name: "b", children: [] }
+] } });
+var afterCurrent = window["jawstreeroot_tree"];
+
+process.stdout.write(JSON.stringify({
+	afterStaleMarker: afterStale.marker,
+	afterStaleSelected: selectedIDs(afterStale),
+	afterCurrentMarker: afterCurrent.marker,
+	afterCurrentSelected: selectedIDs(afterCurrent),
+	version: tree.jawsSelectionVersion,
+	sets: tree.sets
+}));
+`)
+
+	var got struct {
+		AfterStaleMarker     string   `json:"afterStaleMarker"`
+		AfterStaleSelected   []string `json:"afterStaleSelected"`
+		AfterCurrentMarker   string   `json:"afterCurrentMarker"`
+		AfterCurrentSelected []string `json:"afterCurrentSelected"`
+		Version              uint64   `json:"version"`
+		Sets                 []struct {
+			Marker   string   `json:"marker"`
+			Selected []string `json:"selected"`
+		} `json:"sets"`
+	}
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unexpected JSON output %q: %v", raw, err)
+	}
+	if got.AfterStaleMarker != "stale" || !reflect.DeepEqual(got.AfterStaleSelected, []string{"children.1"}) {
+		t.Fatalf("stale full update = marker %q selected %v, want non-selection data with newer children.1 selection", got.AfterStaleMarker, got.AfterStaleSelected)
+	}
+	if got.AfterCurrentMarker != "current-version" || !reflect.DeepEqual(got.AfterCurrentSelected, []string{"children.0"}) || got.Version != 2 {
+		t.Fatalf("current-version full update = marker %q selected %v version %d", got.AfterCurrentMarker, got.AfterCurrentSelected, got.Version)
+	}
+	if len(got.Sets) != 2 || !reflect.DeepEqual(got.Sets[0].Selected, []string{"children.1"}) || !reflect.DeepEqual(got.Sets[1].Selected, []string{"children.0"}) {
+		t.Fatalf("Treeview setData selections = %+v", got.Sets)
+	}
+}
+
 func TestJawstreeJS_UpdatesAreScopedByKey(t *testing.T) {
 	raw := runJawstreeJSSnippet(t, `
 function makeTree() {

--- a/jawstree/js_test.go
+++ b/jawstree/js_test.go
@@ -56,11 +56,25 @@ eval(src);
 	return out.String()
 }
 
-func TestJawstreeJS_InitUsesPreloadedRoot(t *testing.T) {
+func TestJawstreeJS_InitSeedsSelectionVersionAndUsesPreloadedRoot(t *testing.T) {
 	raw := runJawstreeJSSnippet(t, `
-const root = { children: [{ id: "children.0", name: "Documents" }] };
+const root = { children: [
+	{ id: "children.0", name: "Documents", children: [] },
+	{ id: "children.1", name: "Pictures", selected: true, children: [] }
+] };
 let got = null;
-const initialized = { ready: true };
+const initialized = {
+	ready: true,
+	selected: ["children.1"],
+	calls: [],
+	getSelectedNodes: function() {
+		return this.selected.map(function(id) { return { id: id }; });
+	},
+	selectNodeById: function(id, set) {
+		this.calls.push({ id: id, set: set });
+		this.selected = set ? [id] : [];
+	}
+};
 const container = { hidden: true };
 global.document = {
 	getElementById: function(id) {
@@ -73,12 +87,18 @@ jawstreeNew = function(key, jid, data, options) {
 	return initialized;
 };
 
-jawstreeInit({ key: "private", jid: "Jid.7", options: 3 });
+jawstreeInit({ key: "private", jid: "Jid.7", options: 3, selectionVersion: 2 });
+jawstreeSetSelection({ key: "private", selectionVersion: 1, selected: ["children.0"] });
 process.stdout.write(JSON.stringify({
 	got: got,
 	usesRoot: got.data === root,
 	stored: window["jawstree_private"] === initialized,
-	visible: !container.hidden
+	visible: !container.hidden,
+	version: initialized.jawsSelectionVersion,
+	documentsSelected: Boolean(root.children[0].selected),
+	picturesSelected: Boolean(root.children[1].selected),
+	viewSelected: initialized.selected,
+	selectionCalls: initialized.calls
 }));
 `)
 
@@ -88,9 +108,14 @@ process.stdout.write(JSON.stringify({
 			Jid     string `json:"jid"`
 			Options int    `json:"options"`
 		} `json:"got"`
-		UsesRoot bool `json:"usesRoot"`
-		Stored   bool `json:"stored"`
-		Visible  bool `json:"visible"`
+		UsesRoot          bool            `json:"usesRoot"`
+		Stored            bool            `json:"stored"`
+		Visible           bool            `json:"visible"`
+		Version           uint64          `json:"version"`
+		DocumentsSelected bool            `json:"documentsSelected"`
+		PicturesSelected  bool            `json:"picturesSelected"`
+		ViewSelected      []string        `json:"viewSelected"`
+		SelectionCalls    []jsSetPathCall `json:"selectionCalls"`
 	}
 	if err := json.Unmarshal([]byte(raw), &got); err != nil {
 		t.Fatalf("unexpected JSON output %q: %v", raw, err)
@@ -106,6 +131,10 @@ process.stdout.write(JSON.stringify({
 	}
 	if !got.Visible {
 		t.Fatal("initializer did not unhide the managed Jid container")
+	}
+	if got.Version != 2 || got.DocumentsSelected || !got.PicturesSelected ||
+		!reflect.DeepEqual(got.ViewSelected, []string{"children.1"}) || len(got.SelectionCalls) != 0 {
+		t.Fatalf("stale selection changed initialized state: version=%d shadow=[%t %t] view=%v calls=%v", got.Version, got.DocumentsSelected, got.PicturesSelected, got.ViewSelected, got.SelectionCalls)
 	}
 }
 

--- a/jawstree/node.go
+++ b/jawstree/node.go
@@ -105,6 +105,12 @@ var (
 // field by path. This is the server-side enforcement of the "server holds the truth"
 // contract for [Tree].
 //
+// On a default single-select Tree (neither [MultiSelectEnabled] nor
+// [CascadeSelectChildren]), selecting a node also clears every other selected
+// node. This keeps the server-side state authoritative when clients sharing the
+// Tree select concurrently. Multi-select and cascading Trees retain their
+// client selection semantics.
+//
 // The root's Selected flag is effectively server-only: the standard client cannot
 // produce the path that addresses the root itself, so avoid rendering the root
 // selected, since clients cannot change it back through the protocol.
@@ -127,7 +133,26 @@ func (node *Node) JawsSetPath(elem *jaws.Element, jsPath string, value any) (err
 	// index == len.
 	var target *Node
 	if target, err = node.resolveChildPath(nodePath); err == nil {
-		if target.Selected == selected {
+		if node.Tree != nil && node.Tree.isDefaultSingleSelect() {
+			changed := false
+			if selected {
+				node.Tree.Ptr.Walk("", func(_ string, candidate *Node) {
+					want := candidate == target
+					if candidate.Selected != want {
+						candidate.Selected = want
+						changed = true
+					}
+				})
+			} else if target.Selected {
+				target.Selected = false
+				changed = true
+			}
+			if changed {
+				node.Tree.selectionVersion++
+			} else {
+				err = jaws.ErrValueUnchanged
+			}
+		} else if target.Selected == selected {
 			err = jaws.ErrValueUnchanged
 		} else {
 			target.Selected = selected
@@ -176,14 +201,21 @@ func (node *Node) resolveChildPath(nodePath string) (*Node, error) {
 	return cur, nil
 }
 
-// JawsPathSet runs after a node's selected flag has been set on the server-side
-// tree; it broadcasts a jawstreeSetPath JsCall so the change is reflected in the
-// rendered tree of every client sharing this Tree.
+// JawsPathSet broadcasts a completed selection mutation.
+//
+// It runs after a node's selected flag has been set on the server-side tree. A
+// default single-select Tree broadcasts its versioned authoritative selection;
+// other modes broadcast the changed path. Both calls update every client sharing
+// this Tree without replacing the tree DOM.
 //
 // It requires node.Tree to be set — that is, the node must have been passed to
 // [New] — and panics otherwise, since a bare [Root] node has a nil Tree.
 func (node *Node) JawsPathSet(elem *jaws.Element, jsPath string, value any) {
 	if nodePath, ok := strings.CutSuffix(jsPath, ".selected"); ok {
+		if _, isBool := value.(bool); isBool && node.Tree.isDefaultSingleSelect() {
+			elem.Jaws.JsCall(node.Tree.JawsGetTag(nil), "jawstreeSetSelection", string(node.Tree.appendSelectionCallData(nil)))
+			return
+		}
 		// The marshaled struct holds two strings plus value, which JawsSetPath has
 		// already verified to be a bool, so marshaling cannot fail in practice; guard
 		// the error anyway so a future change that lets a non-marshalable value reach

--- a/jawstree/tree.go
+++ b/jawstree/tree.go
@@ -24,9 +24,10 @@ var _ jaws.UI = (*Tree)(nil)
 // [Tree.SetSelected]) under the lock is safe, but adding, removing, or reordering Children
 // afterward breaks that mapping and is unsupported on a rendered Tree.
 type Tree struct {
-	key          string
-	options      Option
-	renderParams [1]any
+	key              string
+	options          Option
+	renderParams     [1]any
+	selectionVersion uint64 // guarded by the embedded JsVar lock
 	*ui.JsVar[Node]
 }
 
@@ -43,6 +44,10 @@ func makeTreeKey() (key string) {
 			return
 		}
 	}
+}
+
+func (tree *Tree) isDefaultSingleSelect() bool {
+	return tree.options&(MultiSelectEnabled|CascadeSelectChildren) == 0
 }
 
 // New returns a tree widget for jsvar.
@@ -107,6 +112,28 @@ func (tree *Tree) appendInitCallData(b []byte, containerJid jid.Jid) []byte {
 	return b
 }
 
+func (tree *Tree) appendSelectionCallData(b []byte) []byte {
+	b = append(b, `{"key":`...)
+	b = strconv.AppendQuote(b, tree.key)
+	b = append(b, `,"selectionVersion":`...)
+	tree.RLock()
+	b = strconv.AppendUint(b, tree.selectionVersion, 10)
+	b = append(b, `,"selected":[`...)
+	first := true
+	tree.Ptr.Walk("", func(_ string, node *Node) {
+		if node.Selected {
+			if !first {
+				b = append(b, ',')
+			}
+			first = false
+			b = strconv.AppendQuote(b, node.ID)
+		}
+	})
+	tree.RUnlock()
+	b = append(b, `]}`...)
+	return b
+}
+
 // JawsRender renders the tree state and schedules browser initialization.
 func (tree *Tree) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err error) {
 	if len(params) == 0 {
@@ -129,11 +156,14 @@ func (tree *Tree) JawsUpdate(elem *jaws.Element) {
 	var b []byte
 	b = append(b, `{"key":`...)
 	b = strconv.AppendQuote(b, tree.key)
-	b = append(b, `,"data":`...)
 	// marshalJSON walks the shared Node tree, which a concurrent JawsInput on
 	// another Request can mutate under the JsVar write lock. Read it under the
-	// JsVar read lock so the two never race; JawsRender is likewise locked.
+	// JsVar read lock so the selection version and data form one snapshot and the
+	// walk never races; JawsRender is likewise locked.
 	tree.RLock()
+	b = append(b, `,"selectionVersion":`...)
+	b = strconv.AppendUint(b, tree.selectionVersion, 10)
+	b = append(b, `,"data":`...)
 	b = tree.JsVar.Ptr.marshalJSON(b)
 	tree.RUnlock()
 	b = append(b, `}`...)

--- a/jawstree/tree.go
+++ b/jawstree/tree.go
@@ -101,13 +101,15 @@ func New(jsvar *ui.JsVar[Node], options ...Option) (t *Tree) {
 	return
 }
 
-func (tree *Tree) appendInitCallData(b []byte, containerJid jid.Jid) []byte {
+func (tree *Tree) appendInitCallData(b []byte, containerJid jid.Jid, selectionVersion uint64) []byte {
 	b = append(b, `{"key":`...)
 	b = strconv.AppendQuote(b, tree.key)
 	b = append(b, `,"jid":`...)
 	b = containerJid.AppendQuote(b)
 	b = append(b, `,"options":`...)
 	b = strconv.AppendInt(b, int64(tree.options), 10)
+	b = append(b, `,"selectionVersion":`...)
+	b = strconv.AppendUint(b, selectionVersion, 10)
 	b = append(b, '}')
 	return b
 }
@@ -136,13 +138,16 @@ func (tree *Tree) appendSelectionCallData(b []byte) []byte {
 
 // JawsRender renders the tree state and schedules browser initialization.
 func (tree *Tree) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err error) {
+	var selectionVersion uint64
 	if len(params) == 0 {
 		params = tree.renderParams[:]
 	} else {
 		params = append([]any{tree.renderParams[0]}, params...)
 	}
-	if err = tree.JsVar.JawsRender(elem, w, params); err == nil {
-		elem.JsCall("jawstreeInit", string(tree.appendInitCallData(nil, elem.Jid())))
+	if err = tree.JsVar.JawsRenderSnapshot(elem, w, params, func(_ *Node) {
+		selectionVersion = tree.selectionVersion
+	}); err == nil {
+		elem.JsCall("jawstreeInit", string(tree.appendInitCallData(nil, elem.Jid(), selectionVersion)))
 	}
 	return
 }

--- a/jawstree/tree_test.go
+++ b/jawstree/tree_test.go
@@ -153,6 +153,105 @@ func TestTreeSelectionMethods(t *testing.T) {
 	}
 }
 
+func TestNode_JawsSetPathSelectionModes(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []Option
+		before  [2]bool
+		path    string
+		value   bool
+		want    [2]bool
+		version uint64
+		wantErr error
+	}{
+		{
+			name:    "select clears the previous selection",
+			before:  [2]bool{true, false},
+			path:    "children.1.selected",
+			value:   true,
+			want:    [2]bool{false, true},
+			version: 1,
+		},
+		{
+			name:    "deselect changes only the target",
+			before:  [2]bool{true, false},
+			path:    "children.0.selected",
+			value:   false,
+			want:    [2]bool{false, false},
+			version: 1,
+		},
+		{
+			name:    "sole selection is unchanged",
+			before:  [2]bool{true, false},
+			path:    "children.0.selected",
+			value:   true,
+			want:    [2]bool{true, false},
+			wantErr: jaws.ErrValueUnchanged,
+		},
+		{
+			name:    "select repairs existing multiple selection",
+			before:  [2]bool{true, true},
+			path:    "children.1.selected",
+			value:   true,
+			want:    [2]bool{false, true},
+			version: 1,
+		},
+		{
+			name:    "multi-select preserves other selections",
+			options: []Option{MultiSelectEnabled},
+			before:  [2]bool{true, false},
+			path:    "children.1.selected",
+			value:   true,
+			want:    [2]bool{true, true},
+		},
+		{
+			name:    "cascade preserves descendant selection semantics",
+			options: []Option{CascadeSelectChildren},
+			before:  [2]bool{true, false},
+			path:    "children.1.selected",
+			value:   true,
+			want:    [2]bool{true, true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := &Node{Children: []*Node{
+				{Name: "a", Selected: tt.before[0]},
+				{Name: "b", Selected: tt.before[1]},
+			}}
+			var mu sync.RWMutex
+			tree := New(ui.NewJsVar(&mu, root), tt.options...)
+
+			err := root.JawsSetPath(nil, tt.path, tt.value)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("JawsSetPath() error = %v, want %v", err, tt.wantErr)
+			}
+			got := [2]bool{root.Children[0].Selected, root.Children[1].Selected}
+			if got != tt.want {
+				t.Fatalf("selected = %v, want %v", got, tt.want)
+			}
+			if tree.selectionVersion != tt.version {
+				t.Fatalf("selectionVersion = %d, want %d", tree.selectionVersion, tt.version)
+			}
+		})
+	}
+}
+
+func TestTree_SetSelectedPreservesProgrammaticMultipleSelection(t *testing.T) {
+	root := &Node{Children: []*Node{{Name: "a"}, {Name: "b"}}}
+	var mu sync.RWMutex
+	tree := New(ui.NewJsVar(&mu, root))
+
+	changed := tree.SetSelected([][]string{{"a"}, {"b"}})
+	if !reflect.DeepEqual(changed, root.Children) {
+		t.Fatalf("SetSelected() changed = %#v, want both children %#v", changed, root.Children)
+	}
+	if !root.Children[0].Selected || !root.Children[1].Selected {
+		t.Fatalf("programmatic selection = [%v %v], want [true true]", root.Children[0].Selected, root.Children[1].Selected)
+	}
+}
+
 func TestTreeRenderEmitsSelfContainedRootAndQueuesInitializer(t *testing.T) {
 	jw, err := jaws.New()
 	maybeError(t, err)
@@ -516,25 +615,27 @@ func TestTree(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for jawstreeSet message")
 	case msg := <-rq.OutCh:
-		if s := string(rootnode.marshalJSON(nil)); !strings.Contains(msg.Data, s) {
-			t.Log(msg.Data)
-			t.Error("msg data did not contain our JSON")
+		want := `jawstreeSet={"key":` + strconv.Quote(tree.key) + `,"selectionVersion":0,"data":` + string(rootnode.marshalJSON(nil)) + `}`
+		if msg.Data != want {
+			t.Errorf("msg data = %q, want %q", msg.Data, want)
 		}
 		if !strings.Contains(msg.Data, `"selectable":false`) {
 			t.Error("msg data did not contain selectable:false")
 		}
 	}
 
-	// The value is a bool at runtime (JsVar unmarshals the wire value and the
-	// JawsSetPath gate requires a bool), so pass one here rather than a string.
+	// Match the production callback order: mutate under the JsVar lock, then
+	// publish after the lock is released.
+	tree.Lock()
+	err = rootnode.JawsSetPath(elem, changed[0].ID+".selected", false)
+	tree.Unlock()
+	maybeError(t, err)
 	rootnode.JawsPathSet(elem, changed[0].ID+".selected", false)
 	select {
 	case <-t.Context().Done():
-		t.Fatal("expected a jawstreeSetPath broadcast")
+		t.Fatal("expected a jawstreeSetSelection broadcast")
 	case msg := <-rq.OutCh:
-		// The broadcast id is the node's own ID; derive the expectation from it
-		// rather than a literal, which is fragile to the package directory listing.
-		want := `jawstreeSetPath={"key":` + strconv.Quote(tree.key) + `,"id":` + strconv.Quote(changed[0].ID) + `,"set":false}`
+		want := "jawstreeSetSelection=" + string(tree.appendSelectionCallData(nil))
 		if msg.Data != want {
 			t.Errorf("unexpected data: %q, want %q", msg.Data, want)
 		}
@@ -619,15 +720,18 @@ func TestTree_JawsPathSetIgnoresNonSelectedPath(t *testing.T) {
 	child := rootnode.Children[0]
 	// A non-".selected" path must be ignored (no broadcast)...
 	child.JawsPathSet(elem, child.ID+".name", "renamed")
-	// ...so the ".selected" broadcast is the first message on OutCh. The value is
-	// a bool at runtime, so pass one rather than a string.
+	// ...so the authoritative selection broadcast is the first message on OutCh.
+	tree.Lock()
+	err = rootnode.JawsSetPath(elem, child.ID+".selected", true)
+	tree.Unlock()
+	maybeError(t, err)
 	child.JawsPathSet(elem, child.ID+".selected", true)
 
 	select {
 	case <-t.Context().Done():
-		t.Fatal("expected a jawstreeSetPath message")
+		t.Fatal("expected a jawstreeSetSelection message")
 	case msg := <-rq.OutCh:
-		if !strings.Contains(msg.Data, "jawstreeSetPath") || !strings.Contains(msg.Data, `"set":true`) {
+		if msg.Data != "jawstreeSetSelection="+string(tree.appendSelectionCallData(nil)) {
 			t.Fatalf("first message should be the .selected broadcast, got %q (a non-.selected path leaked a broadcast)", msg.Data)
 		}
 	}
@@ -744,6 +848,185 @@ func collectJawstreeSetMessages(t *testing.T, ch <-chan wire.WsMsg) (msgs []wire
 				}
 				idle.Reset(250 * time.Millisecond)
 			}
+		}
+	}
+}
+
+type jawstreeSelectionCall struct {
+	Key              string   `json:"key"`
+	SelectionVersion uint64   `json:"selectionVersion"`
+	Selected         []string `json:"selected"`
+}
+
+func collectJawstreeSelectionCalls(t *testing.T, ch <-chan wire.WsMsg) (calls []jawstreeSelectionCall) {
+	t.Helper()
+	deadline := time.NewTimer(2 * time.Second)
+	defer deadline.Stop()
+	idle := time.NewTimer(time.Hour)
+	if !idle.Stop() {
+		<-idle.C
+	}
+	defer idle.Stop()
+
+	for {
+		var idleC <-chan time.Time
+		if len(calls) > 0 {
+			idleC = idle.C
+		}
+		select {
+		case <-t.Context().Done():
+			t.Fatal("test context expired while waiting for jawstreeSetSelection messages")
+		case <-deadline.C:
+			if len(calls) == 0 {
+				t.Fatal("timed out waiting for jawstreeSetSelection message")
+			}
+			return calls
+		case <-idleC:
+			return calls
+		case msg := <-ch:
+			if strings.HasPrefix(msg.Data, "jawstreeSet=") {
+				t.Fatalf("default selection rebuilt the tree with %q", msg.Data)
+			}
+			if payload, ok := strings.CutPrefix(msg.Data, "jawstreeSetSelection="); ok {
+				var call jawstreeSelectionCall
+				if err := json.Unmarshal([]byte(payload), &call); err != nil {
+					t.Fatalf("invalid jawstreeSetSelection payload %q: %v", payload, err)
+				}
+				calls = append(calls, call)
+				if !idle.Stop() {
+					select {
+					case <-idle.C:
+					default:
+					}
+				}
+				idle.Reset(250 * time.Millisecond)
+			}
+		}
+	}
+}
+
+func TestTree_DefaultSingleSelectionConcurrentClients(t *testing.T) {
+	jw, err := jaws.New()
+	maybeError(t, err)
+	defer jw.Close()
+	go jw.Serve()
+
+	rq1 := jawstest.NewTestRequest(jw, nil)
+	rq2 := jawstest.NewTestRequest(jw, nil)
+	abortSelections := make(chan struct{})
+	defer func() {
+		close(abortSelections)
+		rq1.Close()
+		rq2.Close()
+		<-rq1.DoneCh
+		<-rq2.DoneCh
+	}()
+	<-rq1.ReadyCh
+	<-rq2.ReadyCh
+
+	root := &Node{Children: []*Node{{Name: "a"}, {Name: "b"}}}
+	var mu sync.RWMutex
+	tree := New(ui.NewJsVar(&mu, root))
+
+	// Both event handlers pause before reaching the JsVar. This models two normal
+	// clients selecting from the same initial snapshot, without relying on the
+	// scheduler to keep either client's peer update from arriving first.
+	var arrivalMu sync.Mutex
+	arrivals := 0
+	bothArrived := make(chan struct{})
+	concurrentSelection := jaws.InputFn(func(_ *jaws.Element, value string) error {
+		if strings.HasSuffix(value, ".selected=true") {
+			arrivalMu.Lock()
+			arrivals++
+			if arrivals == 2 {
+				close(bothArrived)
+			}
+			arrivalMu.Unlock()
+			select {
+			case <-bothArrived:
+			case <-abortSelections:
+				return nil
+			}
+		}
+		return jaws.ErrEventUnhandled
+	})
+
+	renderTree := func(rq *jawstest.TestRequest) *jaws.Element {
+		t.Helper()
+		elem := rq.NewElement(tree)
+		var out strings.Builder
+		maybeError(t, elem.JawsRender(&out, []any{concurrentSelection}))
+		rq.InCh <- wire.WsMsg{}
+		select {
+		case msg := <-rq.OutCh:
+			if msg.What != what.Call || msg.Jid != elem.Jid() || !strings.HasPrefix(msg.Data, "jawstreeInit=") {
+				t.Fatalf("initializer = %+v, want a tree initializer for %s", msg, elem.Jid())
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for tree initializer")
+		}
+		return elem
+	}
+	elem1 := renderTree(rq1)
+	elem2 := renderTree(rq2)
+
+	// A click on a separate, normally rendered button is a FIFO barrier behind
+	// each Set event in that Request's event goroutine.
+	selectionDone := make(chan struct{}, 2)
+	newBarrier := func(rq *jawstest.TestRequest) *jaws.Element {
+		t.Helper()
+		clicked := ui.New("done").Clicked(func(_ ui.Object, _ *jaws.Element, _ jaws.Click) error {
+			selectionDone <- struct{}{}
+			return nil
+		})
+		elem := rq.NewElement(ui.NewButton(clicked))
+		maybeError(t, elem.JawsRender(&strings.Builder{}, nil))
+		return elem
+	}
+	barrier1 := newBarrier(rq1)
+	barrier2 := newBarrier(rq2)
+
+	rq1.InCh <- wire.WsMsg{Jid: elem1.Jid(), What: what.Set, Data: "children.0.selected=true"}
+	rq2.InCh <- wire.WsMsg{Jid: elem2.Jid(), What: what.Set, Data: "children.1.selected=true"}
+	select {
+	case <-bothArrived:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for concurrent selections")
+	}
+	rq1.InCh <- wire.WsMsg{Jid: barrier1.Jid(), What: what.Click, Data: "0 0 0"}
+	rq2.InCh <- wire.WsMsg{Jid: barrier2.Jid(), What: what.Click, Data: "0 0 0"}
+	for range 2 {
+		select {
+		case <-selectionDone:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for selection event barrier")
+		}
+	}
+
+	tree.RLock()
+	selected := [2]bool{root.Children[0].Selected, root.Children[1].Selected}
+	wantVersion := tree.selectionVersion
+	var wantSelected []string
+	for _, node := range root.Children {
+		if node.Selected {
+			wantSelected = append(wantSelected, node.ID)
+		}
+	}
+	tree.RUnlock()
+	if selected != [2]bool{true, false} && selected != [2]bool{false, true} {
+		t.Fatalf("concurrent default selections left server state %v, want exactly one selected node", selected)
+	}
+
+	for i, ch := range []<-chan wire.WsMsg{rq1.OutCh, rq2.OutCh} {
+		calls := collectJawstreeSelectionCalls(t, ch)
+		var newest jawstreeSelectionCall
+		for _, call := range calls {
+			if call.SelectionVersion > newest.SelectionVersion {
+				newest = call
+			}
+		}
+		if newest.Key != tree.key || newest.SelectionVersion != wantVersion || !reflect.DeepEqual(newest.Selected, wantSelected) {
+			t.Errorf("client %d newest targeted selection = %+v, want key %q version %d selected %v", i+1, newest, tree.key, wantVersion, wantSelected)
 		}
 	}
 }

--- a/jawstree/tree_test.go
+++ b/jawstree/tree_test.go
@@ -306,7 +306,7 @@ func TestTreeRenderEmitsSelfContainedRootAndQueuesInitializer(t *testing.T) {
 		if msg.What != what.Call || msg.Jid != elem.Jid() {
 			t.Fatalf("initializer message = %+v, want element-scoped Call for %s", msg, elem.Jid())
 		}
-		if want := "jawstreeInit=" + string(tree.appendInitCallData(nil, elem.Jid())); msg.Data != want {
+		if want := "jawstreeInit=" + string(tree.appendInitCallData(nil, elem.Jid(), 0)); msg.Data != want {
 			t.Fatalf("initializer data = %q, want %q", msg.Data, want)
 		}
 	case <-time.After(time.Second):
@@ -460,7 +460,10 @@ func TestTreeSelectionMethodsConcurrentWithInput(t *testing.T) {
 	if rq == nil {
 		t.Fatal("nil test request")
 	}
-	defer rq.Close()
+	defer func() {
+		rq.Close()
+		<-rq.DoneCh
+	}()
 
 	root := &Node{Name: "root", Children: []*Node{{Name: "child"}}}
 	var mu deadlock.RWMutex
@@ -555,7 +558,7 @@ func TestTree(t *testing.T) {
 	rq.InCh <- wire.WsMsg{}
 	select {
 	case msg := <-rq.OutCh:
-		if msg.What != what.Call || msg.Jid != elem.Jid() || msg.Data != "jawstreeInit="+string(tree.appendInitCallData(nil, elem.Jid())) {
+		if msg.What != what.Call || msg.Jid != elem.Jid() || msg.Data != "jawstreeInit="+string(tree.appendInitCallData(nil, elem.Jid(), 0)) {
 			t.Fatalf("unexpected initial tree message: %+v", msg)
 		}
 	case <-time.After(2 * time.Second):
@@ -659,6 +662,141 @@ func (fw *failWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
+type blockingWriter struct {
+	wrote   chan<- []byte
+	release <-chan struct{}
+}
+
+func (bw blockingWriter) Write(p []byte) (n int, err error) {
+	b := append([]byte(nil), p...)
+	bw.wrote <- b
+	<-bw.release
+	n = len(p)
+	return
+}
+
+func TestTree_JawsRenderSnapshotsSelectionVersionWithInitialData(t *testing.T) {
+	jw, err := jaws.New()
+	maybeError(t, err)
+	defer jw.Close()
+
+	go jw.Serve()
+	rq := jawstest.NewTestRequest(jw, nil)
+	if rq == nil {
+		t.Fatal("nil test request")
+	}
+	defer rq.Close()
+	<-rq.ReadyCh
+
+	root := &Node{Children: []*Node{{Name: "a"}, {Name: "b"}}}
+	var mu sync.RWMutex
+	tree := New(ui.NewJsVar(&mu, root))
+	elem := rq.NewElement(tree)
+
+	tree.Lock()
+	err = root.JawsSetPath(elem, "children.0.selected", true)
+	tree.Unlock()
+	maybeError(t, err)
+
+	wrote := make(chan []byte, 1)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	renderErr := make(chan error, 1)
+	renderDone := false
+	defer func() {
+		releaseOnce.Do(func() { close(release) })
+		if !renderDone {
+			select {
+			case <-renderErr:
+			case <-time.After(time.Second):
+			}
+		}
+	}()
+	go func() {
+		renderErr <- elem.JawsRender(blockingWriter{wrote: wrote, release: release}, nil)
+	}()
+
+	var rendered []byte
+	select {
+	case rendered = <-wrote:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the initial tree write")
+	}
+
+	mutationErr := make(chan error, 1)
+	go func() {
+		tree.Lock()
+		err := root.JawsSetPath(elem, "children.1.selected", true)
+		tree.Unlock()
+		mutationErr <- err
+	}()
+	select {
+	case err = <-mutationErr:
+		maybeError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("selection mutation remained blocked after serialization")
+	}
+
+	releaseOnce.Do(func() { close(release) })
+	select {
+	case err = <-renderErr:
+		renderDone = true
+		maybeError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the initial tree render")
+	}
+
+	_, attr, ok := strings.Cut(string(rendered), `data-jawsdata="`)
+	if !ok {
+		t.Fatalf("rendered tree is missing data-jawsdata: %q", rendered)
+	}
+	attr, _, ok = strings.Cut(attr, `"`)
+	if !ok {
+		t.Fatalf("rendered tree has an unterminated data-jawsdata: %q", rendered)
+	}
+	var initial struct {
+		Children []struct {
+			Selected bool `json:"selected"`
+		} `json:"children"`
+	}
+	if err = json.Unmarshal([]byte(html.UnescapeString(attr)), &initial); err != nil {
+		t.Fatalf("initial tree data is not JSON: %v", err)
+	}
+	if len(initial.Children) != 2 || !initial.Children[0].Selected || initial.Children[1].Selected {
+		t.Fatalf("initial rendered selection = %+v, want only child a", initial.Children)
+	}
+
+	// Wake the already-running Request so it drains the initializer queued after
+	// the blocked write completed.
+	rq.InCh <- wire.WsMsg{}
+	select {
+	case msg := <-rq.OutCh:
+		payload, ok := strings.CutPrefix(msg.Data, "jawstreeInit=")
+		if msg.What != what.Call || msg.Jid != elem.Jid() || !ok {
+			t.Fatalf("initializer message = %+v, want element-scoped jawstreeInit", msg)
+		}
+		var init struct {
+			SelectionVersion uint64 `json:"selectionVersion"`
+		}
+		if err := json.Unmarshal([]byte(payload), &init); err != nil {
+			t.Fatalf("initializer payload is not JSON: %v", err)
+		}
+		if init.SelectionVersion != 1 {
+			t.Fatalf("initializer selectionVersion = %d, want serialized-data version 1", init.SelectionVersion)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the initial tree initializer")
+	}
+
+	tree.RLock()
+	liveVersion := tree.selectionVersion
+	liveSelection := [2]bool{root.Children[0].Selected, root.Children[1].Selected}
+	tree.RUnlock()
+	if liveVersion != 2 || liveSelection != [2]bool{false, true} {
+		t.Fatalf("live tree = version %d selection %v, want version 2 with only child b", liveVersion, liveSelection)
+	}
+}
+
 // TestTree_JawsRenderWriteError verifies Tree.JawsRender propagates a write error
 // from the hidden JsVar data element.
 func TestTree_JawsRenderWriteError(t *testing.T) {
@@ -712,7 +850,7 @@ func TestTree_JawsPathSetIgnoresNonSelectedPath(t *testing.T) {
 	case <-t.Context().Done():
 		t.Fatal("expected a jawstreeInit message")
 	case msg := <-rq.OutCh:
-		if msg.What != what.Call || msg.Jid != elem.Jid() || msg.Data != "jawstreeInit="+string(tree.appendInitCallData(nil, elem.Jid())) {
+		if msg.What != what.Call || msg.Jid != elem.Jid() || msg.Data != "jawstreeInit="+string(tree.appendInitCallData(nil, elem.Jid(), 0)) {
 			t.Fatalf("unexpected initial tree message: %+v", msg)
 		}
 	}
@@ -783,7 +921,7 @@ func TestTree_DirtySharedTreeSendsOneUpdatePerRequest(t *testing.T) {
 		tc.rq.InCh <- wire.WsMsg{}
 		select {
 		case msg := <-tc.rq.OutCh:
-			want := "jawstreeInit=" + string(tree.appendInitCallData(nil, tc.elem.Jid()))
+			want := "jawstreeInit=" + string(tree.appendInitCallData(nil, tc.elem.Jid(), 0))
 			if msg.What != what.Call || msg.Jid != tc.elem.Jid() || msg.Data != want {
 				t.Fatalf("request initializer = %+v, want Jid %s data %q", msg, tc.elem.Jid(), want)
 			}

--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -265,16 +265,7 @@ func (jsvar *JsVar[T]) JawsSet(elem *jaws.Element, value T) (err error) {
 	return jsvar.JawsSetPath(elem, "", value)
 }
 
-// JawsRender writes the hidden element that seeds and routes the JavaScript variable.
-//
-// params[0] must be a valid JsVar name. Otherwise, JawsRender returns
-// [ErrIllegalJsVarName] without writing markup.
-//
-// The bound value's [tag.TagGetter.JawsGetTag] and [jaws.InitHandler.JawsInit]
-// callbacks run while the JsVar write lock is held, so they must not re-enter this
-// JsVar (for example call JawsGet or JawsSet on it), which would self-deadlock the
-// non-reentrant lock.
-func (jsvar *JsVar[T]) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err error) {
+func (jsvar *JsVar[T]) jawsRender(elem *jaws.Element, w io.Writer, params []any, snapshot func(*T)) (err error) {
 	var getterAttrs []template.HTMLAttr
 	var jsvarName string
 	var data []byte
@@ -284,14 +275,18 @@ func (jsvar *JsVar[T]) JawsRender(elem *jaws.Element, w io.Writer, params []any)
 	// another request sharing this JsVar sets it concurrently. Release before
 	// ApplyParams and, crucially, before writing to w: holding the value lock across a
 	// network write would let a slow client stall every goroutine sharing the locker.
-	jsvar.Lock()
-	if jsvar.dirtyTag, getterAttrs, err = elem.ApplyGetter(jsvar.Ptr); err == nil {
-		elem.AddHandlers(jsvar)
-		if jsvarName, err = validateJsVarName(params); err == nil && jsvar.Ptr != nil {
-			data, err = json.Marshal(jsvar.Ptr)
+	func() {
+		jsvar.Lock()
+		defer jsvar.Unlock()
+		if jsvar.dirtyTag, getterAttrs, err = elem.ApplyGetter(jsvar.Ptr); err == nil {
+			elem.AddHandlers(jsvar)
+			if jsvarName, err = validateJsVarName(params); err == nil && jsvar.Ptr != nil {
+				if data, err = json.Marshal(jsvar.Ptr); err == nil && snapshot != nil {
+					snapshot(jsvar.Ptr)
+				}
+			}
 		}
-	}
-	jsvar.Unlock()
+	}()
 
 	// After the fact: if the value has grown past the cap (e.g. via accumulated
 	// client writes), abort the request rather than emit an oversized payload. This
@@ -314,6 +309,37 @@ func (jsvar *JsVar[T]) JawsRender(elem *jaws.Element, w io.Writer, params []any)
 		b = append(b, " hidden></div>"...)
 		_, err = w.Write(b)
 	}
+	return
+}
+
+// JawsRender writes the hidden element that seeds and routes the JavaScript variable.
+//
+// params[0] must be a valid JsVar name. Otherwise, JawsRender returns
+// [ErrIllegalJsVarName] without writing markup.
+//
+// The bound value's [tag.TagGetter.JawsGetTag] and [jaws.InitHandler.JawsInit]
+// callbacks run while the JsVar write lock is held, so they must not re-enter this
+// JsVar (for example call JawsGet or JawsSet on it), which would self-deadlock the
+// non-reentrant lock.
+func (jsvar *JsVar[T]) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err error) {
+	err = jsvar.jawsRender(elem, w, params, nil)
+	return
+}
+
+// JawsRenderSnapshot renders the JavaScript variable and captures related state.
+//
+// When Ptr is non-nil and marshaling succeeds, snapshot is called once with Ptr
+// while the JsVar write lock remains held. This lets a composite UI capture
+// additional state from the same locked snapshot as the rendered value. The
+// callback must only read protected state: it must not re-enter the JsVar, mutate
+// Ptr, retain and later access Ptr without the appropriate lock, or block waiting
+// for code that needs the JsVar lock. A callback panic propagates after the lock is
+// released. The callback is not called when validation, getter initialization, or
+// marshaling fails. It runs before the client-size check and output write, so it
+// can run even when JawsRenderSnapshot subsequently returns [ErrJsVarTooLarge] or
+// a writer error. A nil callback behaves like [JsVar.JawsRender].
+func (jsvar *JsVar[T]) JawsRenderSnapshot(elem *jaws.Element, w io.Writer, params []any, snapshot func(*T)) (err error) {
+	err = jsvar.jawsRender(elem, w, params, snapshot)
 	return
 }
 

--- a/lib/ui/jsvar_test.go
+++ b/lib/ui/jsvar_test.go
@@ -152,6 +152,66 @@ func TestJsVar_RenderSetAndEvent(t *testing.T) {
 	}
 }
 
+func TestJsVar_JawsRenderSnapshot(t *testing.T) {
+	jw, rq := newCoreRequest(t)
+	go jw.Serve()
+
+	var mu sync.RWMutex
+	v := jsVarData{Text: "snapshot", Num: 7}
+	jsv := NewJsVar(&mu, &v)
+	elem := rq.NewElement(jsv)
+
+	var calls int
+	var captured jsVarData
+	var sb strings.Builder
+	err := jsv.JawsRenderSnapshot(elem, &sb, []any{"snapshotVar"}, func(ptr *jsVarData) {
+		calls++
+		captured = *ptr
+		if mu.TryLock() {
+			mu.Unlock()
+			t.Error("snapshot callback ran without the JsVar write lock held")
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 || captured != v {
+		t.Fatalf("snapshot callback = %d calls with %#v, want one call with %#v", calls, captured, v)
+	}
+
+	var rendered jsVarData
+	if err := json.Unmarshal([]byte(htmlAttrValue(t, sb.String(), "data-jawsdata")), &rendered); err != nil {
+		t.Fatal(err)
+	}
+	if rendered != captured {
+		t.Fatalf("rendered value = %#v, captured snapshot %#v", rendered, captured)
+	}
+
+	calls = 0
+	err = jsv.JawsRenderSnapshot(rq.NewElement(jsv), &strings.Builder{}, []any{"not valid"}, func(*jsVarData) {
+		calls++
+	})
+	if !errors.Is(err, ErrIllegalJsVarName) || calls != 0 {
+		t.Fatalf("invalid render = error %v and %d snapshot calls, want ErrIllegalJsVarName and no call", err, calls)
+	}
+
+	wantPanic := errors.New("snapshot panic")
+	func() {
+		defer func() {
+			if got := recover(); got != wantPanic {
+				t.Fatalf("snapshot panic = %v, want %v", got, wantPanic)
+			}
+		}()
+		_ = jsv.JawsRenderSnapshot(rq.NewElement(jsv), &strings.Builder{}, []any{"snapshotVar"}, func(*jsVarData) {
+			panic(wantPanic)
+		})
+	}()
+	if !mu.TryLock() {
+		t.Fatal("JsVar write lock remained held after a snapshot callback panic")
+	}
+	mu.Unlock()
+}
+
 // TestJsVar_SetBroadcastsWirePayload pins the wire payload broadcast when a
 // JsVar path is set: subscribed peers receive a what.Set carrying "path=<json
 // value>". This guards the documented "broadcast carries the caller's JSON


### PR DESCRIPTION
## Problem

Default jawstree single-selection was enforced only in each browser. Two normal clients sharing one Tree could select different nodes concurrently from the same initial state; each sent a valid `selected=true` update, leaving multiple nodes selected in the authoritative server state.

Versioned peer reconciliation also needs an initial baseline: without one, a newly rendered client can accept a delayed older selection call and permanently regress.

## Fix

- Enforce default non-cascading single selection while holding the shared `JsVar` write lock.
- Assign a monotonically versioned authoritative selection snapshot to every accepted browser selection.
- Capture the initial tree JSON and selection version under the same lock and seed that version before publishing the browser Treeview.
- Reconcile peers with a targeted `jawstreeSetSelection` call instead of rebuilding the full Treeview DOM.
- Reject stale targeted selection calls, and preserve newer selection when an older full update arrives.
- Preserve existing multi-select, cascade, disabled-selection, and exact programmatic `Tree.SetSelected` semantics.

The in-place client reconciliation keeps expansion and active search state intact.

## Tests

- Added a production-path regression with two live Requests selecting concurrently and verifies that the server and both clients converge to exactly one node.
- Added a blocked-writer regression proving initial JSON and version remain one atomic snapshot while the live tree changes.
- Added shipped-JavaScript coverage for initialized-version stale rejection, in-place selection, expansion/search preservation, deselection, stale targeted calls, and stale full updates.
- Added table coverage for default, multi-select, cascade, unchanged, and inconsistent-initial-state selection behavior.
- `go test -race ./...`
- Generation, formatting, vet, static analysis, lint, security, and build gates all pass; focused concurrency and JavaScript regressions pass repeatedly.
