### PR TITLE
Document request-scoped UI ownership

### DIFF
--- a/.agents/skills/jaws/SKILL.md
+++ b/.agents/skills/jaws/SKILL.md
@@ -36,8 +36,12 @@ JaWS is an immediate-mode, server-driven UI framework, not an MVC framework.
 ## Hard framework constraints
 
 - Every JaWS `UI` value must be comparable.
+- Every JaWS `UI` value is request-scoped. Once used by one Request, never use
+  that value with another Request; construct fresh widgets per request. The
+  widgets may still refer to shared, synchronized application state, binders,
+  handlers, and tags.
 - `Container.JawsContains` must return hashable `UI` items, and the returned slice must not be mutated after return.
-- Treat `*ui.Container` / `*ui.Tbody` / `ContainerHelper` widgets as render-scoped; construct fresh per render, do not cache across requests.
+- Treat `*ui.Container` / `*ui.Tbody` / `ContainerHelper` widgets as request-scoped; construct fresh per request, do not cache across requests.
 
 ## Constructing UI values: `ui.New` and `bind.New`
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,11 @@ HTML code to the web page. Each Element is a unique instance
 of a UI object bound to a specific Request, and will have a
 unique Jid-based HTML id such as `Jid.7`.
 
+UI objects are request-scoped: construct fresh UI values for each Request and
+never reuse one UI value across Requests. The application state, binders,
+handlers and tags referenced by UI values may be shared when synchronized as
+required. The `ui.RequestWriter` helpers construct fresh widgets while rendering.
+
 If an HTML entity is not registered in a Request, JaWS will not
 forward events from it, nor perform DOM manipulations for it.
 
@@ -160,12 +165,23 @@ must read or change and exchange with Go. Unlike most JaWS UI values, a `JsVar`
 is a bidirectional channel: the binding does not by itself make either the Go
 value or the browser value authoritative.
 
