### PR TITLE
Reconcile multi-select and cascade Trees after connect

### DIFF
--- a/jawstree/connect_reconciliation_production_regression_test.go
+++ b/jawstree/connect_reconciliation_production_regression_test.go
@@ -1,0 +1,178 @@
+package jawstree
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/linkdata/jaws"
+	"github.com/linkdata/jaws/jawstest"
+	"github.com/linkdata/jaws/lib/ui"
+	"github.com/linkdata/jaws/lib/what"
+	"github.com/linkdata/jaws/lib/wire"
+)
+
+func receiveTreeConnectMessage(t *testing.T, ch <-chan wire.WsMsg) (msg wire.WsMsg) {
+	t.Helper()
+	select {
+	case msg = <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Tree connection message")
+	}
+	return
+}
+
+func TestTree_ConnectUpdateClosesRenderToSubscribeGap(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		option Option
+	}{
+		{name: "multi-select", option: MultiSelectEnabled},
+		{name: "cascade-select", option: CascadeSelectChildren},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			jw, err := jaws.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(jw.Close)
+			go jw.Serve()
+
+			active := jawstest.NewTestRequest(jw, nil)
+			defer func() {
+				active.Close()
+				<-active.DoneCh
+			}()
+			<-active.ReadyCh
+
+			root := &Node{Children: []*Node{{Name: "a"}, {Name: "b"}}}
+			var mu sync.RWMutex
+			tree := New(ui.NewJsVar(&mu, root), tc.option)
+			activeElem := active.NewElement(tree)
+			if err = activeElem.JawsRender(&strings.Builder{}, nil); err != nil {
+				t.Fatal(err)
+			}
+			active.InCh <- wire.WsMsg{}
+			if msg := receiveTreeConnectMessage(t, active.OutCh); msg.What != what.Call || msg.Data != "jawstreeInit="+string(tree.appendInitCallData(nil, activeElem.Jid(), 0)) {
+				t.Fatalf("active initializer = %#v", msg)
+			}
+
+			pending := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+			pendingElem := pending.NewElement(tree)
+			if err = pendingElem.JawsRender(&strings.Builder{}, nil); err != nil {
+				t.Fatal(err)
+			}
+
+			// This is an ordinary supported browser selection. Its JsVar path and
+			// Treeview broadcasts correctly reach active subscriptions only,
+			// leaving the pending page with its already-rendered selection.
+			active.InCh <- wire.WsMsg{Jid: activeElem.Jid(), What: what.Set, Data: "children.1.selected=true"}
+			var sawSet bool
+			var sawPathSet bool
+			for !sawPathSet {
+				activeUpdate := receiveTreeConnectMessage(t, active.OutCh)
+				switch {
+				case activeUpdate.What == what.Set && activeUpdate.Data == "children.1.selected=true":
+					sawSet = true
+				case activeUpdate.What == what.Call && strings.HasPrefix(activeUpdate.Data, "jawstreeSetPath="):
+					if !sawSet {
+						t.Fatal("Treeview update arrived before its JsVar path update")
+					}
+					sawPathSet = true
+				default:
+					t.Fatalf("active selection update = %#v", activeUpdate)
+				}
+			}
+
+			inCh, outCh, _, readyCh, doneCh := jw.TestServe(pending, func(recovered any) {
+				if recovered != nil {
+					panic(recovered)
+				}
+			})
+			defer func() {
+				close(inCh)
+				<-doneCh
+			}()
+			<-readyCh
+
+			tree.RLock()
+			currentData := tree.Ptr.marshalJSON(nil)
+			selectionVersion := tree.selectionVersion
+			tree.RUnlock()
+			want := []wire.WsMsg{
+				{
+					Jid:  pendingElem.Jid(),
+					What: what.Call,
+					Data: "jawstreeInit=" + string(tree.appendInitCallData(nil, pendingElem.Jid(), 0)),
+				},
+				{
+					Jid:  pendingElem.Jid(),
+					What: what.Call,
+					Data: "jawstreeSet=" + string(tree.appendSetCallData(nil, currentData, selectionVersion)),
+				},
+			}
+			for i := range want {
+				if msg := receiveTreeConnectMessage(t, outCh); msg != want[i] {
+					t.Fatalf("pending message %d = %#v, want %#v", i, msg, want[i])
+				}
+			}
+			jw.JsCall(pending.JawsKey, "pendingTreeConnectBarrier", "null")
+			if msg := receiveTreeConnectMessage(t, outCh); msg.What != what.Call || msg.Jid != 0 || msg.Data != "pendingTreeConnectBarrier=null" {
+				t.Fatalf("unexpected pending message after reconciliation: %#v", msg)
+			}
+
+			// The catch-up is request-local and must not rebuild an already-current
+			// peer Tree.
+			jw.JsCall(active.JawsKey, "jawstreeConnectBarrier", "null")
+			for {
+				msg := receiveTreeConnectMessage(t, active.OutCh)
+				if strings.HasPrefix(msg.Data, "jawstreeSet=") {
+					t.Fatalf("connection reconciliation leaked to active peer: %#v", msg)
+				}
+				if msg.What == what.Call && msg.Data == "jawstreeConnectBarrier=null" {
+					break
+				}
+			}
+		})
+	}
+}
+
+func TestTree_ConnectUpdateSkipsUnchangedTree(t *testing.T) {
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+	go jw.Serve()
+
+	root := &Node{Children: []*Node{{Name: "a"}}}
+	var mu sync.RWMutex
+	tree := New(ui.NewJsVar(&mu, root), MultiSelectEnabled)
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	elem := rq.NewElement(tree)
+	if err = elem.JawsRender(&strings.Builder{}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	inCh, outCh, _, readyCh, doneCh := jw.TestServe(rq, func(recovered any) {
+		if recovered != nil {
+			panic(recovered)
+		}
+	})
+	defer func() {
+		close(inCh)
+		<-doneCh
+	}()
+	<-readyCh
+
+	if msg := receiveTreeConnectMessage(t, outCh); msg.What != what.Call || msg.Data != "jawstreeInit="+string(tree.appendInitCallData(nil, elem.Jid(), 0)) {
+		t.Fatalf("initializer = %#v", msg)
+	}
+	jw.JsCall(rq.JawsKey, "unchangedTreeConnectBarrier", "null")
+	if msg := receiveTreeConnectMessage(t, outCh); msg.What != what.Call || msg.Data != "unchangedTreeConnectBarrier=null" {
+		t.Fatalf("unchanged Tree queued a connection update before barrier: %#v", msg)
+	}
+}

--- a/jawstree/js_test.go
+++ b/jawstree/js_test.go
@@ -171,6 +171,70 @@ process.stdout.write(JSON.stringify(sent));
 	}
 }
 
