### PR TITLE
Document borrowed Request and Element lifetimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,13 @@ Elements while an initial HTTP handler still holds them. Its key cannot be
 assigned to another Request while the retired Request remains reachable; no
 deadline is guaranteed for later reuse.
 
+`*Request` and `*Element` values are borrowed lifecycle objects. Use them only
+within the synchronous HTTP handler or JaWS callback where they were obtained;
+do not store them in application state or pass them to background goroutines.
+Requests that enter `ServeHTTP` may be returned to an internal pool when it
+returns, so a retained pointer may later represent an unrelated connection.
+Copy the required application data and retain the Request context instead.
+
 Dirtying is two-stage: `Request.Dirty` and `Jaws.Dirty` expand tags and record
 them on the `Jaws` instance, then the serving loop distributes those tags to
 matching active requests and schedules `JawsUpdate` calls. Broadcast helpers
@@ -469,6 +476,23 @@ requested during the JavaScript WebSocket HTTP request.
 context passed to it. If the returned context is canceled or its deadline
 expires, a running Request's WebSocket loop wakes promptly even while idle; no
 browser event or broadcast is needed.
+
+Background work that must cancel the Request should retain its own derived
+context and cancellation function, not the Request pointer:
+
+```go
+var workCtx context.Context
+var cancel context.CancelCauseFunc
+rq.SetContext(func(parent context.Context) context.Context {
+	workCtx, cancel = context.WithCancelCause(parent)
+	return workCtx
+})
+go func() {
+	if err := run(workCtx); err != nil {
+		cancel(err)
+	}
+}()
+```
 
 ### Security of the WebSocket callback
 

--- a/README.md
+++ b/README.md
@@ -215,12 +215,17 @@ Elements while an initial HTTP handler still holds them. Its key cannot be
 assigned to another Request while the retired Request remains reachable; no
 deadline is guaranteed for later reuse.
 
-`*Request` and `*Element` values are borrowed lifecycle objects. Use them only
-within the synchronous HTTP handler or JaWS callback where they were obtained;
-do not store them in application state or pass them to background goroutines.
-Requests that enter `ServeHTTP` may be returned to an internal pool when it
-returns, so a retained pointer may later represent an unrelated connection.
-Copy the required application data and retain the Request context instead.
+`*Request` values are borrowed lifecycle objects. Do not store them in
+application state or pass them to background goroutines; copy the required
+application data and retain the Request context instead.
+
+An `*Element` belongs to its owning Request and embeds a pointer to it.
+Render-scoped widgets may retain child Elements they create between render and
+update calls within that Request lifecycle, as container helpers do, but should
+access them only from those calls. Do not let an Element escape the Request
+lifecycle or pass it to background work: when a Request that entered
+`ServeHTTP` returns, it may be placed in an internal pool, and the Element's
+embedded Request pointer may later represent an unrelated connection.
 
 Dirtying is two-stage: `Request.Dirty` and `Jaws.Dirty` expand tags and record
 them on the `Jaws` instance, then the serving loop distributes those tags to

