### PR TITLE
bind: size float→int range check to the target word size

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,30 @@ jobs:
       - name: Build
         run: go build -v ./...
 
+  build-386:
+    # 32-bit leg: on GOARCH=386 int/uint are 32-bit, so this exercises the
+    # word-size-dependent bounds in lib/bind that the amd64 leg cannot reach.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: stable
+
+      - name: Test lib/bind (386)
+        env:
+          GOARCH: "386"
+          # The race detector is unavailable on 386; disable cgo so the pure-Go
+          # test binary is statically linked and runs under 32-bit emulation.
+          CGO_ENABLED: "0"
+        run: go test ./lib/bind/...
+
   coverage:
     needs: build
     runs-on: ubuntu-latest

--- a/lib/bind/setterfloat64.go
+++ b/lib/bind/setterfloat64.go
@@ -33,10 +33,15 @@ type setterFloat64[T numeric] struct {
 // The conversion T(value) truncates toward zero, so the lower bound is compared
 // against math.Trunc(value): a fractional value like -128.5 truncates to the valid
 // int8 -128 and is accepted, mirroring the high end where 127.5 truncates to 127.
-// The upper bound stays an exclusive power of two to avoid the float64 rounding
-// pitfall at the top of the 64-bit ranges (float64(MaxInt64) rounds up to 2^63),
-// where truncation cannot be used; the low bound MinIntN is exactly representable
-// for every width, so comparing the truncated value there is safe.
+//
+// The exclusive upper bound MaxIntN+1 is an exact power of two: the +1 is
+// untyped-constant (arbitrary-precision) arithmetic evaluated before the single
+// float64 conversion, so it avoids the float64(MaxInt64) rounding pitfall (that
+// conversion rounds up to 2^63). MinIntN is exactly representable for every width,
+// so comparing the truncated value against it is safe. The int and uint bounds use
+// math.MinInt, math.MaxInt and math.MaxUint, which track the target word size, so a
+// 32-bit build rejects magnitudes that only fit a 64-bit word instead of letting
+// T(value) wrap.
 //
 // The type switch matches predeclared types by exact type, so callers must
 // instantiate T only with the predeclared numeric types. A named (defined) type
@@ -56,16 +61,20 @@ func sanitizeFloatForT[T numeric](value float64) error {
 		lo, hiExcl = math.MinInt16, math.MaxInt16+1
 	case int32:
 		lo, hiExcl = math.MinInt32, math.MaxInt32+1
-	case int, int64: // int is 64-bit on all supported platforms
-		lo, hiExcl = math.MinInt64, -float64(math.MinInt64) // [-2^63, 2^63)
+	case int: // math.MinInt/math.MaxInt track the target word size
+		lo, hiExcl = math.MinInt, math.MaxInt+1
+	case int64:
+		lo, hiExcl = math.MinInt64, math.MaxInt64+1
 	case uint8:
 		lo, hiExcl = 0, math.MaxUint8+1
 	case uint16:
 		lo, hiExcl = 0, math.MaxUint16+1
 	case uint32:
 		lo, hiExcl = 0, math.MaxUint32+1
-	case uint, uint64: // uint is 64-bit on all supported platforms
-		lo, hiExcl = 0, -2*float64(math.MinInt64) // [0, 2^64)
+	case uint: // math.MaxUint tracks the target word size
+		lo, hiExcl = 0, math.MaxUint+1
+	case uint64:
+		lo, hiExcl = 0, math.MaxUint64+1
 	default:
 		// float32 or float64: reject a finite value that overflows the target type.
 		// A float64 that exceeds the float32 range converts to ±Inf and silently

--- a/lib/bind/setterfloat64_test.go
+++ b/lib/bind/setterfloat64_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"math"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -128,8 +129,15 @@ func Test_setterFloat64_sanitizesUntrustedInput(t *testing.T) {
 		if ts.Get() != 7 {
 			t.Errorf("bound value mutated to %v", ts.Get())
 		}
-		if err := s.JawsSet(nil, 1<<62); err != nil { // safely in range
-			t.Fatalf("JawsSet(2^62): %v", err)
+		// A value safely below the top of int's range must be accepted, proving the
+		// 2^63 rejection is not a float64-rounding false positive. int's width is
+		// word-size-dependent, so probe with a value that fits the target int.
+		inRange := float64(1 << 62) // safely inside a 64-bit int
+		if strconv.IntSize == 32 {
+			inRange = 1 << 30 // safely inside a 32-bit int
+		}
+		if err := s.JawsSet(nil, inRange); err != nil {
+			t.Fatalf("JawsSet(%v): %v", inRange, err)
 		}
 	})
 }
@@ -181,6 +189,31 @@ func Test_setterFloat64_coversNumericTypes(t *testing.T) {
 	}
 	if err := fs.JawsSet(nil, -1e40); !errors.Is(err, ErrFloatOutOfRange) {
 		t.Errorf("float32 -1e40: got %v, want ErrFloatOutOfRange", err)
+	}
+}
+
+// Test_setterFloat64_intBoundsTrackWordSize pins that the int and uint guards
+// follow the target word size rather than assuming 64 bits. 2^31 fits a 64-bit
+// int but overflows a 32-bit int, and 2^32 fits a 64-bit uint but overflows a
+// 32-bit uint; on a 32-bit build these must be rejected instead of silently
+// wrapping in the float->int conversion, and on a 64-bit build they stay in range.
+func Test_setterFloat64_intBoundsTrackWordSize(t *testing.T) {
+	intErr := sanitizeFloatForT[int](1 << 31)   // 2^31 = MaxInt32 + 1
+	uintErr := sanitizeFloatForT[uint](1 << 32) // 2^32 = MaxUint32 + 1
+	if strconv.IntSize == 32 {
+		if !errors.Is(intErr, ErrFloatOutOfRange) {
+			t.Errorf("32-bit int 2^31: got %v, want ErrFloatOutOfRange", intErr)
+		}
+		if !errors.Is(uintErr, ErrFloatOutOfRange) {
+			t.Errorf("32-bit uint 2^32: got %v, want ErrFloatOutOfRange", uintErr)
+		}
+		return
+	}
+	if intErr != nil {
+		t.Errorf("64-bit int 2^31: got %v, want nil", intErr)
+	}
+	if uintErr != nil {
+		t.Errorf("64-bit uint 2^32: got %v, want nil", uintErr)
 	}
 }
 


