### PR TITLE
Document InputDate date-only, UTC-normalizing edit behavior (#124)

### DIFF
--- a/lib/ui/date.go
+++ b/lib/ui/date.go
@@ -9,9 +9,16 @@ import (
 )
 
 // Date renders an HTML date input bound to a time value setter.
+//
+// The control is date-only: a browser edit normalizes the bound [time.Time] to
+// midnight UTC of the picked date, discarding time-of-day and location. See
+// [InputDate.JawsInput].
 type Date struct{ InputDate }
 
 // NewDate returns a date input widget bound to g.
+//
+// The widget is date-only; see [InputDate.JawsInput] for how a browser edit
+// normalizes the bound [time.Time] to midnight UTC.
 func NewDate(g bind.Setter[time.Time]) *Date { return &Date{InputDate{Setter: g}} }
 
 // JawsRender renders ui as an HTML date input.
@@ -20,6 +27,10 @@ func (u *Date) JawsRender(elem *jaws.Element, w io.Writer, params []any) error {
 }
 
 // Date renders an HTML date input.
+//
+// The control is date-only: a browser edit normalizes the bound [time.Time] to
+// midnight UTC of the picked date, discarding time-of-day and location. See
+// [InputDate.JawsInput].
 func (rw RequestWriter) Date(value any, params ...any) error {
 	return rw.NewUI(NewDate(bind.MakeSetter[time.Time](value)), params...)
 }

--- a/lib/ui/input_widgets.go
+++ b/lib/ui/input_widgets.go
@@ -187,6 +187,10 @@ func (u *InputFloat) JawsInput(elem *jaws.Element, value string) (err error) {
 }
 
 // InputDate is the reusable base for date input widgets.
+//
+// The control is date-only. Rendering shows the calendar date in the bound
+// value's own location, but a browser edit normalizes the bound [time.Time] to
+// midnight UTC of the picked date; see [InputDate.JawsInput].
 type InputDate struct {
 	Input
 	bind.Setter[time.Time]
@@ -218,6 +222,14 @@ func (u *InputDate) JawsUpdate(elem *jaws.Element) {
 }
 
 // JawsInput stores a browser-side date input value.
+//
+// The browser sends a calendar date (YYYY-MM-DD), which [time.Parse] resolves
+// to midnight UTC, so the stored [time.Time] drops any time-of-day and
+// [time.Location] the previously bound value carried. In a non-UTC deployment
+// the stored instant therefore shifts by the zone offset, and because
+// [time.Time] inequality includes the location, re-selecting the same date
+// still reports a change and broadcasts it. Bind a date whose clock and zone are
+// irrelevant, or keep your bound values at midnight UTC to match.
 func (u *InputDate) JawsInput(elem *jaws.Element, value string) (err error) {
 	if value == "" {
 		value = "0001-01-01"

--- a/lib/ui/input_widgets_test.go
+++ b/lib/ui/input_widgets_test.go
@@ -311,6 +311,39 @@ func TestInputDateWidget(t *testing.T) {
 	date.JawsUpdate(elem)
 }
 
+// TestInputDate_BrowserEditNormalizesToMidnightUTC locks in the documented
+// date-only behavior (issue #124): the control renders/reads a calendar date, so
+// a browser edit resolves through time.Parse to midnight UTC and drops the bound
+// value's time-of-day and location. Re-selecting the same calendar date from a
+// non-UTC value still rewrites the bound value, because time.Time inequality
+// includes the location.
+func TestInputDate_BrowserEditNormalizesToMidnightUTC(t *testing.T) {
+	_, rq := newCoreRequest(t)
+	loc := time.FixedZone("CEST", 2*3600)
+	sd := newTestSetter(time.Date(2026, 7, 18, 15, 30, 0, 0, loc))
+
+	date := NewDate(sd)
+	elem, _ := renderUI(t, rq, date, "dateattr")
+
+	if err := date.JawsInput(elem, "2026-07-18"); err != nil {
+		t.Fatal(err)
+	}
+	got := sd.Get()
+	if want := time.Date(2026, 7, 18, 0, 0, 0, 0, time.UTC); !got.Equal(want) || got.Location() != time.UTC {
+		t.Fatalf("date edit did not normalize to midnight UTC: got %v", got)
+	}
+
+	// A no-op re-selection of the same calendar date from a non-UTC value still
+	// mutates the bound value to midnight UTC.
+	sd.Set(time.Date(2026, 7, 18, 0, 0, 0, 0, loc))
+	if err := date.JawsInput(elem, "2026-07-18"); err != nil {
+		t.Fatal(err)
+	}
+	if sd.Get().Location() != time.UTC {
+		t.Fatal("re-selecting the same date did not rewrite the bound value to UTC")
+	}
+}
+
 // TestInputDate_NoSpuriousUpdateOnEqualDate guards the dedup fix: two time.Time
 // values for the same calendar date but with different *Location pointers compare
 // unequal under ==, yet render to the same ISO8601 string. JawsUpdate must dedup


### PR DESCRIPTION
## What

Fixes #124 by documenting the `Date` widget's date-only, UTC-normalizing edit behavior (the "document it" alternative from the issue), rather than changing the round-trip semantics.

A browser date edit is parsed with `time.Parse` using a date-only layout (`2006-01-02`), which yields `00:00:00 UTC`. The bound `time.Time` is therefore replaced with midnight UTC of the picked date, discarding the previous value's time-of-day and `*time.Location`. In a non-UTC deployment this shifts the stored instant by the zone offset, and because `time.Time` inequality includes the location, re-selecting the same calendar date still reports a change and broadcasts it.

## Changes

- Document the behavior on the public surface: `Date`, `NewDate`, `RequestWriter.Date`, `InputDate`, and the authoritative note on `InputDate.JawsInput` (with godoc doc-links to `time.Time`/`time.Location`/`time.Parse`).
- Add `TestInputDate_BrowserEditNormalizesToMidnightUTC`, which turns the documented invariant into an executable guard: a browser edit normalizes a non-UTC bound value to midnight UTC, and a no-op re-selection of the same date still rewrites the bound value.

## Verification

- `gofmt`/`gofumpt`, `go vet`, `staticcheck`: clean
- `go build ./...`: clean
- `go test -race ./lib/ui/`: pass