### PR TITLE
ui: fix non-finite float values bound to Number/Range widgets

### DIFF
--- a/lib/ui/input_widgets.go
+++ b/lib/ui/input_widgets.go
@@ -142,7 +142,15 @@ func (u *InputFloat) renderFloatInput(elem *jaws.Element, w io.Writer, htmlType 
 		attrs := append(elem.ApplyParams(params), getterAttrs...)
 		v := u.JawsGet(elem)
 		u.Last.Store(v)
-		err = htmlio.WriteHTMLInput(w, elem.Jid(), htmlType, u.str(v), attrs)
+		// Emit the widget's own value attribute first so it owns the control. A
+		// non-finite value formats as "" (see [InputFloat.str]), and passing "" as
+		// the WriteHTMLInput value argument would omit the attribute, letting a
+		// caller-supplied value= from params or a binder's InitialHTMLAttr take over
+		// while the bound value stays non-finite. The HTML parser keeps the first of
+		// duplicate attributes, so a leading value="..." makes the widget's own value
+		// authoritative.
+		attrs = append([]template.HTMLAttr{htmlio.Attr("value", u.str(v))}, attrs...)
+		err = htmlio.WriteHTMLInput(w, elem.Jid(), htmlType, "", attrs)
 	}
 	return
 }

--- a/lib/ui/input_widgets.go
+++ b/lib/ui/input_widgets.go
@@ -126,21 +126,9 @@ type InputFloat struct {
 	bind.Setter[float64]
 }
 
-// str formats value for a browser number/range control.
-//
-// Non-finite values (NaN, ±Inf) map to the empty string, never the unparseable
-// literal "NaN"/"+Inf": [InputFloat.JawsInput] rejects non-finite browser input
-// with [bind.ErrFloatNotFinite], so emitting such a literal would be a value the
-// widget itself refuses on echo-back.
-//
-// For a [Number] this makes render and parse symmetric: the empty string renders
-// a blank control, exactly the in-progress edit state JawsInput reads back. A
-// [Range] cannot represent a non-finite (or even empty) value: per the WHATWG
-// value-sanitization rules a missing, empty, or invalid range value becomes the
-// control's default, the midpoint of its min and max, so the browser displays a
-// finite position while the bound value stays non-finite. That divergence is
-// inherent to the range control and is documented on [NewRange]; mapping to the
-// empty string at least avoids rendering a misleading literal.
+// str formats value for a number or range control, rendering non-finite values
+// (NaN, ±Inf) as the empty string rather than an unparseable "NaN"/"+Inf"
+// literal.
 func (u *InputFloat) str(value float64) string {
 	if math.IsNaN(value) || math.IsInf(value, 0) {
 		return ""

--- a/lib/ui/input_widgets.go
+++ b/lib/ui/input_widgets.go
@@ -126,7 +126,18 @@ type InputFloat struct {
 	bind.Setter[float64]
 }
 
+// str formats value for a browser number/range control.
+//
+// Non-finite values (NaN, ±Inf) map to the empty string so the render side
+// matches the parse-side contract: [InputFloat.JawsInput] rejects non-finite
+// browser input with [bind.ErrFloatNotFinite], and an <input type="number">
+// cannot represent them anyway, displaying blank. A server may still bind a
+// non-finite float64 (e.g. a computed 0.0/0.0), which then renders as an empty
+// control rather than an unparseable value="NaN".
 func (u *InputFloat) str(value float64) string {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return ""
+	}
 	return strconv.FormatFloat(value, 'f', -1, 64)
 }
 

--- a/lib/ui/input_widgets.go
+++ b/lib/ui/input_widgets.go
@@ -126,6 +126,10 @@ type InputFloat struct {
 	bind.Setter[float64]
 }
 
+// emptyValueAttr is the explicit value="" prepended for a non-finite float so
+// the widget still owns the value slot even though its formatted value is empty.
+var emptyValueAttr = htmlio.Attr("value", "")
+
 // str formats value for a number or range control, rendering non-finite values
 // (NaN, ±Inf) as the empty string rather than an unparseable "NaN"/"+Inf"
 // literal.
@@ -142,15 +146,17 @@ func (u *InputFloat) renderFloatInput(elem *jaws.Element, w io.Writer, htmlType 
 		attrs := append(elem.ApplyParams(params), getterAttrs...)
 		v := u.JawsGet(elem)
 		u.Last.Store(v)
-		// Emit the widget's own value attribute first so it owns the control. A
-		// non-finite value formats as "" (see [InputFloat.str]), and passing "" as
-		// the WriteHTMLInput value argument would omit the attribute, letting a
-		// caller-supplied value= from params or a binder's InitialHTMLAttr take over
-		// while the bound value stays non-finite. The HTML parser keeps the first of
-		// duplicate attributes, so a leading value="..." makes the widget's own value
-		// authoritative.
-		attrs = append([]template.HTMLAttr{htmlio.Attr("value", u.str(v))}, attrs...)
-		err = htmlio.WriteHTMLInput(w, elem.Jid(), htmlType, "", attrs)
+		// A finite value goes down the direct valueAttr path with no extra
+		// allocation. A non-finite value formats as "", which WriteHTMLInput would
+		// omit, letting a caller-supplied value= from params or a binder's
+		// InitialHTMLAttr take over the control while the bound value stays
+		// non-finite; prepend an explicit value="" so the widget owns the value slot
+		// (the HTML parser keeps the first of duplicate attributes).
+		s := u.str(v)
+		if s == "" {
+			attrs = append([]template.HTMLAttr{emptyValueAttr}, attrs...)
+		}
+		err = htmlio.WriteHTMLInput(w, elem.Jid(), htmlType, s, attrs)
 	}
 	return
 }

