### PR TITLE
jsvar: allow duplicate names, fanning browser writes out to all live bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,15 @@ handler := ui.Handler(jw, "index", app)
 {{$.JsVar "client" .Dot}}
 ```
 
+Several `JsVar` bindings may share a name. The name is a single `window`
+property, and a browser-initiated write to it is delivered to every live binding
+of that name; a removed binding simply stops receiving writes. This makes
+re-rendering a subtree that contains a nested `JsVar` work, lets multiple requests
+expose the same application-owned global, and lets one browser value fan out to
+several independent Go bindings. When several bindings share the same backing
+value, a browser write applies to it once per binding, so avoid exposing one
+non-idempotent value through multiple simultaneously rendered bindings.
+
 The name may refer to an existing application global. For example, browser
 code can update that object and send either the complete value or one path:
 
@@ -252,8 +261,10 @@ client/server protocol code:
   identifiers (for example, `app`), and use dotted suffixes as the JSON path
   (for example, `jawsVar("app.state", value)` sends path `state`). The exact
   top-level name `__proto__` is reserved; rendering it as a `JsVar` returns
-  `ui.ErrIllegalJsVarName`. See [JavaScript variables](#javascript-variables)
-  for the binding and synchronization model.
+  `ui.ErrIllegalJsVarName`. A name may be shared by several live bindings; a
+  browser write is delivered to every live binding of the name. See
+  [JavaScript variables](#javascript-variables) for the binding and
+  synchronization model.
 
 ### HTTP request flow and associating the WebSocket
 

--- a/lib/assets/jaws.js
+++ b/lib/assets/jaws.js
@@ -160,15 +160,37 @@ function jawsInputHandler(e) {
 	}
 }
 
+function jawsForgetName(elem) {
+	const name = elem.dataset && elem.dataset.jawsname;
+	if (!name) {
+		return;
+	}
+	const ids = window.jawsNames.get(name);
+	if (ids !== undefined) {
+		const idx = ids.indexOf(elem.id);
+		if (idx >= 0) {
+			ids.splice(idx, 1);
+		}
+		if (ids.length === 0) {
+			window.jawsNames.delete(name);
+		}
+	}
+}
+
 function jawsRemoving(topElem) {
 	if (!jawsIsJid(topElem.id)) {
 		return;
 	}
+	// Report the descendants being removed and drop any JsVar name routes they own,
+	// so a later browser write does not target a deleted element. topElem itself
+	// survives an Inner update, so its own name is dropped by the callers that
+	// actually remove it (Delete/Replace/Remove), not here.
 	const elements = topElem.querySelectorAll('[id^="' + jawsIdPrefix + '"]');
 	const ids = [];
 	for (let i = 0; i < elements.length; i++) {
 		if (jawsIsJid(elements[i].id)) {
 			ids.push(elements[i].id);
+			jawsForgetName(elements[i]);
 		}
 	}
 	if (ids.length === 0) {
@@ -183,7 +205,18 @@ function jawsAttach(elem) {
 	}
 	if (elem.hasAttribute("data-jawsname")) {
 		const name = elem.dataset.jawsname;
-		window.jawsNames[name] = elem.id;
+		// A name may have several live bindings (a re-rendered subtree, or multiple
+		// requests sharing a global). Track every live Jid so a browser write can fan
+		// out to all of them; removing a binding drops its Jid. jawsNames is a Map so
+		// any name, including "__proto__", is a safe key.
+		let ids = window.jawsNames.get(name);
+		if (ids === undefined) {
+			ids = [];
+			window.jawsNames.set(name, ids);
+		}
+		if (ids.indexOf(elem.id) < 0) {
+			ids.push(elem.id);
+		}
 		if (elem.hasAttribute("data-jawsdata")) {
 			jawsVar(name, JSON.parse(elem.dataset.jawsdata), 'Set');
 		}
@@ -454,9 +487,16 @@ function jawsVar(name, data, operation) {
 					obj[lastkey] = data;
 				}
 				if (jawsCanSend()) {
-					const id = window.jawsNames[name];
-					if (jawsIsJid(id)) {
-						jaws.send("Set\t" + id + "\t" + path + "=" + JSON.stringify(data) + "\n");
+					const ids = window.jawsNames.get(name);
+					if (ids !== undefined) {
+						// The name is a channel: fan the write out to every live binding so
+						// each bound Go value receives it, not just the most recent one.
+						const payload = "\t" + path + "=" + JSON.stringify(data) + "\n";
+						for (let i = 0; i < ids.length; i++) {
+							if (jawsIsJid(ids[i])) {
+								jaws.send("Set\t" + ids[i] + payload);
+							}
+						}
 					}
 				}
 				return data;
@@ -532,6 +572,7 @@ function jawsPerform(what, id, data) {
 		case 'Replace':
 			if (elem.outerHTML !== data) {
 				jawsRemoving(elem);
+				jawsForgetName(elem);
 				elem.replaceWith(jawsAttachChildren(jawsElement(data)));
 			} else {
 				jawsWarnDirtyNoChange(id, what);
@@ -539,12 +580,14 @@ function jawsPerform(what, id, data) {
 			return;
 		case 'Delete':
 			jawsRemoving(elem);
+			jawsForgetName(elem);
 			elem.remove();
 			return;
 		case 'Remove':
 			where = jawsRemoveWhere(elem, data);
 			if (where instanceof Node) {
 				jawsRemoving(where);
+				jawsForgetName(where);
 				elem.removeChild(where);
 			}
 			return;
@@ -605,7 +648,7 @@ function jawsConnectWhenReady() {
 	jawsConnect();
 }
 
-window.jawsNames = {};
+window.jawsNames = new Map();
 jawsAttachChildren(document);
 if (document.readyState === 'complete') {
 	jawsConnect();

--- a/lib/assets/js_benchmark_test.go
+++ b/lib/assets/js_benchmark_test.go
@@ -26,7 +26,7 @@ const elem = { id: "Jid.1", removeAttribute: function() {} };
 global.window = {
     location: { protocol: "http:", host: "example.test" },
     addEventListener: function() {},
-    jawsNames: {}
+    jawsNames: new Map()
 };
 global.document = {
     readyState: "loading",

--- a/lib/assets/js_test.go
+++ b/lib/assets/js_test.go
@@ -201,7 +201,7 @@ global.window = {
 			return other !== fn;
 		});
 	},
-	jawsNames: {},
+	jawsNames: new Map(),
 };
 global.document = {
 	readyState: "loading",
@@ -429,7 +429,7 @@ func TestJawsJS_JsVarNestedPathUsesTopLevelNameRouting(t *testing.T) {
 WebSocket = FakeSocket;
 
 window.app = { state: 0 };
-window.jawsNames["app"] = "Jid.9";
+window.jawsNames.set("app", ["Jid.9"]);
 jaws = new FakeSocket();
 
 jawsVar("app.state", 42);
@@ -455,7 +455,7 @@ process.stdout.write(jaws.sent[0] || "");
 	}
 }
 
-func TestJawsJS_PrototypeNameCannotFormJsVarRoute(t *testing.T) {
+func TestJawsJS_JsVarRoutingTableIsPrototypeSafe(t *testing.T) {
 	raw := runJawsJSSnippet(t, `
 function FakeSocket() { this.readyState = 1; this.sent = []; }
 FakeSocket.prototype.send = function(msg) { this.sent.push(msg); };
