### PR TITLE
Fix absent BoolArray false deselection

### DIFF
--- a/lib/named/namedboolarray.go
+++ b/lib/named/namedboolarray.go
@@ -107,21 +107,23 @@ func (nba *BoolArray) Set(name string, state bool) (changed bool) {
 // single-select deselection, and returns every [Bool] whose state changed. The
 // BoolArray must be locked for writing.
 func (nba *BoolArray) setChangedLocked(name string, state bool) (changed []*Bool) {
+	matched := false
 	for _, nb := range nba.data {
 		if nb.Name() == name {
+			matched = true
 			if nb.Set(state) {
 				changed = append(changed, nb)
 			}
 		}
 	}
-	changed = append(changed, nba.deselectOthersLocked(name, state)...)
+	changed = append(changed, nba.deselectOthersLocked(name, state || !matched)...)
 	return
 }
 
 // deselectOthersLocked clears all Bools whose name differs from
-// the given name when the array is in single-select mode and state is true.
-func (nba *BoolArray) deselectOthersLocked(name string, state bool) (changed []*Bool) {
-	if state && !nba.multi {
+// the given name when the array is in single-select mode and deselect is true.
+func (nba *BoolArray) deselectOthersLocked(name string, deselect bool) (changed []*Bool) {
+	if deselect && !nba.multi {
 		for _, nb := range nba.data {
 			if nb.Name() != name {
 				if nb.Set(false) {

--- a/lib/named/namedboolarray_test.go
+++ b/lib/named/namedboolarray_test.go
@@ -228,6 +228,18 @@ func TestBoolArray_SingleSelectAbsentNameDeselects(t *testing.T) {
 	}
 }
 
+func TestBoolArray_SingleSelectMatchedFalsePreservesOtherSelection(t *testing.T) {
+	nba := NewBoolArray(false).Add("a", "A").Add("b", "B")
+	nba.Set("b", true)
+
+	if nba.Set("a", false) {
+		t.Fatal("Set(a,false) should not change anything")
+	}
+	if got := nba.Get(); got != "b" {
+		t.Fatalf("Get=%q want b preserved", got)
+	}
+}
+
 func TestNamedBoolOption_RenderAndUpdateBranches(t *testing.T) {
 	_, rq := newCoreRequest(t)
 

--- a/lib/named/namedboolarray_test.go
+++ b/lib/named/namedboolarray_test.go
@@ -178,30 +178,40 @@ func TestBoolArray_SingleSelectAbsentNameDeselects(t *testing.T) {
 	// deselecting the current selection, leaving Get() empty. Per the Set/JawsSet
 	// docs a "change" return means the selection changed, not that the name is now
 	// selected.
-	nba := NewBoolArray(false)
-	nba.Add("a", "A")
-	nba.Add("b", "B")
+	for _, tt := range []struct {
+		name  string
+		state bool
+	}{
+		{name: "true", state: true},
+		{name: "false", state: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			nba := NewBoolArray(false).Add("a", "A").Add("b", "B")
 
-	if !nba.Set("a", true) {
-		t.Fatal("Set(a,true) reported no change")
-	}
-	if got := nba.Get(); got != "a" {
-		t.Fatalf("Get=%q want a", got)
-	}
-	// An absent name deselects the current selection and reports a change.
-	if !nba.Set("does-not-exist", true) {
-		t.Fatal("Set(absent,true) should report a change by deselecting the current selection")
-	}
-	if got := nba.Get(); got != "" {
-		t.Fatalf("Get=%q want empty after deselect", got)
-	}
-	// With nothing selected, a further absent-name set changes nothing.
-	if nba.Set("does-not-exist", true) {
-		t.Fatal("Set(absent,true) on an empty selection should report no change")
+			if !nba.Set("a", true) {
+				t.Fatal("Set(a,true) reported no change")
+			}
+			if got := nba.Get(); got != "a" {
+				t.Fatalf("Get=%q want a", got)
+			}
+			// An absent name deselects the current selection and reports a change,
+			// regardless of the requested state.
+			if !nba.Set("does-not-exist", tt.state) {
+				t.Fatalf("Set(absent,%t) should report a change by deselecting the current selection", tt.state)
+			}
+			if got := nba.Get(); got != "" {
+				t.Fatalf("Get=%q want empty after deselect", got)
+			}
+			// With nothing selected, a further absent-name set changes nothing.
+			if nba.Set("does-not-exist", tt.state) {
+				t.Fatalf("Set(absent,%t) on an empty selection should report no change", tt.state)
+			}
+		})
 	}
 
 	// JawsSet path: re-select, then JawsSet an absent name to deselect. A nil error
 	// means the selection changed; Get() is empty afterward. A repeat is unchanged.
+	nba := NewBoolArray(false).Add("a", "A").Add("b", "B")
 	_, rq := newCoreRequest(t)
 	e := rq.NewElement(noopUI{})
 	if !nba.Set("b", true) {


### PR DESCRIPTION
## Summary

- make `BoolArray.Set` deselect the current single-select value when the requested name is absent, regardless of the requested state
- preserve matched-name and multi-select behavior
- cover absent-name calls with both `true` and `false`

## Testing

- `JAWS_REQUIRE_NODE=1 go test -race -coverprofile=/tmp/jaws-boolarray-coverage.out ./...`
- `go vet ./...`
- `go build ./...`
- `gofmt -l .`
- `gofumpt -l .`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`