### PR DESCRIPTION
Fixes #126.

## Problem

`sanitizeFloatForT` in `lib/bind/setterfloat64.go` range-checked `int` and `uint` against the **64-bit** bounds. On a 32-bit build (`GOARCH=386`/`arm`) `int`/`uint` are 32-bit, so an untrusted browser value in `(2^31, 2^63)` passed the guard and then wrapped in the `T(value)` conversion (implementation-defined float→int overflow), silently corrupting the bound variable. `GOARCH=arm` (32-bit Raspberry Pi OS) is a real deployment target and CI only built `amd64`, so the path was never exercised.

## Fix

Select the `int`/`uint` bounds from `math.MinInt`, `math.MaxInt` and `math.MaxUint`, which are themselves word-size-dependent constants (they track `strconv.IntSize`). The guard now matches the `T(value)` conversion it protects on both 32- and 64-bit builds, with no runtime branch.

The whole type switch is now uniform — every signed type uses `math.MinIntN, math.MaxIntN+1` and every unsigned type `0, math.MaxUintN+1`. `MaxIntN+1` stays an *exact* power of two because the `+1` is untyped-constant (arbitrary-precision) arithmetic evaluated before the single `float64` conversion, so it sidesteps the `float64(MaxInt64)`-rounds-up-to-2^63 pitfall (the `int64`/`uint64` cases produce byte-identical bounds to the previous `-float64(math.MinInt64)` forms).

## Regression coverage

- **Test:** `Test_setterFloat64_intBoundsTrackWordSize` asserts `2^31` (int) and `2^32` (uint) are rejected on a 32-bit build and accepted on a 64-bit build.
- **CI:** a new `build-386` leg runs `go test ./lib/bind/...` under `GOARCH=386` (`CGO_ENABLED=0`, since `-race` is unavailable there) so the 32-bit path is actually executed.

## Verification

- `go test -race ./...` — full module suite green; `lib/bind` at 100% statement coverage.
- `go vet ./...`, `gofmt -l .`, `staticcheck ./lib/bind/...` — clean.
- `GOOS=linux GOARCH=386 go build/vet ./lib/bind/...` — clean cross-compile; the 32-bit selection + check logic was verified to reject the previously-wrapping range (e.g. `3e9` for int, `5e9` for uint) with 32-bit constants.