+func TestJawstreeJS_FullSetReconcilesShadowAndView(t *testing.T) {
+	raw := runJawstreeJSSnippet(t, `
+function run(key, multiSelectEnabled, cascadeSelectChildren) {
+	var tree = {
+		options: {
+			multiSelectEnabled: multiSelectEnabled,
+			cascadeSelectChildren: cascadeSelectChildren
+		},
+		jawsSelectionVersion: 0,
+		viewSelected: [],
+		setData: function(children) {
+			this.viewSelected = jawstreeSelectedIDs({ children: children });
+		}
+	};
+	var current = { children: [
+		{ id: "children.0", name: "a", children: [] },
+		{ id: "children.1", name: "b", selected: true, children: [] }
+	] };
+	window["jawstree_"+key] = tree;
+	window["jawstreeroot_"+key] = { children: [
+		{ id: "children.0", name: "a", children: [] },
+		{ id: "children.1", name: "b", children: [] }
+	] };
+
+	// A JsVar root Set replaces only the shadow value. It cannot update the
+	// Quercus view owned by the Tree wrapper.
+	window["jawstreeroot_"+key] = current;
+	var afterRootSet = tree.viewSelected.slice();
+	jawstreeSet({ key: key, selectionVersion: 0, data: current });
+	return {
+		afterRootSet: afterRootSet,
+		afterFullSet: tree.viewSelected,
+		shadowSelected: jawstreeSelectedIDs(window["jawstreeroot_"+key])
+	};
+}
+
+process.stdout.write(JSON.stringify([
+	run("multi", true, false),
+	run("cascade", false, true)
+]));
+`)
+
+	var got []struct {
+		AfterRootSet   []string `json:"afterRootSet"`
+		AfterFullSet   []string `json:"afterFullSet"`
+		ShadowSelected []string `json:"shadowSelected"`
+	}
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unexpected JSON output %q: %v", raw, err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("results = %d, want multi-select and cascade-select", len(got))
+	}
+	for i, result := range got {
+		if len(result.AfterRootSet) != 0 {
+			t.Fatalf("case %d root-only Set changed Treeview selection to %v", i, result.AfterRootSet)
+		}
+		want := []string{"children.1"}
+		if !reflect.DeepEqual(result.AfterFullSet, want) || !reflect.DeepEqual(result.ShadowSelected, want) {
+			t.Fatalf("case %d full Set left view %v and shadow %v, want %v", i, result.AfterFullSet, result.ShadowSelected, want)
+		}
+	}
+}
+
 func TestJawstreeJS_SetPathSingleSelectDeselect(t *testing.T) {
 	raw := runJawstreeJSSnippet(t, `
 function run(options, selected, arg) {

--- a/jawstree/tree.go
+++ b/jawstree/tree.go
@@ -1,6 +1,7 @@
 package jawstree
 
 import (
+	"crypto/sha256"
 	"io"
 	"strconv"
 	"strings"
@@ -12,8 +13,9 @@ import (
 )
 
 var (
-	_ jaws.UI           = (*Tree)(nil)
-	_ jaws.InputHandler = (*Tree)(nil)
+	_ jaws.UI             = (*Tree)(nil)
+	_ jaws.InputHandler   = (*Tree)(nil)
+	_ jaws.ConnectUpdater = (*Tree)(nil)
 )
 
 const selectionSyncPrefix = "jawstree-selection-sync:"
@@ -159,6 +161,17 @@ func (tree *Tree) appendSelectionCallData(b []byte) []byte {
 	return b
 }
 
+func (tree *Tree) appendSetCallData(b, data []byte, selectionVersion uint64) []byte {
+	b = append(b, `{"key":`...)
+	b = strconv.AppendQuote(b, tree.key)
+	b = append(b, `,"selectionVersion":`...)
+	b = strconv.AppendUint(b, selectionVersion, 10)
+	b = append(b, `,"data":`...)
+	b = append(b, data...)
+	b = append(b, '}')
+	return b
+}
+
 // JawsRender renders the tree state and schedules browser initialization.
 func (tree *Tree) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err error) {
 	var selectionVersion uint64
@@ -202,6 +215,35 @@ func (tree *Tree) handleSelectionSync(elem *jaws.Element, value string) (handled
 func (tree *Tree) JawsInput(elem *jaws.Element, value string) (err error) {
 	if !tree.handleSelectionSync(elem, value) {
 		err = tree.JsVar.JawsInput(elem, value)
+	}
+	return
+}
+
+// JawsConnectUpdate reconciles multi-select and cascading Trees after connection.
+//
+// Their clients do not use the default single-select selection handshake. When
+// the shared Node data changed after the initial render but before the WebSocket
+// subscription, JawsConnectUpdate queues one authoritative jawstreeSet call for
+// this request. The call updates the browser-side variable and Quercus view as
+// one snapshot. Default single-select Trees continue to reconcile through their
+// versioned handshake, which preserves browser expansion and search state.
+func (tree *Tree) JawsConnectUpdate(elem *jaws.Element, renderedState any) (err error) {
+	owner, ownsElement := elem.UI().(*Tree)
+	renderedDigest, hasRenderedDigest := renderedState.([sha256.Size]byte)
+	if tree.isDefaultSingleSelect() || renderedState == nil || !ownsElement || owner != tree {
+		return
+	}
+
+	var data []byte
+	var selectionVersion uint64
+	tree.RLock()
+	if tree.Ptr != nil {
+		data = tree.Ptr.marshalJSON(nil)
+		selectionVersion = tree.selectionVersion
+	}
+	tree.RUnlock()
+	if data != nil && (!hasRenderedDigest || sha256.Sum256(data) != renderedDigest) {
+		elem.JsCall("jawstreeSet", string(tree.appendSetCallData(nil, data, selectionVersion)))
 	}
 	return
 }


### PR DESCRIPTION
## Summary

- give Tree an explicit post-subscription reconciliation hook for multi-select and cascade modes
- compare the rendered JsVar digest with one locked current Node snapshot and queue an element-local jawstreeSet only when state changed
- update the shadow variable and Quercus view atomically, while leaving default single-select reconciliation to its versioned handshake

## Production defect

A pending page can render a shared multi-select or cascading Tree, then an already-connected browser can make an ordinary valid selection before the pending browser opens its WebSocket. The documented JsVar path broadcast and jawstreeSetPath call reach active subscriptions only. The pending page therefore initializes from stale HTML, and these Tree modes intentionally send no default-selection handshake.

A generic root Set is not a valid repair for this composite widget: it replaces window jawstreeroot state but does not call Quercus setData, leaving the visible Treeview stale. This PR sends one authoritative jawstreeSet to the connecting request instead.

No malformed frame, forbidden path, unsupported option, or API misuse is involved.

## Verification

- production lifecycle regressions for MultiSelectEnabled and CascadeSelectChildren
- unchanged-state deduplication and request-local delivery barriers
- JavaScript proof that root-only replacement leaves Treeview stale while jawstreeSet reconciles shadow and view
- focused race regressions passed 100 consecutive runs
- focused JavaScript regression passed 30 consecutive race-enabled runs
- go test -race ./...
- go vet ./...
- go build ./...
- staticcheck ./...
- golangci-lint run ./...
- gosec -quiet ./...
- gofumpt and git diff checks

Stacked on #117 because this fix implements the ConnectUpdater phase introduced there.