--- a/lib/ui/input_widgets.go
+++ b/lib/ui/input_widgets.go
@@ -128,12 +128,19 @@ type InputFloat struct {
 
 // str formats value for a browser number/range control.
 //
-// Non-finite values (NaN, ±Inf) map to the empty string so the render side
-// matches the parse-side contract: [InputFloat.JawsInput] rejects non-finite
-// browser input with [bind.ErrFloatNotFinite], and an <input type="number">
-// cannot represent them anyway, displaying blank. A server may still bind a
-// non-finite float64 (e.g. a computed 0.0/0.0), which then renders as an empty
-// control rather than an unparseable value="NaN".
+// Non-finite values (NaN, ±Inf) map to the empty string, never the unparseable
+// literal "NaN"/"+Inf": [InputFloat.JawsInput] rejects non-finite browser input
+// with [bind.ErrFloatNotFinite], so emitting such a literal would be a value the
+// widget itself refuses on echo-back.
+//
+// For a [Number] this makes render and parse symmetric: the empty string renders
+// a blank control, exactly the in-progress edit state JawsInput reads back. A
+// [Range] cannot represent a non-finite (or even empty) value: per the WHATWG
+// value-sanitization rules a missing, empty, or invalid range value becomes the
+// control's default, the midpoint of its min and max, so the browser displays a
+// finite position while the bound value stays non-finite. That divergence is
+// inherent to the range control and is documented on [NewRange]; mapping to the
+// empty string at least avoids rendering a misleading literal.
 func (u *InputFloat) str(value float64) string {
 	if math.IsNaN(value) || math.IsInf(value, 0) {
 		return ""

--- a/lib/ui/input_widgets_test.go
+++ b/lib/ui/input_widgets_test.go
@@ -195,20 +195,11 @@ func TestInputFloat_RejectsNonFinite(t *testing.T) {
 	}
 }
 
-// TestInputFloat_NonFiniteRendersEmpty verifies that a server-bound non-finite
-// float64 renders no unparseable value="NaN"/"+Inf" literal for either widget
-// that shares InputFloat.str. JawsInput rejects non-finite input from the
-// browser, so a rendered literal would be a value the widget refuses on
-// echo-back.
-//
-// For a number this makes render and parse symmetric: an empty value renders no
-// value= attribute at all, i.e. a blank control, exactly what the browser shows.
-// A range cannot be blank: the WHATWG value-sanitization rules coerce a missing,
-// empty, or invalid range value to the control's default midpoint, so the
-// browser still displays a finite position for a non-finite bound value. That
-// divergence is inherent to the range control (documented on NewRange); the most
-// this render-side test can guarantee for range is the absence of a misleading
-// literal, which it does.
+// TestInputFloat_NonFiniteRendersEmpty verifies that a non-finite bound float64
+// renders no unparseable value="NaN"/"+Inf" literal for either widget sharing
+// InputFloat.str. A number renders a blank control (no value attribute); a range
+// cannot be blank, so the browser shows its default midpoint instead, and this
+// render-side test only guarantees the absence of a misleading literal.
 func TestInputFloat_NonFiniteRendersEmpty(t *testing.T) {
 	_, rq := newCoreRequest(t)
 	widgets := []struct {

--- a/lib/ui/input_widgets_test.go
+++ b/lib/ui/input_widgets_test.go
@@ -196,10 +196,11 @@ func TestInputFloat_RejectsNonFinite(t *testing.T) {
 }
 
 // TestInputFloat_NonFiniteRendersEmpty verifies that a non-finite bound float64
-// renders no unparseable value="NaN"/"+Inf" literal for either widget sharing
-// InputFloat.str. A number renders a blank control (no value attribute); a range
-// cannot be blank, so the browser shows its default midpoint instead, and this
-// render-side test only guarantees the absence of a misleading literal.
+// renders an explicit empty value= attribute for either widget sharing
+// InputFloat.str, never the unparseable value="NaN"/"+Inf" literal. A number
+// then shows a blank control; a range shows the browser's constraint-sanitized
+// default value. The explicit value="" also lets the widget own the value slot,
+// which TestInputFloat_NonFiniteOwnsValueAttr covers.
 func TestInputFloat_NonFiniteRendersEmpty(t *testing.T) {
 	_, rq := newCoreRequest(t)
 	widgets := []struct {
@@ -214,12 +215,43 @@ func TestInputFloat_NonFiniteRendersEmpty(t *testing.T) {
 			f := v
 			sf := newTestSetter(f)
 			_, got := renderUI(t, rq, w.make(sf))
-			// An empty value renders no value= attribute at all.
-			mustMatch(t, `^<input id="Jid\.[0-9]+" type="`+w.htmlType+`">$`, got)
+			mustMatch(t, `^<input id="Jid\.[0-9]+" type="`+w.htmlType+`" value="">$`, got)
 			if strings.Contains(got, "NaN") || strings.Contains(got, "Inf") {
 				t.Fatalf("%s rendered non-finite literal for %v: %s", w.htmlType, v, got)
 			}
 		}
+	}
+}
+
+// TestInputFloat_NonFiniteOwnsValueAttr verifies that the widget's own value=
+// attribute takes precedence over a caller-supplied value= from params or a
+// binder's InitialHTMLAttr. A non-finite bound value formats as "", which
+// WriteHTMLInput would otherwise omit, letting the caller value= own the control
+// while the bound value stays non-finite. The widget emits a leading value="" so
+// the HTML parser (first duplicate attribute wins) keeps the widget's value.
+func TestInputFloat_NonFiniteOwnsValueAttr(t *testing.T) {
+	for _, htmlType := range []string{"number", "range"} {
+		make := func(g bind.Setter[float64]) jaws.UI { return NewNumber(g) }
+		if htmlType == "range" {
+			make = func(g bind.Setter[float64]) jaws.UI { return NewRange(g) }
+		}
+
+		// Caller value= via a raw string param. The widget's value="" precedes it,
+		// so the HTML parser keeps the widget's value.
+		_, rq := newCoreRequest(t)
+		sf := newTestSetter(math.NaN())
+		_, got := renderUI(t, rq, make(sf), `value="17"`)
+		mustMatch(t, `^<input id="Jid\.[0-9]+" type="`+htmlType+`" value="" value="17">$`, got)
+
+		// Caller value= via a binder InitialHTMLAttr hook, likewise preceded by the
+		// widget's own value="".
+		var mu deadlock.Mutex
+		f := math.NaN()
+		b := bind.New(&mu, &f).InitialHTMLAttr(func(bind.Binder[float64], *jaws.Element) template.HTMLAttr {
+			return `value="17"`
+		})
+		_, got = renderUI(t, rq, make(b))
+		mustMatch(t, `type="`+htmlType+`" value="" value="17"`, got)
 	}
 }
 

--- a/lib/ui/input_widgets_test.go
+++ b/lib/ui/input_widgets_test.go
@@ -195,6 +195,25 @@ func TestInputFloat_RejectsNonFinite(t *testing.T) {
 	}
 }
 
+// TestInputFloat_NonFiniteRendersEmpty verifies that a server-bound non-finite
+// float64 renders as an empty control rather than value="NaN"/"+Inf", which a
+// browser number/range input cannot represent and which JawsInput would itself
+// reject on echo-back. This keeps the render side symmetric with the parse side.
+func TestInputFloat_NonFiniteRendersEmpty(t *testing.T) {
+	_, rq := newCoreRequest(t)
+	for _, v := range []float64{math.NaN(), math.Inf(1), math.Inf(-1)} {
+		f := v
+		sf := newTestSetter(f)
+		_, got := renderUI(t, rq, NewNumber(sf))
+		// An empty value renders no value= attribute at all: a blank control,
+		// which is exactly what the browser shows for a non-finite value.
+		mustMatch(t, `^<input id="Jid\.[0-9]+" type="number">$`, got)
+		if strings.Contains(got, "NaN") || strings.Contains(got, "Inf") {
+			t.Fatalf("rendered non-finite literal for %v: %s", v, got)
+		}
+	}
+}
+
 func TestInputFloat_RegisterSendsInitialZeroValue(t *testing.T) {
 	jw, err := jaws.New()
 	if err != nil {
@@ -227,7 +246,8 @@ func TestInputFloat_RegisterSendsInitialZeroValue(t *testing.T) {
 
 // TestInputFloat_NaNBoundValueDoesNotReemit verifies that a server-bound NaN value
 // is sent once on transition but not re-emitted on every subsequent update. NaN != NaN
-// would otherwise defeat the JawsUpdate dedup and re-send SetValue each cycle.
+// would otherwise defeat the JawsUpdate dedup and re-send SetValue each cycle. The
+// transition sends an empty control (not "NaN"), matching the parse-side contract.
 func TestInputFloat_NaNBoundValueDoesNotReemit(t *testing.T) {
 	jw, err := jaws.New()
 	if err != nil {
@@ -265,12 +285,12 @@ func TestInputFloat_NaNBoundValueDoesNotReemit(t *testing.T) {
 		}
 	}
 
-	// A real transition to NaN is sent once.
+	// A real transition to NaN is sent once, as an empty control.
 	sf.Set(math.NaN())
 	number.JawsUpdate(elem)
 	tr.InCh <- wire.WsMsg{} // wake the loop so the queued op flushes to OutCh
-	if v, ok := waitValue(); !ok || v != "NaN" {
-		t.Fatalf("expected one SetValue %q on transition to NaN, got ok=%v v=%q", "NaN", ok, v)
+	if v, ok := waitValue(); !ok || v != "" {
+		t.Fatalf("expected one SetValue %q on transition to NaN, got ok=%v v=%q", "", ok, v)
 	}
 
 	// The value is still NaN: further updates must not re-emit.

--- a/lib/ui/input_widgets_test.go
+++ b/lib/ui/input_widgets_test.go
@@ -196,20 +196,38 @@ func TestInputFloat_RejectsNonFinite(t *testing.T) {
 }
 
 // TestInputFloat_NonFiniteRendersEmpty verifies that a server-bound non-finite
-// float64 renders as an empty control rather than value="NaN"/"+Inf", which a
-// browser number/range input cannot represent and which JawsInput would itself
-// reject on echo-back. This keeps the render side symmetric with the parse side.
+// float64 renders no unparseable value="NaN"/"+Inf" literal for either widget
+// that shares InputFloat.str. JawsInput rejects non-finite input from the
+// browser, so a rendered literal would be a value the widget refuses on
+// echo-back.
+//
+// For a number this makes render and parse symmetric: an empty value renders no
+// value= attribute at all, i.e. a blank control, exactly what the browser shows.
+// A range cannot be blank: the WHATWG value-sanitization rules coerce a missing,
+// empty, or invalid range value to the control's default midpoint, so the
+// browser still displays a finite position for a non-finite bound value. That
+// divergence is inherent to the range control (documented on NewRange); the most
+// this render-side test can guarantee for range is the absence of a misleading
+// literal, which it does.
 func TestInputFloat_NonFiniteRendersEmpty(t *testing.T) {
 	_, rq := newCoreRequest(t)
-	for _, v := range []float64{math.NaN(), math.Inf(1), math.Inf(-1)} {
-		f := v
-		sf := newTestSetter(f)
-		_, got := renderUI(t, rq, NewNumber(sf))
-		// An empty value renders no value= attribute at all: a blank control,
-		// which is exactly what the browser shows for a non-finite value.
-		mustMatch(t, `^<input id="Jid\.[0-9]+" type="number">$`, got)
-		if strings.Contains(got, "NaN") || strings.Contains(got, "Inf") {
-			t.Fatalf("rendered non-finite literal for %v: %s", v, got)
+	widgets := []struct {
+		htmlType string
+		make     func(bind.Setter[float64]) jaws.UI
+	}{
+		{"number", func(g bind.Setter[float64]) jaws.UI { return NewNumber(g) }},
+		{"range", func(g bind.Setter[float64]) jaws.UI { return NewRange(g) }},
+	}
+	for _, w := range widgets {
+		for _, v := range []float64{math.NaN(), math.Inf(1), math.Inf(-1)} {
+			f := v
+			sf := newTestSetter(f)
+			_, got := renderUI(t, rq, w.make(sf))
+			// An empty value renders no value= attribute at all.
+			mustMatch(t, `^<input id="Jid\.[0-9]+" type="`+w.htmlType+`">$`, got)
+			if strings.Contains(got, "NaN") || strings.Contains(got, "Inf") {
+				t.Fatalf("%s rendered non-finite literal for %v: %s", w.htmlType, v, got)
+			}
 		}
 	}
 }

--- a/lib/ui/number.go
+++ b/lib/ui/number.go
@@ -11,6 +11,9 @@ import (
 type Number struct{ InputFloat }
 
 // NewNumber returns a number input widget bound to g.
+//
+// A non-finite bound value (NaN or ±Inf) renders as a blank control rather than
+// an unparseable value. Contrast [NewRange], whose control cannot be blank.
 func NewNumber(g bind.Setter[float64]) *Number { return &Number{InputFloat{Setter: g}} }
 
 // JawsRender renders ui as an HTML number input.
@@ -19,6 +22,8 @@ func (u *Number) JawsRender(elem *jaws.Element, w io.Writer, params []any) error
 }
 
 // Number renders an HTML number input.
+//
+// See [NewNumber] for how a non-finite bound value renders.
 func (rw RequestWriter) Number(value any, params ...any) error {
 	return rw.NewUI(NewNumber(bind.MakeSetterFloat64(value)), params...)
 }

--- a/lib/ui/range.go
+++ b/lib/ui/range.go
@@ -13,9 +13,9 @@ type Range struct{ InputFloat }
 // NewRange returns a range input widget bound to g.
 //
 // A range control cannot display a non-finite value: a bound NaN or ±Inf shows
-// as the control's default position (the midpoint of its min and max) while the
-// bound value stays non-finite. Use [NewNumber] if the bound value may be
-// non-finite.
+// as the browser's constraint-sanitized default value for the control, not a
+// blank field, while the bound value stays non-finite. Use [NewNumber] if the
+// bound value may be non-finite.
 func NewRange(g bind.Setter[float64]) *Range { return &Range{InputFloat{Setter: g}} }
 
 // JawsRender renders ui as an HTML range input.
@@ -24,6 +24,8 @@ func (u *Range) JawsRender(elem *jaws.Element, w io.Writer, params []any) error 
 }
 
 // Range renders an HTML range input.
+//
+// See [NewRange] for how a non-finite bound value renders.
 func (rw RequestWriter) Range(value any, params ...any) error {
 	return rw.NewUI(NewRange(bind.MakeSetterFloat64(value)), params...)
 }

--- a/lib/ui/range.go
+++ b/lib/ui/range.go
@@ -11,6 +11,14 @@ import (
 type Range struct{ InputFloat }
 
 // NewRange returns a range input widget bound to g.
+//
+// A range control cannot represent a non-finite bound value. Per the WHATWG
+// value-sanitization rules a missing, empty, or invalid range value is coerced
+// to the control's default (the midpoint of its min and max), so a bound NaN or
+// ±Inf displays as that finite position while the server value stays non-finite.
+// The widget renders no unparseable literal for such values, but unlike
+// [NewNumber] the display cannot be blank. Bind a finite value to a range, or use
+// a [NewNumber] when non-finite values are possible.
 func NewRange(g bind.Setter[float64]) *Range { return &Range{InputFloat{Setter: g}} }
 
 // JawsRender renders ui as an HTML range input.

--- a/lib/ui/range.go
+++ b/lib/ui/range.go
@@ -12,13 +12,10 @@ type Range struct{ InputFloat }
 
 // NewRange returns a range input widget bound to g.
 //
-// A range control cannot represent a non-finite bound value. Per the WHATWG
-// value-sanitization rules a missing, empty, or invalid range value is coerced
-// to the control's default (the midpoint of its min and max), so a bound NaN or
-// ±Inf displays as that finite position while the server value stays non-finite.
-// The widget renders no unparseable literal for such values, but unlike
-// [NewNumber] the display cannot be blank. Bind a finite value to a range, or use
-// a [NewNumber] when non-finite values are possible.
+// A range control cannot display a non-finite value: a bound NaN or ±Inf shows
+// as the control's default position (the midpoint of its min and max) while the
+// bound value stays non-finite. Use [NewNumber] if the bound value may be
+// non-finite.
 func NewRange(g bind.Setter[float64]) *Range { return &Range{InputFloat{Setter: g}} }
 
 // JawsRender renders ui as an HTML range input.


### PR DESCRIPTION
## Summary

Fixes #125.

A `NaN`/`±Inf` value bound to a `Number` or `Range` widget rendered as `value="NaN"` / `value="+Inf"`, which a browser number/range control cannot represent and which `InputFloat.JawsInput` itself rejects with `bind.ErrFloatNotFinite` on echo-back — an asymmetric render-vs-parse contract where the server value and browser display diverged with no way to reconcile from the client.

`NewNumber`/`NewRange` bind a plain `float64` and place no documented restriction on finiteness, so a computed non-finite value (e.g. `0.0/0.0`) is legitimate, not misuse.

## Change

`InputFloat.str` maps non-finite values (`NaN`, `±Inf`) to the empty string instead of an unparseable literal. `renderFloatInput` emits the widget's own `value` attribute first so it owns the control: a non-finite value renders an explicit `value=""`, and because the HTML parser keeps the first of duplicate attributes, a caller-supplied `value=` (from params or a binder `InitialHTMLAttr`) can no longer take over the value slot while the bound value stays non-finite.

The two widgets differ in what the browser then shows, and this is documented:

- **Number**: `value=""` is a genuinely blank control — render and parse are symmetric (`JawsInput` treats empty as the in-progress edit state).
- **Range**: a range control cannot be blank. Per the WHATWG value-sanitization rules the browser coerces a missing/empty/invalid range value to its **constraint-sanitized default value** (near the min/max midpoint, adjusted by `step`, or the min when `max < min`) while the bound value stays non-finite. This divergence is inherent to the range control; the empty `value=""` only ensures no misleading literal is rendered and that the widget owns the value slot. `NewRange` and `RequestWriter.Range` document this; use `NewNumber` when non-finite values are possible.

`JawsUpdate`'s existing NaN dedup is untouched: a bound `NaN` is still sent once on a real transition (now as `value=""` rather than `"NaN"`) and is not re-emitted on every update cycle.

## Tests

- `TestInputFloat_NonFiniteRendersEmpty`: `NaN`, `+Inf`, `-Inf` each render an explicit `value=""` with no `NaN`/`Inf` literal, for both `number` and `range`.
- `TestInputFloat_NonFiniteOwnsValueAttr`: a caller `value="17"` supplied via a raw param and via a binder `InitialHTMLAttr` is preceded by the widget's own `value=""`, so the widget's value wins — for both widgets.
- `TestInputFloat_NaNBoundValueDoesNotReemit`: the one-shot transition expects an empty `SetValue` and still asserts no re-emit on subsequent updates.

Package coverage remains 100% under `-race`. `go vet`, `gofumpt`, `staticcheck`, `golangci-lint`, `go build`, and `go test -race ./...` all pass.