### PR TITLE
Reconcile shared JsVars after WebSocket subscription

### DIFF
--- a/connectupdate_test.go
+++ b/connectupdate_test.go
@@ -1,0 +1,347 @@
+package jaws
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/linkdata/jaws/lib/what"
+	"github.com/linkdata/jaws/lib/wire"
+)
+
+type connectUpdateTag string
+
+type connectUpdateTestUI struct {
+	entered chan<- struct{}
+	release <-chan struct{}
+	state   chan<- any
+	value   any
+	err     error
+}
+
+func (ui *connectUpdateTestUI) JawsRender(elem *Element, w io.Writer, _ []any) (err error) {
+	elem.Tag(connectUpdateTag("ordered"))
+	elem.SetConnectState("rendered")
+	elem.JsCall("initial", "null")
+	_, err = io.WriteString(w, `<div id="`+elem.Jid().String()+`"></div>`)
+	return
+}
+
+func (*connectUpdateTestUI) JawsUpdate(*Element) {}
+
+func (ui *connectUpdateTestUI) JawsConnectUpdate(elem *Element, renderedState any) (err error) {
+	if ui.state != nil {
+		ui.state <- renderedState
+	}
+	if ui.entered != nil {
+		ui.entered <- struct{}{}
+	}
+	if ui.release != nil {
+		<-ui.release
+	}
+	if err = ui.err; err == nil && ui.value != nil {
+		err = elem.SetJsVar(ui.value)
+	}
+	return
+}
+
+func receiveConnectUpdateMessage(t *testing.T, ch <-chan wire.WsMsg) (msg wire.WsMsg) {
+	t.Helper()
+	select {
+	case msg = <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for connection update message")
+	}
+	return
+}
+
+func TestRequestProcess_OrdersConnectUpdateBeforeSubscribedBroadcast(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+	go jw.Serve()
+
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	state := make(chan any, 1)
+	var releaseOnce sync.Once
+	ui := &connectUpdateTestUI{
+		entered: entered,
+		release: release,
+		state:   state,
+		value:   "snapshot",
+	}
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	elem := rq.NewElement(ui)
+	if err = elem.JawsRender(io.Discard, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	inCh, outCh, bcastCh, readyCh, doneCh := jw.TestServe(rq, func(recovered any) {
+		if recovered != nil {
+			panic(recovered)
+		}
+	})
+	defer func() {
+		close(inCh)
+		<-doneCh
+	}()
+	defer releaseOnce.Do(func() { close(release) })
+	<-readyCh
+	<-entered
+	if got := <-state; got != "rendered" {
+		t.Fatalf("rendered connect state = %#v, want %q", got, "rendered")
+	}
+
+	// The broadcast subscription is already installed, but process is paused in
+	// the state snapshot. Buffer a normal subscribed update on the exact channel
+	// that production Serve registered, then let the snapshot finish.
+	bcastCh <- wire.Message{
+		Dest: connectUpdateTag("ordered"),
+		What: what.Set,
+		Data: `="broadcast"`,
+	}
+	releaseOnce.Do(func() { close(release) })
+
+	want := []wire.WsMsg{
+		{Jid: elem.Jid(), What: what.Call, Data: "initial=null"},
+		{Jid: elem.Jid(), What: what.Set, Data: `="snapshot"`},
+		{Jid: elem.Jid(), What: what.Set, Data: `="broadcast"`},
+	}
+	for i := range want {
+		if got := receiveConnectUpdateMessage(t, outCh); got != want[i] {
+			t.Fatalf("message %d = %#v, want %#v", i, got, want[i])
+		}
+	}
+}
+
+func TestRequestProcess_ConnectUpdateErrorCancelsBeforeSend(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+	go jw.Serve()
+
+	wantErr := errors.New("connect update failed")
+	ui := &connectUpdateTestUI{err: wantErr}
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	ctx := rq.Context()
+	if err = rq.NewElement(ui).JawsRender(io.Discard, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	inCh, outCh, _, _, doneCh := jw.TestServe(rq, func(recovered any) {
+		if recovered != nil {
+			panic(recovered)
+		}
+	})
+	defer close(inCh)
+	select {
+	case <-doneCh:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for request cancellation")
+	}
+	if !errors.Is(context.Cause(ctx), wantErr) {
+		t.Fatalf("request cancellation cause = %v, want %v", context.Cause(ctx), wantErr)
+	}
+	select {
+	case msg, ok := <-outCh:
+		if ok {
+			t.Fatalf("connect update error sent queued message %#v", msg)
+		}
+	default:
+		t.Fatal("outbound channel remained open after process stopped")
+	}
+}
+
+func TestElementSetJsVar(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+
+	ui := &connectUpdateTestUI{}
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	elem := rq.NewElement(ui)
+	if err = elem.JawsRender(io.Discard, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err = elem.SetJsVar(nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := rq.wsQueue[len(rq.wsQueue)-1]; got.What != what.Set || got.Jid != elem.Jid() || got.Data != "=null" {
+		t.Fatalf("SetJsVar(nil) queued %#v", got)
+	}
+	before := len(rq.wsQueue)
+	if err = elem.SetJsVar(make(chan int)); err == nil {
+		t.Fatal("expected JSON marshal error")
+	}
+	if got := len(rq.wsQueue); got != before {
+		t.Fatalf("SetJsVar queue length = %d, want %d", got, before)
+	}
+}
+
+func TestElementSetConnectStateAfterRenderPanics(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	elem := rq.NewElement(&connectUpdateTestUI{})
+	if err = elem.JawsRender(io.Discard, nil); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if recovered := recover(); recovered == nil {
+			t.Fatal("expected late SetConnectState to report API misuse")
+		}
+	}()
+	elem.SetConnectState("late")
+}
+
+func TestElementSetConnectStateDeletedElementIsInert(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	elem := rq.NewElement(&connectUpdateTestUI{})
+	rq.DeleteElement(elem)
+	elem.SetConnectState("ignored")
+	if state := elem.takeConnectState(); state != nil {
+		t.Fatalf("deleted Element retained connect state %#v", state)
+	}
+}
+
+func TestRequestProcess_NilSubscriptionSkipsConnectUpdates(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+	go jw.Serve()
+
+	entered := make(chan struct{}, 1)
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	if err = rq.NewElement(&connectUpdateTestUI{entered: entered}).JawsRender(io.Discard, nil); err != nil {
+		t.Fatal(err)
+	}
+	inCh := make(chan wire.WsMsg)
+	close(inCh)
+	outCh := make(chan wire.WsMsg, 1)
+	rq.process(nil, inCh, outCh)
+	select {
+	case <-entered:
+		t.Fatal("nil broadcast subscription invoked ConnectUpdater")
+	default:
+	}
+	if _, ok := <-outCh; ok {
+		t.Fatal("outbound channel remained open after process stopped")
+	}
+}
+
+func TestRequestQueueConnectUpdates_DropsDynamicElementState(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	if err = rq.queueConnectUpdates(); err != nil {
+		t.Fatal(err)
+	}
+	if err = rq.queueConnectUpdates(); err != nil {
+		t.Fatalf("second connection update pass = %v", err)
+	}
+	elem := rq.NewElement(&connectUpdateTestUI{})
+	if err = elem.JawsRender(io.Discard, nil); err != nil {
+		t.Fatal(err)
+	}
+	if state := elem.takeConnectState(); state != nil {
+		t.Fatalf("dynamic Element retained connect state %#v after reconciliation", state)
+	}
+}
+
+func TestTestServe_ClosesConnectSnapshotBeforeReturn(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+
+	// Drive TestServe's subscription rendezvous directly, and hold jw.mu so its
+	// process goroutine cannot publish Ready before TestServe returns. This makes
+	// the synchronous snapshot boundary observable without a scheduler race.
+	unsubscribed := make(chan struct{})
+	go func() {
+		<-jw.subCh
+		<-jw.subCh
+		<-jw.unsubCh
+		close(unsubscribed)
+	}()
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	jw.mu.Lock()
+	inCh, _, _, readyCh, doneCh := jw.TestServe(rq, func(recovered any) {
+		if recovered != nil {
+			panic(recovered)
+		}
+	})
+	started := rq.connectStarted.Load()
+	elem := rq.NewElement(&connectUpdateTestUI{})
+	renderErr := elem.JawsRender(io.Discard, nil)
+	state := elem.takeConnectState()
+	jw.mu.Unlock()
+
+	<-readyCh
+	close(inCh)
+	<-doneCh
+	<-unsubscribed
+	if renderErr != nil {
+		t.Fatal(renderErr)
+	}
+	if !started {
+		t.Fatal("TestServe returned while connection snapshots were still accepted")
+	}
+	if state != nil {
+		t.Fatalf("Element rendered after TestServe retained connection state %#v", state)
+	}
+}
+
+func TestRequestQueueConnectUpdates_SkipsFrozenUnrenderedElement(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+
+	entered := make(chan struct{}, 1)
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	elem := rq.NewElement(&connectUpdateTestUI{entered: entered})
+	elem.SetConnectState("update-only")
+	elem.Freeze()
+	if err = rq.queueConnectUpdates(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-entered:
+		t.Fatal("ConnectUpdater ran for an Element that was frozen without rendering")
+	default:
+	}
+	if state := elem.takeConnectState(); state != nil {
+		t.Fatalf("frozen unrendered Element retained connect state %#v", state)
+	}
+}

--- a/contracts.go
+++ b/contracts.go
@@ -17,6 +17,27 @@ type Container interface {
 	JawsContains(elem *Element) (contents []UI)
 }
 
+// ConnectUpdater reconciles browser state when a rendered [Element] connects.
+//
+// The request invokes JawsConnectUpdate once after its WebSocket broadcast
+// subscription is active and before it sends messages queued during the initial
+// render. Messages the method queues for elem follow that same Element's initial
+// messages and precede subscribed broadcasts. An error aborts the request before
+// any queued messages are sent.
+//
+// Implementations that read shared state must synchronize that read with
+// concurrent mutations. JawsConnectUpdate runs without the request registry lock
+// held and may safely acquire UI-owned locks, but it must not mutate the request's
+// element registry. It must return promptly and must not wait for request message
+// processing, which starts only after all connection updates return.
+type ConnectUpdater interface {
+	// JawsConnectUpdate queues any updates needed to reconcile elem with shared
+	// state. renderedState is the value recorded by [Element.SetConnectState], or
+	// nil when none was recorded. A returned error becomes the [Request]
+	// cancellation cause.
+	JawsConnectUpdate(elem *Element, renderedState any) (err error)
+}
+
 // InitHandler allows initializing UI getters and setters before their use.
 //
 // You can of course initialize them in the call from the template engine,

--- a/element.go
+++ b/element.go
@@ -1,11 +1,13 @@
 package jaws
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"html/template"
 	"io"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/linkdata/jaws/lib/jid"
@@ -29,9 +31,15 @@ type Element struct {
 	// All builds enforce this: appendHandlers drops late mutations (debug builds
 	// panic).
 	handlers []any
-	jid      jid.Jid     // JaWS ID, unique to this Element within its Request
-	deleted  atomic.Bool // true once the Element has been removed from its Request
-	frozen   atomic.Bool // set when handlers are sealed (JawsRender returns or Freeze called); guards handler mutators in all builds
+	// connectState is written only during rendering and consumed by process after
+	// rendered publishes the completed Element. It lets a ConnectUpdater compare
+	// its post-subscription state with the exact state rendered into the page.
+	connectMu    sync.Mutex // guards connectState across connection and deletion
+	connectState any
+	jid          jid.Jid     // JaWS ID, unique to this Element within its Request
+	deleted      atomic.Bool // true once the Element has been removed from its Request
+	frozen       atomic.Bool // set when handlers are sealed (JawsRender returns or Freeze called); guards handler mutators in all builds
+	rendered     atomic.Bool // set after a successful JawsRender; excludes update-only Elements sealed with Freeze
 }
 
 func (elem *Element) String() string {
@@ -64,9 +72,10 @@ func (elem *Element) appendHandlers(h ...any) {
 }
 
 // Freeze marks the [Element]'s handlers as final, as [Element.JawsRender] does on
-// return. After Freeze, the handler-mutating methods (AddHandlers, ApplyParams,
-// ApplyGetter) drop handlers; debug builds panic. Use this for elements registered
-// for updates without being rendered.
+// return. It does not mark the Element as rendered, so [ConnectUpdater] is not
+// invoked for an update-only Element. After Freeze, the handler-mutating methods
+// (AddHandlers, ApplyParams, ApplyGetter) drop handlers; debug builds panic. Use
+// this for elements registered for updates without being rendered.
 func (elem *Element) Freeze() {
 	elem.frozen.Store(true)
 }
@@ -79,6 +88,45 @@ func (elem *Element) Freeze() {
 // are dropped; debug builds panic.
 func (elem *Element) AddHandlers(h ...any) {
 	elem.appendHandlers(h...)
+}
+
+// SetConnectState records state for [ConnectUpdater.JawsConnectUpdate].
+//
+// Call it only while the Element is being rendered, before [Element.JawsRender]
+// returns. The state is retained until the WebSocket broadcast subscription is
+// active, passed once to JawsConnectUpdate, and then released. It may be any
+// non-nil value; mutable state must be copied or otherwise safe to read after
+// rendering. A nil state clears any value recorded by an earlier call. Calls
+// after rendering are programming errors and are dropped. Calls made after the
+// Request's one-shot connection reconciliation has started are harmless no-ops;
+// dynamically rendered Elements are already subscribed to broadcasts.
+func (elem *Element) SetConnectState(state any) {
+	if elem.frozen.Load() {
+		elem.Jaws.reportMisuse(errors.New("jaws: Element connect state mutated after JawsRender returned; state must be set during rendering"))
+		return
+	}
+	if elem.Request.connectStarted.Load() {
+		return
+	}
+	elem.connectMu.Lock()
+	if !elem.deleted.Load() && !elem.Request.connectStarted.Load() {
+		elem.connectState = state
+	}
+	elem.connectMu.Unlock()
+}
+
+func (elem *Element) takeConnectState() (state any) {
+	elem.connectMu.Lock()
+	state = elem.connectState
+	elem.connectState = nil
+	elem.connectMu.Unlock()
+	return
+}
+
+func (elem *Element) clearConnectState() {
+	elem.connectMu.Lock()
+	elem.connectState = nil
+	elem.connectMu.Unlock()
 }
 
 // Tag adds the given tags to the [Element].
@@ -142,17 +190,23 @@ var debugCommentSanitizer = strings.NewReplacer("-->", "==>", "--!>", "==>")
 //
 // Do not call this yourself unless it is from within another JawsRender implementation.
 func (elem *Element) JawsRender(w io.Writer, params []any) (err error) {
+	var succeeded bool
 	if !elem.deleted.Load() {
 		if err = elem.UI().JawsRender(elem, w, params); err == nil {
 			if elem.Jaws.Debug {
 				elem.renderDebug(w)
 			}
+			succeeded = true
 		}
 	}
 	// Render is complete: handlers are now frozen and read lock-free on the
-	// event goroutine. Any later handler mutation is a bug and is dropped
-	// (see appendHandlers).
+	// event goroutine. Publish a successful render after that freeze so the
+	// connection updater cannot observe an Element whose handlers are unfinished.
+	// Any later handler mutation is a bug and is dropped (see appendHandlers).
 	elem.frozen.Store(true)
+	if succeeded {
+		elem.rendered.Store(true)
+	}
 	return
 }
 
@@ -263,6 +317,22 @@ func (elem *Element) SetInner(innerHTML template.HTML) {
 // request is not guaranteed to be prompt (see [Element.queue]).
 func (elem *Element) SetValue(value string) {
 	elem.queue(what.Value, value)
+}
+
+// SetJsVar queues replacement of the root JavaScript variable routed by elem.
+//
+// The initial HTML for elem must have a data-jawsname attribute, as a
+// [github.com/linkdata/jaws/lib/ui.JsVar] does. value is encoded with
+// [encoding/json.Marshal], so nil sets the variable to JSON null. An encoding
+// error is returned without queueing an update. Call this while rendering,
+// updating, or from
+// [ConnectUpdater.JawsConnectUpdate], when a send pass is imminent.
+func (elem *Element) SetJsVar(value any) (err error) {
+	var data []byte
+	if data, err = json.Marshal(value); err == nil {
+		elem.queue(what.Set, "="+string(data))
+	}
+	return
 }
 
 // JsCall queues a browser JavaScript function path call for the [Element].

--- a/lib/ui/errjsvar.go
+++ b/lib/ui/errjsvar.go
@@ -29,9 +29,9 @@ var ErrJsVarArgumentType = errors.New("expected jaws.UI or JsVarMaker")
 
 // ErrJsVarTooLarge reports that a client-writable JsVar grew past [MaxClientJsVarBytes].
 //
-// It is returned by [JsVar.JawsRender] when the serialized size of a JsVar that does
-// not implement [PathSetter] exceeds the cap; the [jaws.Request] is aborted. See the
-// [JsVar] SECURITY note.
+// It is returned by [JsVar.JawsRender] or [JsVar.JawsConnectUpdate] when the
+// serialized size of a JsVar that does not implement [PathSetter] exceeds the
+// cap; the [jaws.Request] is aborted. See the [JsVar] SECURITY note.
 var ErrJsVarTooLarge = errors.New("jsvar: serialized value exceeds MaxClientJsVarBytes")
 
 // ErrIllegalJsVarPath reports that a JsVar path contained a protocol byte.

--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -87,9 +88,12 @@ type JsVarMaker interface {
 	JawsMakeJsVar(rq *jaws.Request) (value IsJsVar, err error)
 }
 
+type nilJsVarConnectState struct{}
+
 var (
-	_ IsJsVar          = &JsVar[int]{}
-	_ bind.Setter[int] = &JsVar[int]{}
+	_ IsJsVar             = &JsVar[int]{}
+	_ jaws.ConnectUpdater = &JsVar[int]{}
+	_ bind.Setter[int]    = &JsVar[int]{}
 )
 
 // JsVar binds a Go value to a named JavaScript variable in the browser.
@@ -110,12 +114,12 @@ var (
 // element per message. The size of any single client write is bounded by the
 // WebSocket read limit; to also stop a hostile client growing server state without
 // bound across many writes, a non-[PathSetter] value whose serialized size exceeds
-// [MaxClientJsVarBytes] aborts the [jaws.Request] when it is next rendered
-// ([ErrJsVarTooLarge]). The cap does not prevent a client from setting individual
-// exported fields, so when only some fields/paths should be client-writable,
-// implement [PathSetter] on the bound value to allow-list paths and bound lengths.
-// See jawstree's Node for an example that restricts client writes to a single
-// boolean field.
+// [MaxClientJsVarBytes] aborts the [jaws.Request] when it is next rendered or
+// reconciled on WebSocket connection ([ErrJsVarTooLarge]). The cap does not
+// prevent a client from setting individual exported fields, so when only some
+// fields/paths should be client-writable, implement [PathSetter] on the bound
+// value to allow-list paths and bound lengths. See jawstree's Node for an example
+// that restricts client writes to a single boolean field.
 type JsVar[T any] struct {
 	bind.RWLocker
 	Ptr      *T         // bound Go value
@@ -129,7 +133,7 @@ type JsVar[T any] struct {
 // Without it, a hostile browser could grow such a JsVar's server-side state without
 // bound across many writes (each single write is already bounded by the WebSocket
 // read limit). A value larger than the cap aborts the [jaws.Request] with
-// [ErrJsVarTooLarge] when next rendered.
+// [ErrJsVarTooLarge] when next rendered or reconciled on WebSocket connection.
 //
 // Set it once before serving requests; a value <= 0 disables the cap, and values
 // that implement [PathSetter] enforce their own bounds and are exempt. It is a
@@ -167,7 +171,11 @@ func (jsvar *JsVar[T]) exceedsClientJsVarCap(n int) bool {
 	if MaxClientJsVarBytes <= 0 || n <= MaxClientJsVarBytes {
 		return false
 	}
-	_, isPathSetter := any(jsvar.Ptr).(PathSetter)
+	// PathSetter implementation is a property of *T, not of the current Ptr
+	// value. Avoid reading the public Ptr field here: callers may replace it while
+	// holding the JsVar locker, and cap checks run after the render/connect
+	// snapshot releases that locker.
+	_, isPathSetter := any((*T)(nil)).(PathSetter)
 	return !isPathSetter
 }
 
@@ -265,6 +273,51 @@ func (jsvar *JsVar[T]) JawsSet(elem *jaws.Element, value T) (err error) {
 	return jsvar.JawsSetPath(elem, "", value)
 }
 
+// JawsConnectUpdate reconciles the browser with the bound value when needed.
+//
+// JaWS calls it after a Request subscribes to broadcasts, closing the interval
+// between the initial HTTP render and the WebSocket subscription. renderedState
+// is the fixed-size digest of the JSON snapshot recorded by JawsRender; if it
+// still matches, no duplicate update is sent. A Ptr that becomes nil after
+// rendering is reconciled to JSON null; a Ptr that was already nil needs no
+// update. A nil renderedState means the Element was not part of the initial
+// connection snapshot and also needs no update. The value is marshaled while the
+// JsVar read lock is held, and an oversized non-[PathSetter] value returns
+// [ErrJsVarTooLarge]. When this method is promoted through a JsVar embedded in a
+// composite UI, it queues no root-only update: the outer UI must implement
+// [jaws.ConnectUpdater] itself so its JavaScript consumer and bound value remain
+// synchronized.
+func (jsvar *JsVar[T]) JawsConnectUpdate(elem *jaws.Element, renderedState any) (err error) {
+	owner, ownsElement := elem.UI().(*JsVar[T])
+	if renderedState == nil || !ownsElement || owner != jsvar {
+		return
+	}
+	var encoded []byte
+	var ptrNil bool
+	func() {
+		jsvar.RLock()
+		defer jsvar.RUnlock()
+		if jsvar.Ptr != nil {
+			encoded, err = json.Marshal(jsvar.Ptr)
+		} else {
+			ptrNil = true
+		}
+	}()
+
+	if err == nil {
+		if ptrNil {
+			if _, wasNil := renderedState.(nilJsVarConnectState); !wasNil {
+				err = elem.SetJsVar(nil)
+			}
+		} else if jsvar.exceedsClientJsVarCap(len(encoded)) {
+			err = fmt.Errorf("%w: serialized size %d exceeds MaxClientJsVarBytes (%d)", ErrJsVarTooLarge, len(encoded), MaxClientJsVarBytes)
+		} else if rendered, ok := renderedState.([sha256.Size]byte); !ok || sha256.Sum256(encoded) != rendered {
+			err = elem.SetJsVar(json.RawMessage(encoded))
+		}
+	}
+	return
+}
+
 func (jsvar *JsVar[T]) jawsRender(elem *jaws.Element, w io.Writer, params []any, snapshot func(*T)) (err error) {
 	var getterAttrs []template.HTMLAttr
 	var jsvarName string
@@ -280,9 +333,16 @@ func (jsvar *JsVar[T]) jawsRender(elem *jaws.Element, w io.Writer, params []any,
 		defer jsvar.Unlock()
 		if jsvar.dirtyTag, getterAttrs, err = elem.ApplyGetter(jsvar.Ptr); err == nil {
 			elem.AddHandlers(jsvar)
-			if jsvarName, err = validateJsVarName(params); err == nil && jsvar.Ptr != nil {
-				if data, err = json.Marshal(jsvar.Ptr); err == nil && snapshot != nil {
-					snapshot(jsvar.Ptr)
+			if jsvarName, err = validateJsVarName(params); err == nil {
+				if jsvar.Ptr == nil {
+					elem.SetConnectState(nilJsVarConnectState{})
+				} else {
+					if data, err = json.Marshal(jsvar.Ptr); err == nil {
+						elem.SetConnectState(sha256.Sum256(data))
+						if snapshot != nil {
+							snapshot(jsvar.Ptr)
+						}
+					}
 				}
 			}
 		}

--- a/lib/ui/jsvar_connect_production_regression_test.go
+++ b/lib/ui/jsvar_connect_production_regression_test.go
@@ -1,0 +1,474 @@
+package ui
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/linkdata/jaws"
+	"github.com/linkdata/jaws/jawstest"
+	"github.com/linkdata/jaws/lib/what"
+	"github.com/linkdata/jaws/lib/wire"
+)
+
+type connectMarshalValue struct {
+	Panic bool
+	Value any
+}
+
+type connectWrappedJsVar struct {
+	*JsVar[jsVarData]
+}
+
+type connectValueWrappedJsVar struct {
+	*JsVar[jsVarData]
+	marker int
+}
+
+type connectBarrierRWMutex struct {
+	sync.RWMutex
+	armed    atomic.Bool
+	unlocked chan struct{}
+	release  chan struct{}
+}
+
+func (mu *connectBarrierRWMutex) RUnlock() {
+	mu.RWMutex.RUnlock()
+	if mu.armed.CompareAndSwap(true, false) {
+		close(mu.unlocked)
+		<-mu.release
+	}
+}
+
+func (value *connectMarshalValue) MarshalJSON() ([]byte, error) {
+	if value.Panic {
+		panic("connect marshal panic")
+	}
+	return json.Marshal(value.Value)
+}
+
+func TestJsVar_ConnectUpdateClosesRenderToSubscribeGap(t *testing.T) {
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+	go jw.Serve()
+
+	active := jawstest.NewTestRequest(jw, nil)
+	defer func() {
+		active.Close()
+		<-active.DoneCh
+	}()
+	<-active.ReadyCh
+
+	var mu sync.RWMutex
+	value := jsVarData{Text: "rendered", Num: 1}
+	jsvar := NewJsVar(&mu, &value)
+	activeElem := active.NewElement(jsvar)
+	if err = activeElem.JawsRender(&strings.Builder{}, []any{"shared"}); err != nil {
+		t.Fatal(err)
+	}
+
+	pending := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	pendingElem := pending.NewElement(jsvar)
+	var rendered strings.Builder
+	if err = pendingElem.JawsRender(&rendered, []any{"shared"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := htmlAttrValue(t, rendered.String(), "data-jawsdata"); got != `{"text":"rendered","num":1}` {
+		t.Fatalf("pending initial data = %s", got)
+	}
+
+	// This is an ordinary server-side write through the documented JsVar API.
+	// Broadcasts intentionally target active requests, so the pending request
+	// cannot receive this frame through the normal distribution path.
+	if err = jsvar.JawsSetPath(activeElem, "text", "current"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case msg := <-active.OutCh:
+		if msg.What != what.Set || msg.Jid != activeElem.Jid() || msg.Data != `text="current"` {
+			t.Fatalf("active broadcast = %#v", msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for active JsVar broadcast")
+	}
+
+	inCh, outCh, _, readyCh, doneCh := jw.TestServe(pending, func(recovered any) {
+		if recovered != nil {
+			panic(recovered)
+		}
+	})
+	defer func() {
+		close(inCh)
+		<-doneCh
+	}()
+	<-readyCh
+
+	select {
+	case msg := <-outCh:
+		want := wire.WsMsg{
+			Jid:  pendingElem.Jid(),
+			What: what.Set,
+			Data: `={"text":"current","num":1}`,
+		}
+		if msg != want {
+			t.Fatalf("pending connection update = %#v, want %#v", msg, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for pending JsVar connection update")
+	}
+
+	// A request-key barrier proves the one-request catch-up did not leak back to
+	// the already-current peer.
+	jw.JsCall(active.JawsKey, "jsVarConnectBarrier", "null")
+	select {
+	case msg := <-active.OutCh:
+		if msg.What != what.Call || msg.Data != "jsVarConnectBarrier=null" {
+			t.Fatalf("connection update leaked to active peer before barrier: %#v", msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for active-request barrier")
+	}
+}
+
+func TestJsVar_ConnectUpdateOrdersMutationAfterSnapshot(t *testing.T) {
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+	go jw.Serve()
+
+	active := jawstest.NewTestRequest(jw, nil)
+	defer func() {
+		active.Close()
+		<-active.DoneCh
+	}()
+	<-active.ReadyCh
+
+	mu := &connectBarrierRWMutex{
+		unlocked: make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+	var releaseOnce sync.Once
+	value := jsVarData{Text: "rendered", Num: 1}
+	jsvar := NewJsVar(mu, &value)
+	activeElem := active.NewElement(jsvar)
+	if err = activeElem.JawsRender(&strings.Builder{}, []any{"shared"}); err != nil {
+		t.Fatal(err)
+	}
+
+	pending := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	pendingElem := pending.NewElement(jsvar)
+	if err = pendingElem.JawsRender(&strings.Builder{}, []any{"shared"}); err != nil {
+		t.Fatal(err)
+	}
+	pendingElem.JsCall("initial", "null")
+
+	if err = jsvar.JawsSetPath(activeElem, "text", "snapshot"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case msg := <-active.OutCh:
+		if msg.What != what.Set || msg.Data != `text="snapshot"` {
+			t.Fatalf("snapshot broadcast = %#v", msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for snapshot broadcast")
+	}
+
+	mu.armed.Store(true)
+	inCh, outCh, _, readyCh, doneCh := jw.TestServe(pending, func(recovered any) {
+		if recovered != nil {
+			panic(recovered)
+		}
+	})
+	defer func() {
+		releaseOnce.Do(func() { close(mu.release) })
+		close(inCh)
+		<-doneCh
+	}()
+	<-readyCh
+	select {
+	case <-mu.unlocked:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for connection snapshot unlock")
+	}
+
+	// The hook has captured "snapshot" and released the value lock, but it is
+	// paused before queueing that root update. Apply a normal later mutation and
+	// prove Serve has distributed it to every subscription before releasing the
+	// hook.
+	if err = jsvar.JawsSetPath(activeElem, "text", "latest"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case msg := <-active.OutCh:
+		if msg.What != what.Set || msg.Data != `text="latest"` {
+			t.Fatalf("latest broadcast = %#v", msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for latest broadcast")
+	}
+	jw.JsCall(active.JawsKey, "snapshotBarrier", "null")
+	select {
+	case msg := <-active.OutCh:
+		if msg.What != what.Call || msg.Data != "snapshotBarrier=null" {
+			t.Fatalf("snapshot barrier = %#v", msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for snapshot barrier")
+	}
+	releaseOnce.Do(func() { close(mu.release) })
+
+	want := []wire.WsMsg{
+		{Jid: pendingElem.Jid(), What: what.Call, Data: "initial=null"},
+		{Jid: pendingElem.Jid(), What: what.Set, Data: `={"text":"snapshot","num":1}`},
+		{Jid: pendingElem.Jid(), What: what.Set, Data: `text="latest"`},
+	}
+	for i := range want {
+		select {
+		case msg := <-outCh:
+			if msg != want[i] {
+				t.Fatalf("pending message %d = %#v, want %#v", i, msg, want[i])
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for pending message %d", i)
+		}
+	}
+}
+
+func TestJsVar_ConnectUpdateSkipsUnchangedValue(t *testing.T) {
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+	go jw.Serve()
+
+	var mu sync.RWMutex
+	value := jsVarData{Text: "unchanged", Num: 1}
+	jsvar := NewJsVar(&mu, &value)
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	if err = rq.NewElement(jsvar).JawsRender(&strings.Builder{}, []any{"shared"}); err != nil {
+		t.Fatal(err)
+	}
+
+	inCh, outCh, _, readyCh, doneCh := jw.TestServe(rq, func(recovered any) {
+		if recovered != nil {
+			panic(recovered)
+		}
+	})
+	defer func() {
+		close(inCh)
+		<-doneCh
+	}()
+	<-readyCh
+
+	jw.JsCall(rq.JawsKey, "unchangedBarrier", "null")
+	select {
+	case msg := <-outCh:
+		if msg.What != what.Call || msg.Data != "unchangedBarrier=null" {
+			t.Fatalf("unchanged JsVar queued a connection update before barrier: %#v", msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for unchanged-value barrier")
+	}
+}
+
+func TestJsVar_ConnectUpdateReconcilesPtrBecomingNil(t *testing.T) {
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+	go jw.Serve()
+
+	var mu sync.RWMutex
+	value := jsVarData{Text: "rendered", Num: 1}
+	jsvar := NewJsVar(&mu, &value)
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	elem := rq.NewElement(jsvar)
+	if err = elem.JawsRender(&strings.Builder{}, []any{"shared"}); err != nil {
+		t.Fatal(err)
+	}
+	jsvar.Lock()
+	jsvar.Ptr = nil
+	jsvar.Unlock()
+
+	inCh, outCh, _, readyCh, doneCh := jw.TestServe(rq, func(recovered any) {
+		if recovered != nil {
+			panic(recovered)
+		}
+	})
+	defer func() {
+		close(inCh)
+		<-doneCh
+	}()
+	<-readyCh
+
+	select {
+	case msg := <-outCh:
+		want := wire.WsMsg{Jid: elem.Jid(), What: what.Set, Data: "=null"}
+		if msg != want {
+			t.Fatalf("nil Ptr connection update = %#v, want %#v", msg, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for nil Ptr connection update")
+	}
+}
+
+func TestJsVar_ConnectUpdateSkipsMissingSnapshotAndOriginallyNilPtr(t *testing.T) {
+	_, rq := newCoreRequest(t)
+
+	var mu sync.RWMutex
+	jsvar := NewJsVar[jsVarData](&mu, nil)
+	elem := rq.NewElement(jsvar)
+	if err := jsvar.JawsConnectUpdate(elem, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := jsvar.JawsConnectUpdate(elem, nilJsVarConnectState{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestJsVar_ConnectUpdateSkipsPromotedCompositeMethod(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		wrap func(*JsVar[jsVarData]) jaws.UI
+	}{
+		{
+			name: "pointer",
+			wrap: func(jsvar *JsVar[jsVarData]) jaws.UI {
+				return &connectWrappedJsVar{JsVar: jsvar}
+			},
+		},
+		{
+			name: "value",
+			wrap: func(jsvar *JsVar[jsVarData]) jaws.UI {
+				return connectValueWrappedJsVar{JsVar: jsvar, marker: 1}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			jw, err := jaws.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(jw.Close)
+			go jw.Serve()
+
+			var mu sync.RWMutex
+			value := jsVarData{Text: "rendered", Num: 1}
+			jsvar := NewJsVar(&mu, &value)
+			rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+			elem := rq.NewElement(tc.wrap(jsvar))
+			if err = elem.JawsRender(&strings.Builder{}, []any{"shared"}); err != nil {
+				t.Fatal(err)
+			}
+			mu.Lock()
+			value.Text = "changed"
+			mu.Unlock()
+
+			inCh, outCh, _, readyCh, doneCh := jw.TestServe(rq, func(recovered any) {
+				if recovered != nil {
+					panic(recovered)
+				}
+			})
+			defer func() {
+				close(inCh)
+				<-doneCh
+			}()
+			<-readyCh
+
+			jw.JsCall(rq.JawsKey, "compositeBarrier", "null")
+			select {
+			case msg := <-outCh:
+				if msg.What != what.Call || msg.Data != "compositeBarrier=null" {
+					t.Fatalf("promoted JsVar method queued a partial root update: %#v", msg)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for composite barrier")
+			}
+		})
+	}
+}
+
+func TestJsVar_ConnectUpdateSizeCapCancelsRequest(t *testing.T) {
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+	go jw.Serve()
+
+	old := MaxClientJsVarBytes
+	MaxClientJsVarBytes = 64
+	defer func() { MaxClientJsVarBytes = old }()
+
+	var mu sync.RWMutex
+	value := jsVarData{Text: "small", Num: 1}
+	jsvar := NewJsVar(&mu, &value)
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	ctx := rq.Context()
+	elem := rq.NewElement(jsvar)
+	if err = elem.JawsRender(&strings.Builder{}, []any{"shared"}); err != nil {
+		t.Fatal(err)
+	}
+	if err = jsvar.JawsSetPath(elem, "text", strings.Repeat("z", 256)); err != nil {
+		t.Fatal(err)
+	}
+
+	inCh, _, _, _, doneCh := jw.TestServe(rq, func(recovered any) {
+		if recovered != nil {
+			panic(recovered)
+		}
+	})
+	defer close(inCh)
+	select {
+	case <-doneCh:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for oversized JsVar cancellation")
+	}
+	if cause := context.Cause(ctx); !errors.Is(cause, ErrJsVarTooLarge) {
+		t.Fatalf("oversized JsVar cancellation cause = %v, want ErrJsVarTooLarge", cause)
+	}
+}
+
+func TestJsVar_ConnectUpdateMarshalPanicReleasesValueLock(t *testing.T) {
+	jw, rq := newCoreRequest(t)
+	go jw.Serve()
+
+	var mu sync.RWMutex
+	value := connectMarshalValue{Value: "rendered"}
+	jsvar := NewJsVar(&mu, &value)
+	elem := rq.NewElement(jsvar)
+	if err := elem.JawsRender(&strings.Builder{}, []any{"shared"}); err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	value.Panic = true
+	mu.Unlock()
+	func() {
+		defer func() {
+			if recovered := recover(); recovered != "connect marshal panic" {
+				t.Fatalf("marshal panic = %v", recovered)
+			}
+		}()
+		_ = jsvar.JawsConnectUpdate(elem, struct{}{})
+	}()
+	if !mu.TryLock() {
+		t.Fatal("JsVar read lock remained held after connection marshal panic")
+	}
+	mu.Unlock()
+}

--- a/request.go
+++ b/request.go
@@ -48,6 +48,8 @@ type Request struct {
 	remoteIP         netip.Addr              // (read-only) remote IP, or the zero netip.Addr if unset
 	running          atomic.Bool             // if ServeHTTP() is running
 	claimed          atomic.Bool             // if UseRequest() has been called for it
+	connectStarted   atomic.Bool             // if connection reconciliation no longer accepts render snapshots
+	connectProcessed atomic.Bool             // if the one-shot post-subscription callbacks have started
 	lastWriteSeconds atomic.Int32            // [Jaws.runtimeSeconds] value at the most recent RequestWriter write; lock-free, drives pending-eviction recency (oldestEvictablePendingLocked) and idle expiry (maintenance)
 	mu               deadlock.RWMutex        // protects following
 	lastJid          Jid                     // last element Jid allocated within this Request
@@ -221,6 +223,8 @@ func (rq *Request) clearLocked() *Request {
 	rq.killSessionLocked()
 	rq.running.Store(false)
 	rq.claimed.Store(false)
+	rq.connectStarted.Store(false)
+	rq.connectProcessed.Store(false)
 	// Every field is reset to its zero state except ctx and cancelFn, which keep their
 	// (cancelled) values until getRequestLocked replaces them on reuse.
 	if rq.cancelFn != nil {
@@ -234,13 +238,15 @@ func (rq *Request) clearLocked() *Request {
 		if e != nil {
 			// Nil the GC-reachable fields and set the deleted guard, which makes any
 			// retained *Element inert (see [Element.Deleted]). The Request back-pointer
-			// and frozen flag are deliberately left as-is: Elements are allocated fresh
-			// per newElementLocked and never pooled, so a stale frozen value can never
-			// be observed by a reused Element. Any future move to pool Elements must
-			// also reset frozen, since it gates the lock-free handler read.
-			e.handlers = nil
-			e.ui = nil
+			// and frozen/rendered flags are deliberately left as-is: Elements are
+			// allocated fresh per newElementLocked and never pooled, so stale flag
+			// values can never be observed by a reused Element. Any future move to pool
+			// Elements must also reset both flags, since they publish handlers and
+			// render completion.
 			e.deleted.Store(true)
+			e.handlers = nil
+			e.clearConnectState()
+			e.ui = nil
 		}
 	}
 	clear(rq.elems)

--- a/requestloop.go
+++ b/requestloop.go
@@ -66,6 +66,32 @@ func (rq *Request) process(broadcastMsgCh chan wire.Message, incomingMsgCh <-cha
 		}
 	}()
 
+	if broadcastMsgCh == nil {
+		return
+	}
+	select {
+	case <-jawsDoneCh:
+		return
+	case <-httpDoneCh:
+		return
+	case <-rq.Context().Done():
+		return
+	default:
+	}
+	if err := rq.queueConnectUpdates(); err != nil {
+		rq.cancel(err)
+		return
+	}
+	select {
+	case <-jawsDoneCh:
+		return
+	case <-httpDoneCh:
+		return
+	case <-rq.Context().Done():
+		return
+	default:
+	}
+
 	for {
 		var tagmsg wire.Message
 		var wsmsg wire.WsMsg
@@ -102,6 +128,56 @@ func (rq *Request) process(broadcastMsgCh chan wire.Message, incomingMsgCh <-cha
 
 		rq.handleBroadcast(tagmsg, eventCallCh)
 	}
+}
+
+// queueConnectUpdates snapshots the rendered element list, then queues each
+// optional post-subscription reconciliation update. It runs before process sends
+// the initial render queue or receives from the broadcast subscription.
+func (rq *Request) queueConnectUpdates() (err error) {
+	if !rq.connectProcessed.CompareAndSwap(false, true) {
+		return
+	}
+	rq.connectStarted.Store(true)
+	defer func() {
+		// Elements may be registered or still rendering while the callbacks run.
+		// Once the phase flag is set, SetConnectState rechecks it under connectMu;
+		// this final pass therefore clears every pre-phase state without racing a
+		// late writer that could repopulate it.
+		rq.mu.RLock()
+		remaining := slices.Clone(rq.elems)
+		rq.mu.RUnlock()
+		for _, elem := range remaining {
+			if elem != nil {
+				elem.clearConnectState()
+			}
+		}
+	}()
+
+	rq.mu.RLock()
+	elems := slices.Clone(rq.elems)
+	httpDoneCh := rq.httpDoneCh
+	rq.mu.RUnlock()
+
+	for _, elem := range elems {
+		select {
+		case <-rq.Jaws.Done():
+			return
+		case <-httpDoneCh:
+			return
+		case <-rq.Context().Done():
+			return
+		default:
+		}
+		if elem != nil && elem.rendered.Load() && !elem.deleted.Load() {
+			renderedState := elem.takeConnectState()
+			if updater, ok := elem.UI().(ConnectUpdater); ok {
+				if err = updater.JawsConnectUpdate(elem, renderedState); err != nil {
+					return
+				}
+			}
+		}
+	}
+	return
 }
 
 // handleIncoming processes a single incoming WebSocket event message, queuing an
@@ -223,6 +299,7 @@ func (rq *Request) handleRemove(containerJid Jid, data string) {
 						victims = map[Jid]struct{}{}
 					}
 					e.deleted.Store(true)
+					e.clearConnectState()
 					victims[e.Jid()] = struct{}{}
 				}
 			}
@@ -390,6 +467,7 @@ func (rq *Request) removeElementsLocked(pred func(*Element) bool) {
 func (rq *Request) deleteElementLocked(elem *Element) {
 	if elem.Request == rq {
 		elem.deleted.Store(true)
+		elem.clearConnectState()
 		rq.removeElementsLocked(func(e *Element) bool { return e == elem })
 	}
 }

--- a/testserve.go
+++ b/testserve.go
@@ -46,6 +46,12 @@ func (jw *Jaws) TestServe(rq *Request, onPanic func(recovered any)) (inCh chan w
 	case <-time.After(5 * time.Second):
 		panic("jaws: TestServe timed out subscribing; the Jaws processing loop (Serve or ServeWithTimeout) must be running")
 	}
+	// Close the render-snapshot phase before returning any channels. Test
+	// harnesses may render dynamic Elements as soon as TestServe returns; those
+	// Elements are already covered by the installed subscription and must not be
+	// mistaken for initial-page Elements if process has not started yet. process
+	// still runs the one-shot callbacks for snapshots recorded before TestServe.
+	rq.connectStarted.Store(true)
 
 	inCh = make(chan wire.WsMsg)
 	outCh = make(chan wire.WsMsg, cap(bcastCh))


### PR DESCRIPTION
## Summary

- add a one-shot ConnectUpdater phase after broadcast subscription and before the initial outbound send
- record a fixed-size digest of each direct JsVar render and queue a request-local root replacement only when shared state changed before connection
- preserve ordering against later subscribed broadcasts, release snapshots promptly, and keep composite widgets responsible for their own atomic reconciliation

## Production defect

A server can render a pending request with a shared JsVar, then correctly update that JsVar through JawsSetPath from an already-connected request before the pending browser opens its WebSocket. The normal broadcast reaches active subscriptions only. Without a post-subscription comparison, the pending browser keeps the stale value from its initial HTML indefinitely.

This is an ordinary documented server-side write and normal request lifecycle; it requires no malformed messages, unsupported call order, or API misuse.

## Verification

- production-lifecycle regressions for the render-to-subscribe gap and request-local catch-up
- deterministic ordering test: initial queue, connection snapshot, then subscribed broadcast
- unchanged, nil, size-cap, marshal-panic, composite, deletion, frozen-element, and test-harness phase coverage
- focused race suites passed 100 consecutive runs
- go test -race ./...
- go vet ./...
- go build ./...
- staticcheck ./...
- golangci-lint run ./...
- gosec -quiet ./...
- gofumpt and git diff checks

Stacked on #116 because this PR uses the post-subscription connection phase introduced for the same class of request-lifecycle reconciliation.