-Create the binding in Go, pass it as the handler's dot value, and render it
-under the top-level name used by the browser:
+Create each binding for the Request that renders it. A `JsVarMaker` can be kept
+in shared handler data because each call returns a fresh `JsVar` over the
+possibly shared backing state:
 
 ```go
-clientVar := ui.NewJsVar(&clientMu, &client)
-handler := ui.Handler(jw, "index", clientVar)
+type application struct {
+	clientMu sync.Mutex
+	client   Client
+}
+
+// JawsMakeJsVar creates the binding for one request.
+func (app *application) JawsMakeJsVar(*jaws.Request) (ui.IsJsVar, error) {
+	return ui.NewJsVar(&app.clientMu, &app.client), nil
+}
+
+app := new(application)
+handler := ui.Handler(jw, "index", app)
 ```
 
 ```gotemplate

--- a/contracts.go
+++ b/contracts.go
@@ -13,7 +13,8 @@ type Container interface {
 	//
 	// The returned [UI] values must be comparable, since they are used as map keys
 	// (see [UI] for the comparability requirement), and the slice contents must not
-	// be modified after returning it.
+	// be modified after returning it. A child UI may be returned repeatedly for
+	// the same Request, but must not be shared with a different Request.
 	JawsContains(elem *Element) (contents []UI)
 }
 
@@ -47,6 +48,12 @@ type TemplateLookuper interface {
 }
 
 // UI defines the required methods on JaWS UI objects.
+//
+// A UI value is request-scoped. Once it has been used to create an [Element]
+// for one [Request], it must not be used to create an Element for another
+// Request. Construct a fresh UI value for each Request. The application state,
+// getters, setters, handlers and tags referenced by those UI values may be
+// shared across Requests when synchronized as required.
 //
 // In addition, all UI objects must be comparable so they can be used as map keys.
 // The compile-time type must be comparable; debug builds additionally perform a

--- a/element.go
+++ b/element.go
@@ -17,7 +17,7 @@ import (
 // Element is an instance of a [Request], a [UI] object and a [Jid].
 //
 // An Element pointer supplied to a render, update or event handler is borrowed
-// for that call. A render-scoped widget may retain child Elements it creates
+// for that call. A request-scoped widget may retain child Elements it creates
 // between its render and update calls within the same Request lifecycle, but
 // should access them only from those calls. Do not retain an Element in
 // longer-lived application state or pass it to background work: the embedded
@@ -113,7 +113,7 @@ func (elem *Element) UI() UI {
 // Deleted reports whether the [Element] has been removed from its [Request].
 //
 // [Element.JawsRender], [Element.JawsUpdate] and the queue helpers are no-ops on
-// a deleted Element. A render-scoped widget that retains child Elements it
+// a deleted Element. A request-scoped widget that retains child Elements it
 // creates between render and update calls within one Request lifecycle can use
 // Deleted to detect and discard children removed out-of-band before reuse.
 // Deleted is not a lifetime check: it does not report whether the embedded

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -73,12 +73,15 @@ but it does not keep the locker passed to `NewJsVar` held.
 
 ## Widget lifetime
 
-UI widget values are render-scoped. Construct them during rendering, typically
-through `RequestWriter` helpers such as `$.Container(...)` and `$.Tbody(...)`.
+Every UI widget value is request-scoped. Construct a fresh widget for each
+request, typically through `RequestWriter` helpers such as `$.Span(...)`,
+`$.Text(...)`, `$.Container(...)`, and `$.JsVar(...)`. Do not cache a widget and
+reuse it across requests, even if that widget currently appears stateless.
 
-Do not cache and reuse `*ui.Container` / `*ui.Tbody` instances across requests.
-Those widgets keep internal render/update bookkeeping and are intended to be
-created fresh for each render.
+The application data referenced by widgets has a separate lifetime. Distinct
+request-scoped widgets may share synchronized backing state, binders, handlers
+and tags. For `JsVar`, use a `JsVarMaker` when a shared handler or template value
+needs to create the binding for the current request.
 
 ## Adding a simple static widget
 

--- a/lib/ui/containerhelper.go
+++ b/lib/ui/containerhelper.go
@@ -16,8 +16,8 @@ import (
 // It tracks already-rendered child elements and performs append/remove/order
 // updates during [ContainerHelper.UpdateContainer].
 //
-// A ContainerHelper belongs to a widget instance and is intended for render-scoped
-// widget lifetimes (for example widgets created via RequestWriter helper methods).
+// A ContainerHelper belongs to a request-scoped widget instance (for example a
+// widget created via a RequestWriter helper method).
 //
 // Error model:
 // Child render/update failures are treated as application bugs. Initial-render
@@ -42,7 +42,7 @@ type ContainerHelper struct {
 }
 
 // NewContainerHelper returns a ContainerHelper for rendering and updating c.
-// ContainerHelper values are render-scoped and should not be reused across requests.
+// ContainerHelper values are request-scoped and must not be reused across requests.
 func NewContainerHelper(c jaws.Container) ContainerHelper {
 	return ContainerHelper{Container: c}
 }

--- a/lib/ui/doc.go
+++ b/lib/ui/doc.go
@@ -10,6 +10,13 @@
 //
 // Naming follows short widget names (`Span`, `NewSpan`).
 //
+// Every widget that implements [github.com/linkdata/jaws.UI] is request-scoped.
+// Construct a fresh widget for each request, normally by calling a
+// [RequestWriter] helper while rendering, and never cache a widget for use by
+// multiple requests. Widgets for different requests may refer to the same
+// application state, binders, handlers or tags when that shared state is
+// synchronized as required.
+//
 // HTML-inner widgets route content through [bind.MakeHTMLGetter]. Plain strings
 // are treated as trusted HTML, while [bind.Getter][string], [bind.Binder][string]
 // and [fmt.Stringer] values are escaped. Raw [template.HTMLAttr] params are also

--- a/lib/ui/doc.go
+++ b/lib/ui/doc.go
@@ -10,7 +10,7 @@
 //
 // Naming follows short widget names (`Span`, `NewSpan`).
 //
-// Every widget that implements [github.com/linkdata/jaws.UI] is request-scoped.
+// Every widget that implements [jaws.UI] is request-scoped.
 // Construct a fresh widget for each request, normally by calling a
 // [RequestWriter] helper while rendering, and never cache a widget for use by
 // multiple requests. Widgets for different requests may refer to the same

--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -83,6 +83,10 @@ type IsJsVar interface {
 }
 
 // JsVarMaker creates a request-scoped JavaScript variable binding.
+//
+// JawsMakeJsVar must return a fresh [IsJsVar] for each request. The returned
+// bindings may share synchronized backing state, but the bindings themselves
+// must not be shared between requests.
 type JsVarMaker interface {
 	JawsMakeJsVar(rq *jaws.Request) (value IsJsVar, err error)
 }
@@ -93,6 +97,12 @@ var (
 )
 
 // JsVar binds a Go value to a named JavaScript variable in the browser.
+//
+// A JsVar is request-scoped and must not be rendered by more than one
+// [jaws.Request]. Construct a fresh JsVar for each request, either directly
+// while rendering or through [JsVarMaker]. Distinct JsVar values may use the
+// same locker and Ptr to expose synchronized application state to multiple
+// requests.
 //
 // JsVar is intended for JSON-marshalable state shared with application
 // JavaScript. The browser binding reads and writes the window property named
@@ -117,7 +127,8 @@ var (
 // It is safe for concurrent use when the locker passed to [NewJsVar] is safe
 // for concurrent use. Concurrent writes are applied one at a time. Any
 // broadcasts they produce preserve the order in which the writes modify the
-// bound value.
+// bound value. This concurrency guarantee does not permit one JsVar to be
+// shared between requests.
 //
 // A JsVar must not be copied after first use.
 //
@@ -387,6 +398,9 @@ func (jsvar *JsVar[T]) JawsInput(elem *jaws.Element, value string) (err error) {
 // NewJsVar creates a JsVar over v protected by l.
 //
 // The locker l must be non-nil and must remain valid for the lifetime of the JsVar.
+// Create a fresh JsVar for each request; l and v may be shared by distinct
+// request-scoped JsVar values. Use [JsVarMaker] when construction depends on the
+// current request or the maker is stored in shared handler data.
 func NewJsVar[T any](l sync.Locker, v *T) *JsVar[T] {
 	return &JsVar[T]{RWLocker: bind.AsRWLocker(l), Ptr: v}
 }
@@ -408,7 +422,9 @@ func isNilUI(ui jaws.UI) (yes bool) {
 //
 // It returns [ErrIllegalJsVarName] if jsvarName is invalid or reserved.
 //
-// You can also pass a [JsVarMaker] instead of a [JsVar].
+// A directly supplied [JsVar] must be scoped to rw.Request. You can instead pass
+// a [JsVarMaker], which is useful when the maker is stored in handler or template
+// data shared by multiple requests.
 func (rw RequestWriter) JsVar(jsvarName string, jsvar any, params ...any) (err error) {
 	if _, err = validateJsVarName([]any{jsvarName}); err == nil {
 		if jvm, ok := jsvar.(JsVarMaker); ok {

--- a/request.go
+++ b/request.go
@@ -592,6 +592,9 @@ func (rq *Request) newElementLocked(ui UI) (elem *Element) {
 
 // NewElement creates a new [Element] using the given [UI] object.
 //
+// The UI value becomes scoped to rq and must not be used with another
+// [Request]. See [UI] for the ownership contract.
+//
 // Panics if the build tag "debug" is set and the [UI] object doesn't satisfy all requirements.
 func (rq *Request) NewElement(ui UI) *Element {
 	if deadlock.Debug {


### PR DESCRIPTION
## Summary

- define every jaws.UI value as owned by one Request while allowing synchronized backing state to be shared
- document JsVar and JsVarMaker as request-scoped and fix the README example to construct a fresh binding per request
- align the standard UI package, Container contract, Element terminology, and repository JaWS guidance with that lifecycle

## Audit result

The standard RequestWriter construction paths create fresh widgets. Stateful inputs retain request-local tag and last-value state; containers retain request-owned child Elements; radio helpers retain request-specific JIDs; and ui.Handler copies its page-template UI value for each request.

jawstree.Tree remains a known, intentionally deferred exception: it currently documents and tests cross-request sharing and is not changed in this PR.

## Verification

- go test -race ./...
- go vet ./...
- go doc checks for jaws.UI, Request.NewElement, ui.JsVar, ui.JsVarMaker, and package ui
- git diff --check