@@ -470,42 +470,228 @@ function jsVarElement(name, id) {
 	};
 }
 
+// jawsNames is a Map, so even "__proto__" is just an ordinary key: it is tracked
+// like any other name and cannot pollute Object.prototype or the table itself.
 jawsAttach(jsVarElement("__proto__", "Jid.9"));
 jawsAttach(jsVarElement("__proto", "Jid.10"));
-jawsVar("__proto__");
-jawsVar("__proto", 42);
 
 process.stdout.write(JSON.stringify({
-	prototypeOwnRoute: Object.hasOwn(window.jawsNames, "__proto__"),
-	prototypeRouteType: typeof window.jawsNames["__proto__"],
-	nearOwnRoute: Object.hasOwn(window.jawsNames, "__proto"),
-	nearRoute: window.jawsNames["__proto"],
-	frames: jaws.sent,
+	protoRoute: window.jawsNames.get("__proto__") || null,
+	nearRoute: window.jawsNames.get("__proto") || null,
+	objectPolluted: ({}).length !== undefined || Object.prototype.hasOwnProperty("Jid.9"),
 }));
 `)
 
 	var got struct {
-		PrototypeOwnRoute  bool     `json:"prototypeOwnRoute"`
-		PrototypeRouteType string   `json:"prototypeRouteType"`
-		NearOwnRoute       bool     `json:"nearOwnRoute"`
-		NearRoute          string   `json:"nearRoute"`
-		Frames             []string `json:"frames"`
+		ProtoRoute     []string `json:"protoRoute"`
+		NearRoute      []string `json:"nearRoute"`
+		ObjectPolluted bool     `json:"objectPolluted"`
 	}
 	if err := json.Unmarshal([]byte(raw), &got); err != nil {
 		t.Fatalf("unexpected JSON output %q: %v", raw, err)
 	}
-	if got.PrototypeOwnRoute || got.PrototypeRouteType == "string" {
-		t.Fatalf("__proto__ unexpectedly formed an own string route: %+v", got)
+	if got.ObjectPolluted {
+		t.Fatal("attaching a __proto__ binding polluted Object.prototype")
 	}
-	if !got.NearOwnRoute || got.NearRoute != "Jid.10" {
-		t.Fatalf("nearby identifier route = own %t, %q; want own Jid.10", got.NearOwnRoute, got.NearRoute)
+	if len(got.ProtoRoute) != 1 || got.ProtoRoute[0] != "Jid.9" {
+		t.Fatalf(`jawsNames.get("__proto__") = %v, want [Jid.9]`, got.ProtoRoute)
 	}
-	if len(got.Frames) != 1 {
-		t.Fatalf("JsVar frames = %q, want only the nearby identifier frame", got.Frames)
+	if len(got.NearRoute) != 1 || got.NearRoute[0] != "Jid.10" {
+		t.Fatalf(`jawsNames.get("__proto") = %v, want [Jid.10]`, got.NearRoute)
 	}
-	msg, ok := wire.Parse([]byte(got.Frames[0]))
-	if !ok || msg.What != what.Set || msg.Jid != 10 || msg.Data != "=42" {
-		t.Fatalf("nearby identifier frame = %+v, parseable %t; want Set Jid.10 =42", msg, ok)
+}
+
+func TestJawsJS_DuplicateJsVarNameFansOutToAllLiveBindings(t *testing.T) {
+	raw := runJawsJSSnippet(t, `
+function FakeSocket() { this.readyState = 1; this.sent = []; }
+FakeSocket.prototype.send = function(msg) { this.sent.push(msg); };
+WebSocket = FakeSocket;
+jaws = new FakeSocket();
+window.app = { state: 0 };
+
+const elems = {};
+document.getElementById = function(id) { return elems[id] || null; };
+
+function jsVarElement(id) {
+	const e = {
+		id: id,
+		dataset: { jawsname: "app" },
+		hasAttribute: function(attr) { return attr === "data-jawsname"; },
+		querySelectorAll: function() { return []; },
+		remove: function() { delete elems[id]; },
+	};
+	elems[id] = e;
+	return e;
+}
+
+jawsAttach(jsVarElement("Jid.9"));
+jawsAttach(jsVarElement("Jid.10"));
+
+// One browser write reaches every live binding of the name.
+jaws.sent = [];
+jawsVar("app.state", 1);
+const bothLive = jaws.sent;
+
+// Deleting one binding leaves the write reaching only the remaining one.
+jawsPerform("Delete", "Jid.10", "\"\"");
+jaws.sent = [];
+jawsVar("app.state", 2);
+const oneLive = jaws.sent;
+
+// Deleting the last binding drops the name entirely.
+jawsPerform("Delete", "Jid.9", "\"\"");
+jaws.sent = [];
+jawsVar("app.state", 3);
+const noneLive = jaws.sent;
+
+process.stdout.write(JSON.stringify({
+	bothLive: bothLive,
+	oneLive: oneLive,
+	noneLive: noneLive,
+	nameStillTracked: window.jawsNames.has("app"),
+}));
+`)
+
+	var got struct {
+		BothLive         []string `json:"bothLive"`
+		OneLive          []string `json:"oneLive"`
+		NoneLive         []string `json:"noneLive"`
+		NameStillTracked bool     `json:"nameStillTracked"`
+	}
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unexpected JSON output %q: %v", raw, err)
+	}
+
+	// While both bindings are live, the write fans out to both (oldest-first).
+	if len(got.BothLive) != 2 {
+		t.Fatalf("write with two live bindings = %q, want a frame for each", got.BothLive)
+	}
+	if msg, ok := wire.Parse([]byte(got.BothLive[0])); !ok || msg.Jid != 9 || msg.Data != "state=1" {
+		t.Fatalf("first fan-out frame = %+v, parseable %t; want Jid.9 state=1", msg, ok)
+	}
+	if msg, ok := wire.Parse([]byte(got.BothLive[1])); !ok || msg.Jid != 10 || msg.Data != "state=1" {
+		t.Fatalf("second fan-out frame = %+v, parseable %t; want Jid.10 state=1", msg, ok)
+	}
+
+	// After removing one, only the survivor receives the write.
+	if len(got.OneLive) != 1 {
+		t.Fatalf("write after deleting one binding = %q, want a single frame", got.OneLive)
+	}
+	if msg, ok := wire.Parse([]byte(got.OneLive[0])); !ok || msg.Jid != 9 || msg.Data != "state=2" {
+		t.Fatalf("surviving-binding frame = %+v, parseable %t; want Jid.9 state=2", msg, ok)
+	}
+
+	// After removing all, nothing is emitted and the name is forgotten.
+	if len(got.NoneLive) != 0 {
+		t.Fatalf("write after deleting all bindings = %q, want no frames", got.NoneLive)
+	}
+	if got.NameStillTracked {
+		t.Fatal("routing table still tracks the name after all bindings were deleted")
+	}
+}
+
+func TestJawsJS_InnerUpdateKeepsTargetJsVarNameRoute(t *testing.T) {
+	raw := runJawsJSSnippet(t, `
+function FakeSocket() { this.readyState = 1; this.sent = []; }
+FakeSocket.prototype.send = function(msg) { this.sent.push(msg); };
+WebSocket = FakeSocket;
+jaws = new FakeSocket();
+window.app = { state: 0 };
+
+// Inner replaces only the target's descendants; the target JsVar element itself
+// stays live, so its name route must survive the update.
+const jsvar = {
+	id: "Jid.9",
+	_inner: "",
+	dataset: { jawsname: "app" },
+	hasAttribute: function(attr) { return attr === "data-jawsname"; },
+	querySelectorAll: function() { return []; },
+	get innerHTML() { return this._inner; },
+	set innerHTML(v) { this._inner = v; },
+};
+document.getElementById = function(id) { return id === "Jid.9" ? jsvar : null; };
+
+jawsAttach(jsvar);
+jawsPerform("Inner", "Jid.9", JSON.stringify("<span>x</span>"));
+jawsVar("app.state", 7);
+
+process.stdout.write(JSON.stringify({
+	nameStillTracked: window.jawsNames.has("app"),
+	frame: jaws.sent[jaws.sent.length - 1] || "",
+}));
+`)
+
+	var got struct {
+		NameStillTracked bool   `json:"nameStillTracked"`
+		Frame            string `json:"frame"`
+	}
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unexpected JSON output %q: %v", raw, err)
+	}
+	if !got.NameStillTracked {
+		t.Fatal("Inner update on a JsVar forgot its still-live name route")
+	}
+	msg, ok := wire.Parse([]byte(got.Frame))
+	if !ok || msg.What != what.Set || msg.Jid != 9 || msg.Data != "state=7" {
+		t.Fatalf("write after Inner routed to %+v, parseable %t; want live target Jid.9 state=7", msg, ok)
+	}
+}
+
+func TestJawsJS_RerenderReplacesNestedJsVarNameRoute(t *testing.T) {
+	raw := runJawsJSSnippet(t, `
+function FakeSocket() { this.readyState = 1; this.sent = []; }
+FakeSocket.prototype.send = function(msg) { this.sent.push(msg); };
+WebSocket = FakeSocket;
+jaws = new FakeSocket();
+window.app = { state: 0 };
+
+function jsVarElement(id) {
+	return {
+		id: id,
+		dataset: { jawsname: "app" },
+		hasAttribute: function(attr) { return attr === "data-jawsname"; },
+	};
+}
+
+// A container holds a nested JsVar. Re-rendering it (Inner) removes the old nested
+// binding and attaches a fresh one with the same name; routing must land on the
+// new binding without a duplicate-name error.
+const children = { before: [jsVarElement("Jid.2")], after: [jsVarElement("Jid.3")] };
+let phase = "before";
+const container = {
+	id: "Jid.1",
+	_inner: "",
+	get innerHTML() { return this._inner; },
+	set innerHTML(v) { this._inner = v; phase = "after"; },
+	querySelectorAll: function(sel) {
+		return sel.indexOf("jawsonchangesubmit") >= 0 ? [] : children[phase];
+	},
+};
+document.getElementById = function(id) { return id === "Jid.1" ? container : null; };
+
+jawsAttach(children.before[0]);
+jawsPerform("Inner", "Jid.1", JSON.stringify("<div>new</div>"));
+jawsVar("app.state", 5);
+
+process.stdout.write(JSON.stringify({
+	route: window.jawsNames.get("app") || null,
+	frame: jaws.sent[jaws.sent.length - 1] || "",
+}));
+`)
+
+	var got struct {
+		Route []string `json:"route"`
+		Frame string   `json:"frame"`
+	}
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unexpected JSON output %q: %v", raw, err)
+	}
+	if len(got.Route) != 1 || got.Route[0] != "Jid.3" {
+		t.Fatalf(`jawsNames.get("app") = %v, want the re-rendered [Jid.3]`, got.Route)
+	}
+	msg, ok := wire.Parse([]byte(got.Frame))
+	if !ok || msg.What != what.Set || msg.Jid != 3 || msg.Data != "state=5" {
+		t.Fatalf("write after re-render routed to %+v, parseable %t; want new binding Jid.3 state=5", msg, ok)
 	}
 }
 
@@ -516,7 +702,7 @@ func TestJawsJS_JsVarNestedPathHandlesShadowedHasOwnProperty(t *testing.T) {
 	WebSocket = FakeSocket;
 
 	window.app = { hasOwnProperty: 1, state: { value: 0 } };
-	window.jawsNames["app"] = "Jid.9";
+	window.jawsNames.set("app", ["Jid.9"]);
 	jaws = new FakeSocket();
 
 	jawsVar("app.state.value", 42);
@@ -769,7 +955,7 @@ window.app = { state: 0 };
 
 const routes = ["application-id", "Jid.0", "Jid.01", "Jid.-1", "Jid.7"];
 routes.forEach(function(id, i) {
-	window.jawsNames.app = id;
+	window.jawsNames.set("app", [id]);
 	jawsVar("app.state", i + 1);
 });
 process.stdout.write(JSON.stringify(jaws.sent));

--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -33,8 +33,9 @@ func validateJsVarName(value []any) (name string, err error) {
 			err = errIllegalJsVarName("illegal syntax")
 			return
 		}
-		// jaws.js stores top-level routes on a plain object. Assigning "__proto__"
-		// changes its prototype rather than creating an own route.
+		// A JsVar name is used as a property key on the browser window: jaws.js
+		// reads and writes window[name]. Assigning window["__proto__"] mutates the
+		// window's prototype instead of setting a normal property, so it is reserved.
 		if name == "__proto__" {
 			err = errIllegalJsVarName("reserved")
 		}
@@ -109,6 +110,18 @@ var (
 // when the JsVar is rendered. Existing application variables are therefore
 // valid bindings. Do not use a browser-owned property such as window.name, or a
 // global owned by unrelated code.
+//
+// Multiple bindings may share a name. The name is a single browser window
+// property, and a browser-initiated write to it is delivered to every live
+// binding of that name; a removed binding stops receiving writes. This lets a
+// subtree re-render replace a binding, lets several requests expose the same
+// application-owned global, and lets one browser value fan out to several
+// independent Go bindings.
+//
+// When bindings sharing a name also share backing state (the same locker and
+// Ptr), a browser write applies to that shared value once per binding. Do not
+// expose one Ptr through several simultaneously rendered bindings when its
+// [PathSetter] is not idempotent (for example one that appends).
 //
 // Unlike most JaWS UI values, a JsVar is a bidirectional channel and does not
 // imply that the Go value is always authoritative. Browser and Go updates may
@@ -303,6 +316,9 @@ func (jsvar *JsVar[T]) JawsSet(elem *jaws.Element, value T) (err error) {
 // params[0] must be a valid JsVar name. Otherwise, JawsRender returns
 // [ErrIllegalJsVarName] without writing markup.
 //
+// A name may be bound by more than one live binding; see [JsVar] for how a
+// browser write is delivered to every live binding of the name.
+//
 // The serialized value is a render-time snapshot. See [JsVar] for the
 // synchronization semantics between rendering and the WebSocket subscription.
 //
@@ -418,7 +434,8 @@ func isNilUI(ui jaws.UI) (yes bool) {
 // jsvarName identifies a property on the browser window. It should be owned by
 // the application because the binding initializes and updates its value.
 //
-// See [JsVar] for the bidirectional binding and synchronization semantics.
+// See [JsVar] for the bidirectional binding and synchronization semantics,
+// including how a name shared by several live bindings is routed.
 //
 // It returns [ErrIllegalJsVarName] if jsvarName is invalid or reserved.
 //

--- a/lib/ui/jsvar_name_test.go
+++ b/lib/ui/jsvar_name_test.go
@@ -67,3 +67,23 @@ func TestRequestWriterJsVarRejectsReservedPrototypeName(t *testing.T) {
 		t.Fatalf("RequestWriter.JsVar wrote rejected markup %q", output.String())
 	}
 }
+
+func TestJsVarRenderAllowsDuplicateNames(t *testing.T) {
+	_, rq := newCoreRequest(t)
+	var mu sync.Mutex
+
+	// Two bindings sharing a name both render without error; the browser delivers
+	// a write to every live binding of the name.
+	for _, text := range []string{"first", "second"} {
+		v := jsVarData{Text: text}
+		jsvar := NewJsVar(&mu, &v)
+		elem := rq.NewElement(jsvar)
+		var out strings.Builder
+		if err := jsvar.JawsRender(elem, &out, []any{"dup"}); err != nil {
+			t.Fatalf("JawsRender(%q) error = %v", text, err)
+		}
+		if out.Len() == 0 {
+			t.Fatalf("JawsRender(%q) wrote no markup", text)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #137. A duplicate request-scoped `JsVar` name previously overwrote the single `window.jawsNames[name]` routing slot, so removing the newer binding left routing pointing at a deleted Jid and subsequent browser writes silently failed.

Rejecting duplicates at render time turned out not to be viable: a normal subtree re-render legitimately renders the replacement binding while the old one is still registered server-side (browser cleanup is async), which the server cannot distinguish from a genuine coexisting duplicate. So instead, **duplicates are allowed and tracked on the browser**.

## What changed

- `window.jawsNames` is now a `Map` of name → list of live Jids.
- `jawsAttach` appends each binding's Jid; element removal (`Delete`/`Replace`/`Remove`, and descendant cleanup during `Inner`) drops it.
- A browser `jawsVar()` write **fans out to every live binding** of the name, so each bound Go value receives it — supporting both the shared-state pattern and a browser value feeding several independent Go consumers.
- `Inner` on a container correctly forgets the removed nested binding and re-registers the fresh one; `Inner` targeting a JsVar itself keeps its route (the element survives).
- The `Map` makes any name (including `__proto__`) a safe key. `__proto__` stays reserved server-side because a JsVar name is a property key on `window` and assigning `window["__proto__"]` mutates the window prototype.

### Caveat (documented)
When bindings share the same backing `Ptr`, a browser write applies once per binding, so a non-idempotent `PathSetter` (e.g. slice-append) should not be exposed through multiple simultaneously-rendered bindings.

## Tests
Node-driven JS tests cover fan-out to all live bindings, removal shrinking the set, `Inner`-keeps-route, re-render replacing a nested binding, and Map prototype-safety. Go tests confirm duplicate names render without error. `go test -race ./...`, `go vet`, `staticcheck`, `gofmt` all clean.