--- a/element.go
+++ b/element.go
@@ -16,9 +16,12 @@ import (
 
 // Element is an instance of a [Request], a [UI] object and a [Jid].
 //
-// An Element pointer passed to a render, update or event handler is borrowed for
-// that call. Do not retain it in application state or use it from a background
-// goroutine. Its embedded Request may later be pooled and reused.
+// An Element pointer supplied to a render, update or event handler is borrowed
+// for that call. A render-scoped widget may retain child Elements it creates
+// between its render and update calls within the same Request lifecycle, but
+// should access them only from those calls. Do not retain an Element in
+// longer-lived application state or pass it to background work: the embedded
+// Request may later be pooled and reused for another connection.
 type Element struct {
 	*Request // (read-only) the Request the Element belongs to
 	// internals
@@ -109,9 +112,13 @@ func (elem *Element) UI() UI {
 
 // Deleted reports whether the [Element] has been removed from its [Request].
 //
-// A deleted Element is inert: [Element.JawsRender], [Element.JawsUpdate] and the
-// queue helpers are all no-ops on it. Deleted does not make a retained pointer
-// safe to use outside the callback that supplied it.
+// [Element.JawsRender], [Element.JawsUpdate] and the queue helpers are no-ops on
+// a deleted Element. A render-scoped widget that retains child Elements it
+// creates between render and update calls within one Request lifecycle can use
+// Deleted to detect and discard children removed out-of-band before reuse.
+// Deleted is not a lifetime check: it does not report whether the embedded
+// Request still represents the owning connection or make that Request safe to
+// use after its lifecycle.
 func (elem *Element) Deleted() bool {
 	return elem.deleted.Load()
 }

--- a/element.go
+++ b/element.go
@@ -15,6 +15,10 @@ import (
 )
 
 // Element is an instance of a [Request], a [UI] object and a [Jid].
+//
+// An Element pointer passed to a render, update or event handler is borrowed for
+// that call. Do not retain it in application state or use it from a background
+// goroutine. Its embedded Request may later be pooled and reused.
 type Element struct {
 	*Request // (read-only) the Request the Element belongs to
 	// internals
@@ -106,12 +110,8 @@ func (elem *Element) UI() UI {
 // Deleted reports whether the [Element] has been removed from its [Request].
 //
 // A deleted Element is inert: [Element.JawsRender], [Element.JawsUpdate] and the
-// queue helpers are all no-ops on it. Widgets that retain *Element references
-// across renders (for example a container helper that pools child elements for
-// reuse) can use this to detect and discard an element that was deleted
-// out-of-band — via a [Jaws.Delete] broadcast on a shared tag or a browser
-// removal — before reusing it, which would otherwise leave the child silently
-// unrendered.
+// queue helpers are all no-ops on it. Deleted does not make a retained pointer
+// safe to use outside the callback that supplied it.
 func (elem *Element) Deleted() bool {
 	return elem.deleted.Load()
 }

--- a/request.go
+++ b/request.go
@@ -240,12 +240,13 @@ func (rq *Request) clearLocked() *Request {
 	rq.remoteIP = netip.Addr{}
 	for _, e := range rq.elems {
 		if e != nil {
-			// Nil the GC-reachable fields and set the deleted guard, which makes any
-			// retained *Element inert (see [Element.Deleted]). The Request back-pointer
-			// and frozen flag are deliberately left as-is: Elements are allocated fresh
-			// per newElementLocked and never pooled, so a stale frozen value can never
-			// be observed by a reused Element. Any future move to pool Elements must
-			// also reset frozen, since it gates the lock-free handler read.
+			// Nil the GC-reachable fields and set the deleted guard, which makes the
+			// render, update and queue paths of any retained *Element no-ops (see
+			// [Element.Deleted]). The Request back-pointer and frozen flag are
+			// deliberately left as-is: Elements are allocated fresh per newElementLocked
+			// and never pooled, so a stale frozen value can never be observed by a reused
+			// Element. Any future move to pool Elements must also reset frozen, since it
+			// gates the lock-free handler read.
 			e.handlers = nil
 			e.ui = nil
 			e.deleted.Store(true)

--- a/request.go
+++ b/request.go
@@ -36,6 +36,14 @@ type ConnectFn = func(rq *Request) error
 // Request maintains the state for a JaWS WebSocket connection, and handles processing
 // of events and broadcasts.
 //
+// A Request pointer is borrowed for the HTTP or WebSocket lifecycle that supplied
+// it. Do not retain it in application state or use it from a background goroutine:
+// a Request that enters [Request.ServeHTTP] may be returned to an internal pool
+// when ServeHTTP returns, and the same pointer may later represent another
+// connection. Background work should retain [Request.Context] and, when it must
+// terminate the connection, the cancel function returned while deriving a
+// replacement context through [Request.SetContext].
+//
 // Unlike [Session], whose methods are nil-safe, Request methods are not safe to call on a
 // nil *Request: a Request is always obtained from [Jaws.NewRequest] or [Jaws.UseRequest]
 // and is never legitimately nil. The nil-receiver guard on [Request.JawsKeyString] (and
@@ -323,7 +331,10 @@ func (rq *Request) Set(key string, value any) {
 	rq.Session().Set(key, value)
 }
 
-// Context returns the [Request]'s context, which is by default derived from [Jaws.BaseContext].
+// Context returns the [Request]'s context.
+//
+// The context is derived from [Jaws.BaseContext] by default. Unlike the Request
+// pointer, it may be retained by background work.
 func (rq *Request) Context() (ctx context.Context) {
 	rq.mu.RLock()
 	ctx = rq.ctx
@@ -343,6 +354,9 @@ func (rq *Request) Context() (ctx context.Context) {
 // Request, call code that may do so, or block on work that needs the same
 // Request. SetContext panics if fn is nil. If fn panics, SetContext releases the
 // lock and propagates the panic.
+//
+// Background work that must cancel the Request should create a derived context in
+// fn and retain that context's cancellation function, not the Request pointer.
 //
 // Returning a nil context is a programming error: debug builds panic and production
 // builds report it through [Jaws.MustLog] and retain the current context.
@@ -436,9 +450,12 @@ func (rq *Request) cancel(err error) {
 // It cancels the Request's context with the given cause (logged via [Jaws.Logger]);
 // the WebSocket processing loop and its goroutines observe the cancelled context and
 // shut down asynchronously. Cancel returns immediately and does not wait for teardown.
-// It is safe to call from UI code, for example to terminate a connection that violates
-// a server-side limit. A nil err cancels without a specific cause, and calling Cancel
-// on an already-finished or already-cancelled Request has no effect.
+// It is safe to call synchronously from UI code, for example to terminate a
+// connection that violates a server-side limit. A nil err cancels without a
+// specific cause.
+//
+// Do not retain the Request for asynchronous cancellation; use [Request.SetContext]
+// and retain the derived context's cancellation function instead.
 func (rq *Request) Cancel(err error) {
 	rq.cancel(err)
 }
@@ -460,8 +477,8 @@ func alertData(level, msg string) string {
 //
 // The default JaWS JavaScript only supports Bootstrap dismissible alerts.
 //
-// It does nothing if the Request has already been recycled, since it then has no
-// live target. See [Jaws.Broadcast] for processing-loop requirements.
+// See [Request] for pointer lifetime and [Jaws.Broadcast] for processing-loop
+// requirements.
 func (rq *Request) Alert(level, msg string) {
 	if k := rq.destKey(); k != 0 {
 		rq.Jaws.Broadcast(wire.Message{
@@ -486,8 +503,8 @@ func (rq *Request) AlertError(err error) {
 // schemes such as javascript: and protocol-relative ("//host") URLs are refused
 // and logged rather than sent to the browser.
 //
-// It does nothing if the Request has already been recycled, since it then has no
-// live target. See [Jaws.Broadcast] for processing-loop requirements.
+// See [Request] for pointer lifetime and [Jaws.Broadcast] for processing-loop
+// requirements.
 func (rq *Request) Redirect(url string) {
 	if msg, ok := rq.Jaws.redirectMessage(url); ok {
 		if k := rq.destKey(); k != 0 {

--- a/requestpool.go
+++ b/requestpool.go
@@ -28,6 +28,8 @@ import (
 // returned [Request] pointer so it can be used while constructing the HTML
 // response in order to register the JaWS IDs you use in the response, and
 // use its [Request.JawsKey] when sending the JavaScript portion of the reply.
+// Do not retain the pointer beyond the initial HTTP handling and rendering; see
+// [Request].
 //
 // Automatic timeout handling is performed by [Jaws.ServeWithTimeout]. The default
 // [Jaws.Serve] helper uses a 10-second timeout.
@@ -198,6 +200,9 @@ func (jw *Jaws) nonZeroRandomLocked() key.Key {
 // Returns nil if the key was not found, the request was already claimed by an
 // earlier WebSocket callback, or the IP doesn't match, in which case you
 // should return an HTTP "404 Not Found" status.
+//
+// The returned pointer is borrowed for WebSocket handling. Do not retain it
+// after [Request.ServeHTTP] returns; see [Request].
 func (jw *Jaws) UseRequest(jawsKey key.Key, r *http.Request) (rq *Request) {
 	if jawsKey != 0 {
 		var err error

--- a/session.go
+++ b/session.go
@@ -225,7 +225,8 @@ func (sess *Session) Clear() {
 
 // Requests returns a list of the [Request] values using this [Session].
 //
-// The returned pointers are borrowed for immediate synchronous use; see [Request].
+// The returned slice is a snapshot. Its Request pointers are not pinned and may
+// become stale immediately; see [Request].
 // It is safe to call on a nil [Session].
 func (sess *Session) Requests() (requests []*Request) {
 	if sess != nil {

--- a/session.go
+++ b/session.go
@@ -224,6 +224,8 @@ func (sess *Session) Clear() {
 }
 
 // Requests returns a list of the [Request] values using this [Session].
+//
+// The returned pointers are borrowed for immediate synchronous use; see [Request].
 // It is safe to call on a nil [Session].
 func (sess *Session) Requests() (requests []*Request) {
 	if sess != nil {


### PR DESCRIPTION
## Summary

- define `Request` pointers as borrowed lifecycle values that must not be retained past their connection
- document that an `Element` embeds its owning `Request`, so it is unsafe after that Request can be recycled
- preserve the narrow render-scoped widget pattern of retaining created child Elements between render/update calls within one live Request
- document that `Element.Deleted` is an element-removal flag, not a Request identity or lifetime check
- document the `NewRequest`, `UseRequest`, and `Session.Requests` ownership boundaries
- direct background work to retain `Request.Context` and a cancel function derived through `SetContext`
- remove misleading guarantees for stale `Cancel`, `Alert`, and `Redirect` calls

## Verification

- `JAWS_REQUIRE_NODE=1 go test -race ./...`
- `go generate ./...`
- `go vet ./...`
- `go build ./...`
- `staticcheck ./...`
- `golangci-lint run ./...`
- `gosec -quiet ./...`
- `gofmt`, `gofumpt`, and `git diff --check`
- verified rendered godoc for `Request`, `Element`, `Element.Deleted`, `NewRequest`, `UseRequest`, `Session.Requests`, and `Request.SetContext`
