### PR TITLE
Reconcile default tree selection after connect

### DIFF
--- a/jawstree/assets/jawstree.js
+++ b/jawstree/assets/jawstree.js
@@ -78,6 +78,13 @@ function jawstreeInit(arg) {
     );
     t.jawsSelectionVersion = arg.selectionVersion || 0;
     window["jawstree_"+arg.key] = t;
+
+    /*jslint bitwise: true */
+    var defaultSingleSelect = !(arg.options & (1<<2)) && !(arg.options & (1<<7));
+    /*jslint bitwise: false */
+    if (defaultSingleSelect && jawsCanSend()) {
+        jaws.send("Input\t" + arg.jid + "\t" + JSON.stringify("jawstree-selection-sync:" + t.jawsSelectionVersion) + "\n");
+    }
 }
 
 function jawstreeSet(arg) {

--- a/jawstree/js_test.go
+++ b/jawstree/js_test.go
@@ -63,6 +63,9 @@ const root = { children: [
 	{ id: "children.1", name: "Pictures", selected: true, children: [] }
 ] };
 let got = null;
+const sent = [];
+global.jawsCanSend = function() { return true; };
+global.jaws = { send: function(frame) { sent.push(frame); } };
 const initialized = {
 	ready: true,
 	selected: ["children.1"],
@@ -98,7 +101,8 @@ process.stdout.write(JSON.stringify({
 	documentsSelected: Boolean(root.children[0].selected),
 	picturesSelected: Boolean(root.children[1].selected),
 	viewSelected: initialized.selected,
-	selectionCalls: initialized.calls
+	selectionCalls: initialized.calls,
+	sent: sent
 }));
 `)
 
@@ -116,6 +120,7 @@ process.stdout.write(JSON.stringify({
 		PicturesSelected  bool            `json:"picturesSelected"`
 		ViewSelected      []string        `json:"viewSelected"`
 		SelectionCalls    []jsSetPathCall `json:"selectionCalls"`
+		Sent              []string        `json:"sent"`
 	}
 	if err := json.Unmarshal([]byte(raw), &got); err != nil {
 		t.Fatalf("unexpected JSON output %q: %v", raw, err)
@@ -135,6 +140,34 @@ process.stdout.write(JSON.stringify({
 	if got.Version != 2 || got.DocumentsSelected || !got.PicturesSelected ||
 		!reflect.DeepEqual(got.ViewSelected, []string{"children.1"}) || len(got.SelectionCalls) != 0 {
 		t.Fatalf("stale selection changed initialized state: version=%d shadow=[%t %t] view=%v calls=%v", got.Version, got.DocumentsSelected, got.PicturesSelected, got.ViewSelected, got.SelectionCalls)
+	}
+	wantSent := []string{"Input\tJid.7\t\"jawstree-selection-sync:2\"\n"}
+	if !reflect.DeepEqual(got.Sent, wantSent) {
+		t.Fatalf("selection synchronization frames = %q, want %q", got.Sent, wantSent)
+	}
+}
+
+func TestJawstreeJS_InitSkipsSelectionSyncForOtherModes(t *testing.T) {
+	raw := runJawstreeJSSnippet(t, `
+const sent = [];
+global.jawsCanSend = function() { return true; };
+global.jaws = { send: function(frame) { sent.push(frame); } };
+global.document = { getElementById: function() { return { hidden: true }; } };
+jawstreeNew = function() { return {}; };
+
+window["jawstreeroot_multi"] = { children: [] };
+jawstreeInit({ key: "multi", jid: "Jid.1", options: 1<<2, selectionVersion: 0 });
+window["jawstreeroot_cascade"] = { children: [] };
+jawstreeInit({ key: "cascade", jid: "Jid.2", options: 1<<7, selectionVersion: 0 });
+process.stdout.write(JSON.stringify(sent));
+`)
+
+	var got []string
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unexpected JSON output %q: %v", raw, err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("non-default selection modes sent synchronization frames: %q", got)
 	}
 }
 

--- a/jawstree/selection_sync_production_regression_test.go
+++ b/jawstree/selection_sync_production_regression_test.go
@@ -1,0 +1,180 @@
+package jawstree
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/linkdata/jaws"
+	"github.com/linkdata/jaws/jawstest"
+	"github.com/linkdata/jaws/lib/ui"
+	"github.com/linkdata/jaws/lib/what"
+	"github.com/linkdata/jaws/lib/wire"
+)
+
+func TestTree_SelectionSyncClosesRenderToConnectGap(t *testing.T) {
+	jw, err := jaws.New()
+	maybeError(t, err)
+	defer jw.Close()
+	go jw.Serve()
+
+	active := jawstest.NewTestRequest(jw, nil)
+	defer func() {
+		active.Close()
+		<-active.DoneCh
+	}()
+	<-active.ReadyCh
+
+	root := &Node{Children: []*Node{{Name: "a"}, {Name: "b"}}}
+	var mu sync.RWMutex
+	tree := New(ui.NewJsVar(&mu, root))
+	activeElem := active.NewElement(tree)
+	maybeError(t, activeElem.JawsRender(&strings.Builder{}, nil))
+	active.InCh <- wire.WsMsg{}
+	select {
+	case msg := <-active.OutCh:
+		if msg.What != what.Call || !strings.HasPrefix(msg.Data, "jawstreeInit=") {
+			t.Fatalf("active initializer = %+v", msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the active initializer")
+	}
+
+	initial := httptest.NewRequest("GET", "/", nil)
+	pending := jw.NewRequest(initial)
+	pendingElem := pending.NewElement(tree)
+	callerInput := make(chan string, 1)
+	catchAllInput := jaws.InputFn(func(_ *jaws.Element, value string) (err error) {
+		callerInput <- value
+		return
+	})
+	maybeError(t, pendingElem.JawsRender(&strings.Builder{}, []any{catchAllInput}))
+
+	// Move the shared tree after the second page has rendered but before that
+	// Request subscribes. Broadcasts correctly target active Requests only, so
+	// the pending page cannot observe this selection through the ordinary path.
+	active.InCh <- wire.WsMsg{Jid: activeElem.Jid(), What: what.Set, Data: "children.1.selected=true"}
+	for {
+		select {
+		case msg := <-active.OutCh:
+			if strings.HasPrefix(msg.Data, "jawstreeSetSelection=") {
+				goto selectionDistributed
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for the active selection broadcast")
+		}
+	}
+
+selectionDistributed:
+	if selected := tree.GetSelected(); !reflect.DeepEqual(selected, [][]string{{"b"}}) {
+		t.Fatalf("server selection = %v, want b", selected)
+	}
+
+	inCh, outCh, _, readyCh, doneCh := jw.TestServe(pending, func(recovered any) {
+		if recovered != nil {
+			panic(recovered)
+		}
+	})
+	defer func() {
+		close(inCh)
+		<-doneCh
+	}()
+	<-readyCh
+
+	select {
+	case msg := <-outCh:
+		payload, ok := strings.CutPrefix(msg.Data, "jawstreeInit=")
+		if msg.What != what.Call || msg.Jid != pendingElem.Jid() || !ok {
+			t.Fatalf("pending initializer = %+v", msg)
+		}
+		var init struct {
+			SelectionVersion uint64 `json:"selectionVersion"`
+		}
+		if err = json.Unmarshal([]byte(payload), &init); err != nil {
+			t.Fatalf("pending initializer is not JSON: %v", err)
+		}
+		if init.SelectionVersion != 0 {
+			t.Fatalf("pending rendered version = %d, want 0", init.SelectionVersion)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the pending initializer")
+	}
+
+	inCh <- wire.WsMsg{Jid: pendingElem.Jid(), What: what.Input, Data: selectionSyncPrefix + "0"}
+	select {
+	case msg := <-outCh:
+		payload, ok := strings.CutPrefix(msg.Data, "jawstreeSetSelection=")
+		if msg.What != what.Call || msg.Jid != 0 || !ok {
+			t.Fatalf("selection synchronization = %+v, want request-scoped Call", msg)
+		}
+		var call jawstreeSelectionCall
+		if err = json.Unmarshal([]byte(payload), &call); err != nil {
+			t.Fatalf("selection synchronization is not JSON: %v", err)
+		}
+		if call.Key != tree.key || call.SelectionVersion != 1 || !reflect.DeepEqual(call.Selected, []string{"children.1"}) {
+			t.Fatalf("selection synchronization = %+v, want tree %q version 1 selecting b", call, tree.key)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for selection synchronization")
+	}
+	select {
+	case value := <-callerInput:
+		t.Fatalf("private selection synchronization reached caller Input handler with %q", value)
+	default:
+	}
+
+	// Repeating the handshake at the current version is the common fast path and
+	// must not walk or resend the selection.
+	inCh <- wire.WsMsg{Jid: pendingElem.Jid(), What: what.Input, Data: selectionSyncPrefix + "1"}
+
+	// The private handler must fall through for ordinary events so existing caller
+	// handlers retain their normal first-chance semantics. Its completion is also
+	// an event-goroutine barrier behind the equal-version synchronization above.
+	inCh <- wire.WsMsg{Jid: pendingElem.Jid(), What: what.Set, Data: "children.0.selected=true"}
+	select {
+	case value := <-callerInput:
+		if value != "children.0.selected=true" {
+			t.Fatalf("caller Input value = %q", value)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ordinary Set did not reach the caller Input handler")
+	}
+	jw.JsCall(pending.JawsKey, "jawstreeSelectionSyncPendingBarrier", "null")
+	for {
+		select {
+		case msg := <-outCh:
+			if strings.HasPrefix(msg.Data, "jawstreeSetSelection=") {
+				t.Fatalf("equal-version synchronization resent selection: %+v", msg)
+			}
+			if msg.Data == "jawstreeSelectionSyncPendingBarrier=null" {
+				goto pendingBarrierReached
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for the pending-request barrier")
+		}
+	}
+
+pendingBarrierReached:
+
+	// A request-key barrier deterministically proves the catch-up was not leaked
+	// to the already-current peer: any earlier broadcast to that peer is ordered
+	// before this Call on its subscription channel.
+	jw.JsCall(active.JawsKey, "jawstreeSelectionSyncBarrier", "null")
+	for {
+		select {
+		case msg := <-active.OutCh:
+			if strings.HasPrefix(msg.Data, "jawstreeSetSelection=") {
+				t.Fatalf("request-scoped selection synchronization leaked to peer: %+v", msg)
+			}
+			if msg.Data == "jawstreeSelectionSyncBarrier=null" {
+				return
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for the peer barrier")
+		}
+	}
+}

--- a/jawstree/tree.go
+++ b/jawstree/tree.go
@@ -3,6 +3,7 @@ package jawstree
 import (
 	"io"
 	"strconv"
+	"strings"
 	"sync/atomic"
 
 	"github.com/linkdata/jaws"
@@ -10,7 +11,12 @@ import (
 	"github.com/linkdata/jaws/lib/ui"
 )
 
-var _ jaws.UI = (*Tree)(nil)
+var (
+	_ jaws.UI           = (*Tree)(nil)
+	_ jaws.InputHandler = (*Tree)(nil)
+)
+
+const selectionSyncPrefix = "jawstree-selection-sync:"
 
 // Tree renders and updates a shared Quercus.js tree bound to a [ui.JsVar].
 //
@@ -29,6 +35,18 @@ type Tree struct {
 	renderParams     [1]any
 	selectionVersion uint64 // guarded by the embedded JsVar lock
 	*ui.JsVar[Node]
+}
+
+type selectionSyncHandler struct {
+	tree *Tree
+}
+
+func (h selectionSyncHandler) JawsInput(elem *jaws.Element, value string) (err error) {
+	err = jaws.ErrEventUnhandled
+	if h.tree.handleSelectionSync(elem, value) {
+		err = nil
+	}
+	return
 }
 
 var nextTreeKey atomic.Uint64
@@ -114,11 +132,10 @@ func (tree *Tree) appendInitCallData(b []byte, containerJid jid.Jid, selectionVe
 	return b
 }
 
-func (tree *Tree) appendSelectionCallData(b []byte) []byte {
+func (tree *Tree) appendSelectionCallDataLocked(b []byte) []byte {
 	b = append(b, `{"key":`...)
 	b = strconv.AppendQuote(b, tree.key)
 	b = append(b, `,"selectionVersion":`...)
-	tree.RLock()
 	b = strconv.AppendUint(b, tree.selectionVersion, 10)
 	b = append(b, `,"selected":[`...)
 	first := true
@@ -131,8 +148,14 @@ func (tree *Tree) appendSelectionCallData(b []byte) []byte {
 			b = strconv.AppendQuote(b, node.ID)
 		}
 	})
-	tree.RUnlock()
 	b = append(b, `]}`...)
+	return b
+}
+
+func (tree *Tree) appendSelectionCallData(b []byte) []byte {
+	tree.RLock()
+	b = tree.appendSelectionCallDataLocked(b)
+	tree.RUnlock()
 	return b
 }
 
@@ -147,7 +170,38 @@ func (tree *Tree) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err
 	if err = tree.JsVar.JawsRenderSnapshot(elem, w, params, func(_ *Node) {
 		selectionVersion = tree.selectionVersion
 	}); err == nil {
+		// JsVar renders caller-provided handlers before returning. Append the
+		// protocol handler last so reverse-order event dispatch reaches it before a
+		// general Input handler can consume the private synchronization message.
+		elem.AddHandlers(selectionSyncHandler{tree})
 		elem.JsCall("jawstreeInit", string(tree.appendInitCallData(nil, elem.Jid(), selectionVersion)))
+	}
+	return
+}
+
+func (tree *Tree) handleSelectionSync(elem *jaws.Element, value string) (handled bool) {
+	versionText, isSelectionSync := strings.CutPrefix(value, selectionSyncPrefix)
+	if isSelectionSync && tree.isDefaultSingleSelect() {
+		if renderedVersion, parseErr := strconv.ParseUint(versionText, 10, 64); parseErr == nil && strconv.FormatUint(renderedVersion, 10) == versionText {
+			var data []byte
+			tree.RLock()
+			if tree.selectionVersion > renderedVersion {
+				data = tree.appendSelectionCallDataLocked(nil)
+			}
+			tree.RUnlock()
+			if data != nil {
+				elem.Jaws.JsCall(elem.Request.JawsKey, "jawstreeSetSelection", string(data))
+			}
+			handled = true
+		}
+	}
+	return
+}
+
+// JawsInput handles selection reconciliation and JavaScript variable updates.
+func (tree *Tree) JawsInput(elem *jaws.Element, value string) (err error) {
+	if !tree.handleSelectionSync(elem, value) {
+		err = tree.JsVar.JawsInput(elem, value)
 	}
 	return
 }


### PR DESCRIPTION
## Problem

A shared default single-select Tree can render into an HTTP response and remain pending before its WebSocket subscribes. If an already-connected peer makes a normal selection in that window, the server and active peers advance, but the pending Request correctly misses the active-only Set and Call broadcasts. When it later connects, its browser stays permanently at the older rendered selection.

## Fix

- After `jawstreeInit` establishes a default single-select Treeview on an active WebSocket, send one private Input carrying the initialized selection version.
- Handle that protocol Input before caller-provided handlers can consume it.
- If the server has a newer selection, snapshot it under the Tree read lock and send a request-key-scoped `jawstreeSetSelection` Call only to the stale Request.
- Send nothing when the initialized version is already current.
- Preserve caller handler precedence for every ordinary Input and Set event.

Multi-select and cascading Trees do not use the default-single authoritative snapshot protocol and remain outside this PR.

## Tests

- Added a production-lifecycle regression: render a pending Request at version 0, advance a live peer to version 1, subscribe the pending Request, and verify request-scoped convergence to the server selection.
- Proved a catch-all caller Input handler cannot swallow the private handshake and still receives ordinary Set events first.
- Added deterministic request-key barriers for equal-version no-op behavior and peer isolation.
- Added shipped-JavaScript coverage for the exact quoted Input frame and default-mode gating.
- `go test -race ./...`
- Formatting, vet, static analysis, lint, security, and build gates all pass; focused regressions pass 50 times under the race detector.
