### PR TITLE
jawstree: bound oversized and pathologically deep trees in New

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
 
   build-386:
     # 32-bit leg: on GOARCH=386 int/uint are 32-bit, so this exercises the
-    # word-size-dependent bounds in lib/bind that the amd64 leg cannot reach.
+    # word-size-dependent bounds in lib/bind and jawstree that the amd64 leg cannot reach.
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -93,13 +93,15 @@ jobs:
         with:
           go-version: stable
 
-      - name: Test lib/bind (386)
+      - name: Test lib/bind and jawstree (386)
         env:
           GOARCH: "386"
           # The race detector is unavailable on 386; disable cgo so the pure-Go
           # test binary is statically linked and runs under 32-bit emulation.
           CGO_ENABLED: "0"
-        run: go test ./lib/bind/...
+        # -short on jawstree skips the multi-hundred-MiB boundary trees but keeps the
+        # 32-bit render-byte overflow guard (TestNew_RejectsLargeNameNoOverflow).
+        run: go test ./lib/bind/... && go test -short ./jawstree/...
 
   coverage:
     needs: build

--- a/jawstree/README.md
+++ b/jawstree/README.md
@@ -115,10 +115,12 @@ sharing it is safe.
 
 `New` takes the lock guarding the tree (which may be shared with other application
 state) and the root `*Node`. It returns `ErrInvalidTree` for an invalid graph
-(nil, cyclic, shared node, unknown option bit, or more than `MaxTreeNodes` nodes)
-and `ErrInvalidSelection` when the initial `Selected` flags violate the mode's
-policy. It assigns each node's positional-path ID, a preorder wire index, and the
-parent back-pointers the name-path API needs, so it must run before rendering.
+(nil, cyclic, shared node, unknown option bit, more than `MaxTreeNodes` nodes,
+nesting deeper than `MaxTreeDepth`, or positional-path IDs totalling more than
+`MaxTreePathBytes`) and `ErrInvalidSelection` when the initial `Selected` flags
+violate the mode's policy. It assigns each node's positional-path ID, a preorder
+wire index, and the parent back-pointers the name-path API needs, so it must run
+before rendering.
 After a tree is rendered, mutate selection through `Tree.SetSelected` or browser
 events, but do not add, remove or reorder `Children`; that breaks the
 ID-to-wire-position mapping used by Quercus.js.

--- a/jawstree/README.md
+++ b/jawstree/README.md
@@ -116,7 +116,7 @@ sharing it is safe.
 `New` takes the lock guarding the tree (which may be shared with other application
 state) and the root `*Node`. It returns `ErrInvalidTree` for an invalid graph
 (nil, cyclic, shared node, unknown option bit, more than `MaxTreeNodes` nodes,
-nesting deeper than `MaxTreeDepth`, or depth-weighted positional-path IDs
+nesting deeper than `MaxTreeDepth`, or depth-weighted serialized node data
 exceeding `MaxTreeRenderBytes`) and `ErrInvalidSelection` when the initial
 `Selected` flags violate the mode's policy. It assigns each node's positional-path
 ID, a preorder wire index, and the parent back-pointers the name-path API needs, so

--- a/jawstree/README.md
+++ b/jawstree/README.md
@@ -123,9 +123,11 @@ ID, a preorder wire index, and the parent back-pointers the name-path API needs,
 it must run before rendering.
 Once `New` returns, only the selection may change, through `Tree.SetSelected` or
 browser events. Each node's `Name`, `Disabled`, assigned ID, and the topology
-(`Children`) are fixed; changing any of them afterward is unsupported: it breaks the
-ID-to-wire-position mapping used by Quercus.js and, since rendering re-serializes the
-live tree, can defeat the size bounds `New` enforced.
+(`Children`) are fixed; changing any of them afterward is unsupported, with a different
+consequence per field: altering the topology or an ID breaks the ID-to-wire-position
+mapping used by Quercus.js; enlarging a `Name` defeats the size bounds `New` enforced
+(rendering re-serializes the live tree); toggling `Disabled` can desync the selection
+policy.
 
 Build a `Node` tree (by hand, or from a directory with `Root`) and pass it with a
 lock to `New`. Browser correlation keys and HTML ids are managed internally:

--- a/jawstree/README.md
+++ b/jawstree/README.md
@@ -121,9 +121,11 @@ exceeding `MaxTreeRenderBytes`) and `ErrInvalidSelection` when the initial
 `Selected` flags violate the mode's policy. It assigns each node's positional-path
 ID, a preorder wire index, and the parent back-pointers the name-path API needs, so
 it must run before rendering.
-After a tree is rendered, mutate selection through `Tree.SetSelected` or browser
-events, but do not add, remove or reorder `Children`; that breaks the
-ID-to-wire-position mapping used by Quercus.js.
+Once `New` returns, only the selection may change, through `Tree.SetSelected` or
+browser events. Each node's `Name`, `Disabled`, assigned ID, and the topology
+(`Children`) are fixed; changing any of them afterward is unsupported: it breaks the
+ID-to-wire-position mapping used by Quercus.js and, since rendering re-serializes the
+live tree, can defeat the size bounds `New` enforced.
 
 Build a `Node` tree (by hand, or from a directory with `Root`) and pass it with a
 lock to `New`. Browser correlation keys and HTML ids are managed internally:

--- a/jawstree/README.md
+++ b/jawstree/README.md
@@ -116,11 +116,11 @@ sharing it is safe.
 `New` takes the lock guarding the tree (which may be shared with other application
 state) and the root `*Node`. It returns `ErrInvalidTree` for an invalid graph
 (nil, cyclic, shared node, unknown option bit, more than `MaxTreeNodes` nodes,
-nesting deeper than `MaxTreeDepth`, or positional-path IDs totalling more than
-`MaxTreePathBytes`) and `ErrInvalidSelection` when the initial `Selected` flags
-violate the mode's policy. It assigns each node's positional-path ID, a preorder
-wire index, and the parent back-pointers the name-path API needs, so it must run
-before rendering.
+nesting deeper than `MaxTreeDepth`, or depth-weighted positional-path IDs
+exceeding `MaxTreeRenderBytes`) and `ErrInvalidSelection` when the initial
+`Selected` flags violate the mode's policy. It assigns each node's positional-path
+ID, a preorder wire index, and the parent back-pointers the name-path API needs, so
+it must run before rendering.
 After a tree is rendered, mutate selection through `Tree.SetSelected` or browser
 events, but do not add, remove or reorder `Children`; that breaks the
 ID-to-wire-position mapping used by Quercus.js.

--- a/jawstree/errinvalidtree.go
+++ b/jawstree/errinvalidtree.go
@@ -5,7 +5,7 @@ import "errors"
 // ErrInvalidTree is returned by [New] when the supplied node graph cannot back a
 // [Tree]: a nil root, a cyclic or shared-node graph (a node reachable more than
 // once), a negative or unknown [Option] bit, more nodes than [MaxTreeNodes], nesting
-// deeper than [MaxTreeDepth], or depth-weighted positional-path IDs exceeding
+// deeper than [MaxTreeDepth], or depth-weighted serialized node data exceeding
 // [MaxTreeRenderBytes]. The error text carries the specific reason; match the class
 // with [errors.Is].
 var ErrInvalidTree = errors.New("jawstree: invalid tree")

--- a/jawstree/errinvalidtree.go
+++ b/jawstree/errinvalidtree.go
@@ -4,6 +4,8 @@ import "errors"
 
 // ErrInvalidTree is returned by [New] when the supplied node graph cannot back a
 // [Tree]: a nil root, a cyclic or shared-node graph (a node reachable more than
-// once), a negative or unknown [Option] bit, or more nodes than [MaxTreeNodes].
-// The error text carries the specific reason; match the class with [errors.Is].
+// once), a negative or unknown [Option] bit, more nodes than [MaxTreeNodes], or
+// positional-path IDs totalling more than [MaxTreePathBytes] (a pathologically deep
+// tree). The error text carries the specific reason; match the class with
+// [errors.Is].
 var ErrInvalidTree = errors.New("jawstree: invalid tree")

--- a/jawstree/errinvalidtree.go
+++ b/jawstree/errinvalidtree.go
@@ -5,7 +5,7 @@ import "errors"
 // ErrInvalidTree is returned by [New] when the supplied node graph cannot back a
 // [Tree]: a nil root, a cyclic or shared-node graph (a node reachable more than
 // once), a negative or unknown [Option] bit, more nodes than [MaxTreeNodes], nesting
-// deeper than [MaxTreeDepth], or positional-path IDs totalling more than
-// [MaxTreePathBytes]. The error text carries the specific reason; match the class
+// deeper than [MaxTreeDepth], or depth-weighted positional-path IDs exceeding
+// [MaxTreeRenderBytes]. The error text carries the specific reason; match the class
 // with [errors.Is].
 var ErrInvalidTree = errors.New("jawstree: invalid tree")

--- a/jawstree/errinvalidtree.go
+++ b/jawstree/errinvalidtree.go
@@ -4,8 +4,8 @@ import "errors"
 
 // ErrInvalidTree is returned by [New] when the supplied node graph cannot back a
 // [Tree]: a nil root, a cyclic or shared-node graph (a node reachable more than
-// once), a negative or unknown [Option] bit, more nodes than [MaxTreeNodes], or
-// positional-path IDs totalling more than [MaxTreePathBytes] (a pathologically deep
-// tree). The error text carries the specific reason; match the class with
-// [errors.Is].
+// once), a negative or unknown [Option] bit, more nodes than [MaxTreeNodes], nesting
+// deeper than [MaxTreeDepth], or positional-path IDs totalling more than
+// [MaxTreePathBytes]. The error text carries the specific reason; match the class
+// with [errors.Is].
 var ErrInvalidTree = errors.New("jawstree: invalid tree")

--- a/jawstree/gate_test.go
+++ b/jawstree/gate_test.go
@@ -58,17 +58,26 @@ func TestNew_RejectsCyclicAndSharedGraphs(t *testing.T) {
 	})
 }
 
-func TestNew_RejectsOverCap(t *testing.T) {
+// TestNew_NodeCapBoundary pins the exact node-count cutoff: a tree of exactly
+// MaxTreeNodes nodes is accepted and one node more is rejected. The tree is a shallow
+// fan (depth 1), so neither the depth nor the render-byte bound can fire and only the
+// node cap governs.
+func TestNew_NodeCapBoundary(t *testing.T) {
 	if testing.Short() {
 		t.Skip("builds a MaxTreeNodes+1 tree")
 	}
-	children := make([]*Node, MaxTreeNodes+1)
+	// MaxTreeNodes children plus the root is MaxTreeNodes+1 nodes; the first
+	// MaxTreeNodes-1 children plus the root is exactly MaxTreeNodes.
+	children := make([]*Node, MaxTreeNodes)
 	for i := range children {
 		children[i] = &Node{Name: "n"}
 	}
 	var mu sync.Mutex
+	if _, err := New(&mu, &Node{Children: children[:MaxTreeNodes-1]}); err != nil {
+		t.Fatalf("exactly MaxTreeNodes nodes should be accepted, got %v", err)
+	}
 	if _, err := New(&mu, &Node{Children: children}); !errors.Is(err, ErrInvalidTree) {
-		t.Fatalf("err = %v, want ErrInvalidTree", err)
+		t.Fatalf("MaxTreeNodes+1 nodes err = %v, want ErrInvalidTree", err)
 	}
 }
 
@@ -109,12 +118,11 @@ func buildChain(descendants int) *Node {
 }
 
 // TestNew_RejectsTreeDeeperThanMaxTreeDepth pins the depth bound that keeps a tree the
-// browser cannot render from reaching the client: the vendored treeview.js recurses per
-// level and stores each node's whole subtree on its element, so an over-deep tree would
-// overflow the browser stack and retain data growing with the cube of the depth. New
-// accepts a chain exactly at MaxTreeDepth and rejects one a single level deeper with
-// ErrInvalidTree. Both stay far below MaxTreeNodes and MaxTreePathBytes, so only the
-// depth bound can reject the deeper one.
+// browser cannot render from reaching the client: the vendored treeview.js recurses
+// once per level, so an over-deep tree would overflow the browser stack. New accepts a
+// chain exactly at MaxTreeDepth and rejects one a single level deeper with
+// ErrInvalidTree. Such a chain stays far below MaxTreeNodes, and its depth-weighted ID
+// bytes stay under MaxTreeRenderBytes, so only the depth bound can reject the deeper one.
 func TestNew_RejectsTreeDeeperThanMaxTreeDepth(t *testing.T) {
 	var mu sync.Mutex
 	if _, err := New(&mu, buildChain(MaxTreeDepth)); err != nil {
@@ -125,29 +133,28 @@ func TestNew_RejectsTreeDeeperThanMaxTreeDepth(t *testing.T) {
 	}
 }
 
-// TestNew_RejectsDeepTreeByPathBytes pins that New bounds the quadratic positional-ID
-// growth independently of the depth and node-count bounds: a tree within MaxTreeDepth
-// and MaxTreeNodes, but whose cumulative ID bytes exceed MaxTreePathBytes, is rejected
-// with ErrInvalidTree rather than retaining tens of MiB of paths.
+// TestNew_RejectsWideDeepTreeByRenderBytes is the combined depth-plus-width regression:
+// a spine to the deepest allowed level with a wide fan-out of leaves there passes the
+// node, depth, and raw ID-byte checks yet is rejected by ErrInvalidTree, because each
+// leaf's long ID is retained once per ancestor and the depth-weighted total exceeds
+// MaxTreeRenderBytes. This is the shape whose client retention the independent caps miss
+// (a 47,505-leaf version retains ~8.5 billion ID chars in the browser at ~67 MB of
+// server IDs); only MaxTreeRenderBytes catches it.
 //
-// A pure chain would need sqrt(MaxTreePathBytes) levels, far past MaxTreeDepth, so
-// instead it runs a spine to the deepest allowed level and fans many leaves out there:
-// each leaf's ID carries the full ~11*MaxTreeDepth-byte spine prefix, so a leaf count
-// derived from the byte cap drives the running total past it while depth and node count
-// stay within bounds. The leaf count doubles the estimate to overshoot robustly.
-func TestNew_RejectsDeepTreeByPathBytes(t *testing.T) {
-	if testing.Short() {
-		t.Skip("allocates on the order of MaxTreePathBytes")
-	}
+// The leaf count is derived from the cap and is small: each leaf contributes about
+// MaxTreeDepth*(11*MaxTreeDepth) depth-weighted bytes, so a few hundred leaves overshoot
+// 64 MiB. The tree is tiny (node count and depth both far inside their bounds), so those
+// guards demonstrably cannot be what rejects it.
+func TestNew_RejectsWideDeepTreeByRenderBytes(t *testing.T) {
+	// Leaves sit at depth MaxTreeDepth, each with an ID of at least ~11*MaxTreeDepth
+	// bytes; depth-weighted that is ~MaxTreeDepth*11*MaxTreeDepth per leaf. Double the
+	// derived count to overshoot the cap robustly.
+	leaves := 2 * (MaxTreeRenderBytes / (11 * MaxTreeDepth * MaxTreeDepth))
 	root := buildChain(MaxTreeDepth - 1) // deepest spine node sits at depth MaxTreeDepth-1
 	deepest := root
 	for len(deepest.Children) > 0 {
 		deepest = deepest.Children[0]
 	}
-	// Each leaf ID is ~11 bytes per level (about 11*MaxTreeDepth), so roughly
-	// MaxTreePathBytes/(11*MaxTreeDepth) leaves reach the cap; double it to overshoot
-	// robustly even though each ID runs a hair under that per-level estimate.
-	leaves := 2 * (MaxTreePathBytes / (11 * MaxTreeDepth))
 	deepest.Children = make([]*Node, leaves)
 	for i := range deepest.Children {
 		deepest.Children[i] = &Node{Name: "leaf"}

--- a/jawstree/gate_test.go
+++ b/jawstree/gate_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"math"
 	"reflect"
 	"strings"
 	"sync"
@@ -96,7 +97,7 @@ func TestIndexEnforcesCapDuringTraversal(t *testing.T) {
 		children[i] = &Node{Name: "n"}
 	}
 	tr := &Tree{}
-	err := tr.index(&Node{Children: children}, "", make(map[*Node]bool), new(int), 0)
+	err := tr.index(&Node{Children: children}, "", make(map[*Node]bool), new(int64), 0)
 	if !errors.Is(err, ErrInvalidTree) {
 		t.Fatalf("err = %v, want ErrInvalidTree", err)
 	}
@@ -191,24 +192,61 @@ func TestNew_RejectsNameHeavyDeepTreeByRenderBytes(t *testing.T) {
 	}
 }
 
-// TestNew_RenderBytesBoundary pins the exact MaxTreeRenderBytes cutoff. A single child at
-// depth 1 has depth-weighted serialized size jsonStringBytes(name) + len(id) +
-// nodeJSONOverhead; sizing its plain-ASCII name so the total lands on MaxTreeRenderBytes
-// is accepted, and one byte more is rejected.
+// TestNew_RenderBytesBoundary is the root-heavy boundary test: it pins the exact
+// MaxTreeRenderBytes cutoff and proves the root's own data is charged, not free. A
+// root-only tree is retained once (its init-payload copy), so its weighted size is
+// jsonStringLen(name) + nodeJSONOverhead (its ID is empty). Sizing the plain-ASCII root
+// name so the total lands on MaxTreeRenderBytes is accepted, and one byte more rejected.
 func TestNew_RenderBytesBoundary(t *testing.T) {
 	if testing.Short() {
 		t.Skip("allocates ~MaxTreeRenderBytes")
 	}
-	// The only child's ID is "children.0"; a plain-ASCII name's wire size is len+2.
-	fixed := len("children.0") + nodeJSONOverhead + len(`""`)
+	// A plain-ASCII name's wire size is len+2 (the quotes); the root ID is empty.
+	fixed := nodeJSONOverhead + len(`""`)
 	var mu sync.Mutex
-	atCap := &Node{Children: []*Node{{Name: strings.Repeat("x", MaxTreeRenderBytes-fixed)}}}
-	if _, err := New(&mu, atCap); err != nil {
+	if _, err := New(&mu, &Node{Name: strings.Repeat("x", MaxTreeRenderBytes-fixed)}); err != nil {
 		t.Fatalf("exactly MaxTreeRenderBytes should be accepted, got %v", err)
 	}
-	overCap := &Node{Children: []*Node{{Name: strings.Repeat("x", MaxTreeRenderBytes-fixed+1)}}}
-	if _, err := New(&mu, overCap); !errors.Is(err, ErrInvalidTree) {
+	if _, err := New(&mu, &Node{Name: strings.Repeat("x", MaxTreeRenderBytes-fixed+1)}); !errors.Is(err, ErrInvalidTree) {
 		t.Fatalf("one byte over err = %v, want ErrInvalidTree", err)
+	}
+}
+
+// TestNew_RejectsLargeNameNoOverflow guards the 32-bit overflow path: a node whose
+// depth-weighted serialized size exceeds a signed 32-bit int must still be rejected, not
+// wrap negative and slip under the cap. A ~17 MiB name on the deepest node of a
+// MaxTreeDepth chain makes depth*(node bytes) exceed math.MaxInt32; int64 accounting (and
+// the budget-bounded name measurement) keep it correct and over the cap.
+func TestNew_RejectsLargeNameNoOverflow(t *testing.T) {
+	root := buildChain(MaxTreeDepth - 1)
+	deepest := root
+	for len(deepest.Children) > 0 {
+		deepest = deepest.Children[0]
+	}
+	deepest.Children = []*Node{{Name: strings.Repeat("x", math.MaxInt32/(MaxTreeDepth+1)+1)}}
+	var mu sync.Mutex
+	if _, err := New(&mu, root); !errors.Is(err, ErrInvalidTree) {
+		t.Fatalf("err = %v, want ErrInvalidTree", err)
+	}
+}
+
+// TestJSONStringLen checks the non-allocating escaped-length counter matches
+// encoding/json exactly (so names are weighed at their true wire size) and stops just
+// past the budget instead of scanning the whole input.
+func TestJSONStringLen(t *testing.T) {
+	for _, s := range []string{
+		"", "plain", `q"o\\te`, "\x00\x01\t\n\r", "<b>&", "h\u00e9llo", "\u65e5\U0001f600",
+		"\u2028\u2029", string([]byte{0xff, 0xfe, 0x80}), "a" + string([]byte{0xc3}) + "z",
+	} {
+		enc, _ := json.Marshal(s)
+		if got, want := jsonStringLen(s, math.MaxInt64), int64(len(enc)); got != want {
+			t.Errorf("jsonStringLen(%q) = %d, want %d (json.Marshal length)", s, got, want)
+		}
+	}
+	// Early cutoff: a long input with a small budget stops just past it (never counting
+	// the whole million bytes).
+	if got := jsonStringLen(strings.Repeat("x", 1_000_000), 10); got <= 10 || got >= 20 {
+		t.Fatalf("jsonStringLen early cutoff = %d, want just over 10", got)
 	}
 }
 

--- a/jawstree/gate_test.go
+++ b/jawstree/gate_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"math"
 	"reflect"
 	"sync"
 	"testing"
@@ -87,7 +86,7 @@ func TestIndexEnforcesCapDuringTraversal(t *testing.T) {
 		children[i] = &Node{Name: "n"}
 	}
 	tr := &Tree{}
-	err := tr.index(&Node{Children: children}, "", make(map[*Node]bool), new(int))
+	err := tr.index(&Node{Children: children}, "", make(map[*Node]bool), new(int), 0)
 	if !errors.Is(err, ErrInvalidTree) {
 		t.Fatalf("err = %v, want ErrInvalidTree", err)
 	}
@@ -96,24 +95,65 @@ func TestIndexEnforcesCapDuringTraversal(t *testing.T) {
 	}
 }
 
-// TestNew_RejectsDeepTreeByPathBytes pins that New bounds the quadratic positional-ID
-// growth: a single-child chain far below MaxTreeNodes, but deep enough that its
-// cumulative ID bytes exceed MaxTreePathBytes, is rejected with ErrInvalidTree rather
-// than retaining hundreds of MiB of paths. The depth is derived from the byte cap so
-// the test tracks the constant: each level adds at least ~11 ID bytes, so a depth-d
-// chain retains on the order of 11*d*d/2 bytes and a depth of sqrt(MaxTreePathBytes)
-// overshoots the cap several times over.
-func TestNew_RejectsDeepTreeByPathBytes(t *testing.T) {
-	depth := int(math.Sqrt(float64(MaxTreePathBytes)))
+// buildChain returns the root of a single-child chain with the given number of
+// descendants, so its deepest node sits at depth == descendants.
+func buildChain(descendants int) *Node {
 	root := &Node{Name: "root"}
 	cur := root
-	for i := 0; i < depth; i++ {
+	for i := 0; i < descendants; i++ {
 		child := &Node{Name: "n"}
 		cur.Children = []*Node{child}
 		cur = child
 	}
-	if depth >= MaxTreeNodes {
-		t.Fatalf("test depth %d is not below MaxTreeNodes %d", depth, MaxTreeNodes)
+	return root
+}
+
+// TestNew_RejectsTreeDeeperThanMaxTreeDepth pins the depth bound that keeps a tree the
+// browser cannot render from reaching the client: the vendored treeview.js recurses per
+// level and stores each node's whole subtree on its element, so an over-deep tree would
+// overflow the browser stack and retain data growing with the cube of the depth. New
+// accepts a chain exactly at MaxTreeDepth and rejects one a single level deeper with
+// ErrInvalidTree. Both stay far below MaxTreeNodes and MaxTreePathBytes, so only the
+// depth bound can reject the deeper one.
+func TestNew_RejectsTreeDeeperThanMaxTreeDepth(t *testing.T) {
+	var mu sync.Mutex
+	if _, err := New(&mu, buildChain(MaxTreeDepth)); err != nil {
+		t.Fatalf("depth %d should be accepted, got %v", MaxTreeDepth, err)
+	}
+	if _, err := New(&mu, buildChain(MaxTreeDepth+1)); !errors.Is(err, ErrInvalidTree) {
+		t.Fatalf("depth %d err = %v, want ErrInvalidTree", MaxTreeDepth+1, err)
+	}
+}
+
+// TestNew_RejectsDeepTreeByPathBytes pins that New bounds the quadratic positional-ID
+// growth independently of the depth and node-count bounds: a tree within MaxTreeDepth
+// and MaxTreeNodes, but whose cumulative ID bytes exceed MaxTreePathBytes, is rejected
+// with ErrInvalidTree rather than retaining tens of MiB of paths.
+//
+// A pure chain would need sqrt(MaxTreePathBytes) levels, far past MaxTreeDepth, so
+// instead it runs a spine to the deepest allowed level and fans many leaves out there:
+// each leaf's ID carries the full ~11*MaxTreeDepth-byte spine prefix, so a leaf count
+// derived from the byte cap drives the running total past it while depth and node count
+// stay within bounds. The leaf count doubles the estimate to overshoot robustly.
+func TestNew_RejectsDeepTreeByPathBytes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("allocates on the order of MaxTreePathBytes")
+	}
+	root := buildChain(MaxTreeDepth - 1) // deepest spine node sits at depth MaxTreeDepth-1
+	deepest := root
+	for len(deepest.Children) > 0 {
+		deepest = deepest.Children[0]
+	}
+	// Each leaf ID is ~11 bytes per level (about 11*MaxTreeDepth), so roughly
+	// MaxTreePathBytes/(11*MaxTreeDepth) leaves reach the cap; double it to overshoot
+	// robustly even though each ID runs a hair under that per-level estimate.
+	leaves := 2 * (MaxTreePathBytes / (11 * MaxTreeDepth))
+	deepest.Children = make([]*Node, leaves)
+	for i := range deepest.Children {
+		deepest.Children[i] = &Node{Name: "leaf"}
+	}
+	if total := MaxTreeDepth + leaves; total >= MaxTreeNodes {
+		t.Fatalf("test tree has %d nodes, not below MaxTreeNodes %d", total, MaxTreeNodes)
 	}
 	var mu sync.Mutex
 	if _, err := New(&mu, root); !errors.Is(err, ErrInvalidTree) {

--- a/jawstree/gate_test.go
+++ b/jawstree/gate_test.go
@@ -213,17 +213,24 @@ func TestNew_RenderBytesBoundary(t *testing.T) {
 }
 
 // TestNew_RejectsLargeNameNoOverflow guards the 32-bit overflow path: a node whose
-// depth-weighted serialized size exceeds a signed 32-bit int must still be rejected, not
-// wrap negative and slip under the cap. A ~17 MiB name on the deepest node of a
-// MaxTreeDepth chain makes depth*(node bytes) exceed math.MaxInt32; int64 accounting (and
-// the budget-bounded name measurement) keep it correct and over the cap.
+// weighted serialized size exceeds a signed 32-bit int must still be rejected, not wrap
+// negative and slip under the cap. The old code computed depth*nodeBytes in int, so on a
+// 32-bit build the deepest node (depth MaxTreeDepth == 128) with this ~20 MiB name gave
+// 128 * ~20 MiB > math.MaxInt32 and wrapped negative, wrongly accepting it. int64
+// accounting (and the budget-bounded name measurement) keep it correct and over the cap.
+// Runs under -short so the 386 CI leg exercises it with 32-bit arithmetic.
 func TestNew_RejectsLargeNameNoOverflow(t *testing.T) {
+	// 20 MiB * MaxTreeDepth (128) is ~2.68e9, well over math.MaxInt32 (~2.15e9).
+	name := strings.Repeat("x", 20<<20)
+	if int64(MaxTreeDepth)*int64(len(name)) <= math.MaxInt32 {
+		t.Fatalf("name too small to overflow int32 at depth %d", MaxTreeDepth)
+	}
 	root := buildChain(MaxTreeDepth - 1)
 	deepest := root
 	for len(deepest.Children) > 0 {
 		deepest = deepest.Children[0]
 	}
-	deepest.Children = []*Node{{Name: strings.Repeat("x", math.MaxInt32/(MaxTreeDepth+1)+1)}}
+	deepest.Children = []*Node{{Name: name}}
 	var mu sync.Mutex
 	if _, err := New(&mu, root); !errors.Is(err, ErrInvalidTree) {
 		t.Fatalf("err = %v, want ErrInvalidTree", err)

--- a/jawstree/gate_test.go
+++ b/jawstree/gate_test.go
@@ -86,8 +86,8 @@ func TestNew_NodeCapBoundary(t *testing.T) {
 // TestIndexEnforcesCapDuringTraversal pins that index rejects an oversized tree
 // mid-traversal (returning ErrInvalidTree once byIndex reaches MaxTreeNodes) rather
 // than after fully indexing it. Bounding byIndex bounds the recursion depth, so a
-// pathologically deep single-child tree can no longer overflow the stack before the
-// cap is applied; the deep shape shares this guard with the wide one exercised here.
+// pathologically deep single-child tree cannot overflow the stack before the cap
+// applies; the deep shape shares this guard with the wide one exercised here.
 func TestIndexEnforcesCapDuringTraversal(t *testing.T) {
 	if testing.Short() {
 		t.Skip("builds a MaxTreeNodes+1 tree")
@@ -214,11 +214,11 @@ func TestNew_RenderBytesBoundary(t *testing.T) {
 
 // TestNew_RejectsLargeNameNoOverflow guards the 32-bit overflow path: a node whose
 // weighted serialized size exceeds a signed 32-bit int must still be rejected, not wrap
-// negative and slip under the cap. The old code computed depth*nodeBytes in int, so on a
-// 32-bit build the deepest node (depth MaxTreeDepth == 128) with this ~20 MiB name gave
-// 128 * ~20 MiB > math.MaxInt32 and wrapped negative, wrongly accepting it. int64
-// accounting (and the budget-bounded name measurement) keep it correct and over the cap.
-// Runs under -short so the 386 CI leg exercises it with 32-bit arithmetic.
+// negative and slip under the cap. On a 32-bit build the deepest node (depth
+// MaxTreeDepth == 128) with this ~20 MiB name makes the naive product depth*nodeBytes
+// (128 * ~20 MiB) exceed math.MaxInt32, so int64 accounting and the budget-bounded name
+// measurement are what keep it correct and over the cap. Runs under -short so the 386 CI
+// leg exercises it with 32-bit arithmetic.
 func TestNew_RejectsLargeNameNoOverflow(t *testing.T) {
 	// 20 MiB * MaxTreeDepth (128) is ~2.68e9, well over math.MaxInt32 (~2.15e9).
 	name := strings.Repeat("x", 20<<20)

--- a/jawstree/gate_test.go
+++ b/jawstree/gate_test.go
@@ -176,9 +176,10 @@ func TestNew_RejectsWideDeepTreeByRenderBytes(t *testing.T) {
 // the depth-weighted serialized size exceeds MaxTreeRenderBytes. Counting the whole
 // serialized node, not just the ID, is what rejects it.
 func TestNew_RejectsNameHeavyDeepTreeByRenderBytes(t *testing.T) {
-	// A chain of depth D retains each node's name sum(1..D) = D(D+1)/2 times. Size the
-	// shared name so that weight clears the cap, doubled to overshoot robustly.
-	weight := MaxTreeDepth * (MaxTreeDepth + 1) / 2
+	// The D named nodes sit at depths 1..D and each is retained depth+1 times, so the
+	// shared name is held sum_{d=1..D}(d+1) = D(D+3)/2 times. Size it so that weight clears
+	// the cap, doubled to overshoot robustly.
+	weight := MaxTreeDepth * (MaxTreeDepth + 3) / 2
 	name := strings.Repeat("n", 2*(MaxTreeRenderBytes/weight))
 	root := &Node{Name: "root"}
 	cur := root

--- a/jawstree/gate_test.go
+++ b/jawstree/gate_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"math"
 	"reflect"
 	"sync"
 	"testing"
@@ -86,12 +87,37 @@ func TestIndexEnforcesCapDuringTraversal(t *testing.T) {
 		children[i] = &Node{Name: "n"}
 	}
 	tr := &Tree{}
-	err := tr.index(&Node{Children: children}, "", make(map[*Node]bool))
+	err := tr.index(&Node{Children: children}, "", make(map[*Node]bool), new(int))
 	if !errors.Is(err, ErrInvalidTree) {
 		t.Fatalf("err = %v, want ErrInvalidTree", err)
 	}
 	if len(tr.byIndex) > MaxTreeNodes {
 		t.Fatalf("byIndex grew to %d, want <= %d", len(tr.byIndex), MaxTreeNodes)
+	}
+}
+
+// TestNew_RejectsDeepTreeByPathBytes pins that New bounds the quadratic positional-ID
+// growth: a single-child chain far below MaxTreeNodes, but deep enough that its
+// cumulative ID bytes exceed MaxTreePathBytes, is rejected with ErrInvalidTree rather
+// than retaining hundreds of MiB of paths. The depth is derived from the byte cap so
+// the test tracks the constant: each level adds at least ~11 ID bytes, so a depth-d
+// chain retains on the order of 11*d*d/2 bytes and a depth of sqrt(MaxTreePathBytes)
+// overshoots the cap several times over.
+func TestNew_RejectsDeepTreeByPathBytes(t *testing.T) {
+	depth := int(math.Sqrt(float64(MaxTreePathBytes)))
+	root := &Node{Name: "root"}
+	cur := root
+	for i := 0; i < depth; i++ {
+		child := &Node{Name: "n"}
+		cur.Children = []*Node{child}
+		cur = child
+	}
+	if depth >= MaxTreeNodes {
+		t.Fatalf("test depth %d is not below MaxTreeNodes %d", depth, MaxTreeNodes)
+	}
+	var mu sync.Mutex
+	if _, err := New(&mu, root); !errors.Is(err, ErrInvalidTree) {
+		t.Fatalf("err = %v, want ErrInvalidTree", err)
 	}
 }
 

--- a/jawstree/gate_test.go
+++ b/jawstree/gate_test.go
@@ -72,6 +72,29 @@ func TestNew_RejectsOverCap(t *testing.T) {
 	}
 }
 
+// TestIndexEnforcesCapDuringTraversal pins that index rejects an oversized tree
+// mid-traversal (returning ErrInvalidTree once byIndex reaches MaxTreeNodes) rather
+// than after fully indexing it. Bounding byIndex bounds the recursion depth, so a
+// pathologically deep single-child tree can no longer overflow the stack before the
+// cap is applied; the deep shape shares this guard with the wide one exercised here.
+func TestIndexEnforcesCapDuringTraversal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds a MaxTreeNodes+1 tree")
+	}
+	children := make([]*Node, MaxTreeNodes+1)
+	for i := range children {
+		children[i] = &Node{Name: "n"}
+	}
+	tr := &Tree{}
+	err := tr.index(&Node{Children: children}, "", make(map[*Node]bool))
+	if !errors.Is(err, ErrInvalidTree) {
+		t.Fatalf("err = %v, want ErrInvalidTree", err)
+	}
+	if len(tr.byIndex) > MaxTreeNodes {
+		t.Fatalf("byIndex grew to %d, want <= %d", len(tr.byIndex), MaxTreeNodes)
+	}
+}
+
 func TestApplyClientDelta_Gate(t *testing.T) {
 	var mu sync.Mutex
 	// preorder indices: root=0, a=1, b=2, b.c=3 (disabled)

--- a/jawstree/gate_test.go
+++ b/jawstree/gate_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -165,6 +166,49 @@ func TestNew_RejectsWideDeepTreeByRenderBytes(t *testing.T) {
 	var mu sync.Mutex
 	if _, err := New(&mu, root); !errors.Is(err, ErrInvalidTree) {
 		t.Fatalf("err = %v, want ErrInvalidTree", err)
+	}
+}
+
+// TestNew_RejectsNameHeavyDeepTreeByRenderBytes is the name-heavy regression: a chain
+// within MaxTreeDepth whose nodes share one large Name. Its depth-weighted ID size stays
+// tiny, but the browser serializes each node (its name included) on every ancestor, so
+// the depth-weighted serialized size exceeds MaxTreeRenderBytes. Counting the whole
+// serialized node, not just the ID, is what rejects it.
+func TestNew_RejectsNameHeavyDeepTreeByRenderBytes(t *testing.T) {
+	// A chain of depth D retains each node's name sum(1..D) = D(D+1)/2 times. Size the
+	// shared name so that weight clears the cap, doubled to overshoot robustly.
+	weight := MaxTreeDepth * (MaxTreeDepth + 1) / 2
+	name := strings.Repeat("n", 2*(MaxTreeRenderBytes/weight))
+	root := &Node{Name: "root"}
+	cur := root
+	for i := 0; i < MaxTreeDepth; i++ {
+		cur.Children = []*Node{{Name: name}}
+		cur = cur.Children[0]
+	}
+	var mu sync.Mutex
+	if _, err := New(&mu, root); !errors.Is(err, ErrInvalidTree) {
+		t.Fatalf("err = %v, want ErrInvalidTree", err)
+	}
+}
+
+// TestNew_RenderBytesBoundary pins the exact MaxTreeRenderBytes cutoff. A single child at
+// depth 1 has depth-weighted serialized size jsonStringBytes(name) + len(id) +
+// nodeJSONOverhead; sizing its plain-ASCII name so the total lands on MaxTreeRenderBytes
+// is accepted, and one byte more is rejected.
+func TestNew_RenderBytesBoundary(t *testing.T) {
+	if testing.Short() {
+		t.Skip("allocates ~MaxTreeRenderBytes")
+	}
+	// The only child's ID is "children.0"; a plain-ASCII name's wire size is len+2.
+	fixed := len("children.0") + nodeJSONOverhead + len(`""`)
+	var mu sync.Mutex
+	atCap := &Node{Children: []*Node{{Name: strings.Repeat("x", MaxTreeRenderBytes-fixed)}}}
+	if _, err := New(&mu, atCap); err != nil {
+		t.Fatalf("exactly MaxTreeRenderBytes should be accepted, got %v", err)
+	}
+	overCap := &Node{Children: []*Node{{Name: strings.Repeat("x", MaxTreeRenderBytes-fixed+1)}}}
+	if _, err := New(&mu, overCap); !errors.Is(err, ErrInvalidTree) {
+		t.Fatalf("one byte over err = %v, want ErrInvalidTree", err)
 	}
 }
 

--- a/jawstree/node.go
+++ b/jawstree/node.go
@@ -37,6 +37,15 @@ func appendJSONString(b []byte, s string) []byte {
 	return append(b, enc...)
 }
 
+// jsonStringBytes reports how many bytes s occupies as a wire JSON string literal
+// (surrounding quotes plus any escaping), matching [appendJSONString]. New uses it to
+// weigh each node's retained serialized size, so escaped names count at their true
+// wire length rather than their raw byte length.
+func jsonStringBytes(s string) int {
+	enc, _ := json.Marshal(s)
+	return len(enc)
+}
+
 func (node *Node) marshalJSON(b []byte) []byte {
 	b = append(b, `{"name":`...)
 	b = appendJSONString(b, node.Name)

--- a/jawstree/node.go
+++ b/jawstree/node.go
@@ -22,7 +22,7 @@ import (
 // "selectable":false), so the tags do not all mirror the wire shape.
 type Node struct {
 	Parent   *Node   `json:"-"`                 // parent node, set by New, nil for root
-	Name     string  `json:"name"`              // display name
+	Name     string  `json:"name"`              // display name; do not change after New (see [Tree])
 	ID       string  `json:"id,omitzero"`       // positional JSON path, set by New; also the DOM data-id
 	Selected bool    `json:"selected,omitzero"` // selected state
 	Disabled bool    `json:"disabled,omitzero"` // emitted as "selectable":false (inverted) on the wire

--- a/jawstree/node.go
+++ b/jawstree/node.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"slices"
 	"strconv"
+	"unicode/utf8"
 )
 
 // Node is one tree node rendered by [Tree].
@@ -37,13 +38,42 @@ func appendJSONString(b []byte, s string) []byte {
 	return append(b, enc...)
 }
 
-// jsonStringBytes reports how many bytes s occupies as a wire JSON string literal
-// (surrounding quotes plus any escaping), matching [appendJSONString]. New uses it to
-// weigh each node's retained serialized size, so escaped names count at their true
-// wire length rather than their raw byte length.
-func jsonStringBytes(s string) int {
-	enc, _ := json.Marshal(s)
-	return len(enc)
+// jsonStringLen reports how many bytes s occupies as a wire JSON string literal
+// (surrounding quotes plus escaping, matching [appendJSONString] and encoding/json),
+// but stops once the running length exceeds limit and returns a value greater than
+// limit. It never allocates, so New can weigh an untrusted [Node.Name] — and reject an
+// over-long or escape-heavy one — without encoding a full copy of it.
+func jsonStringLen(s string, limit int64) int64 {
+	n := int64(2) // the surrounding quotes
+	for i := 0; i < len(s); {
+		if n > limit {
+			return n
+		}
+		if c := s[i]; c < utf8.RuneSelf {
+			switch {
+			case c == '"' || c == '\\' || c == '\b' || c == '\f' || c == '\n' || c == '\r' || c == '\t':
+				n += 2
+			case c < 0x20 || c == '<' || c == '>' || c == '&':
+				n += 6 // control bytes and the HTML-escaped set become \u00xx
+			default:
+				n++
+			}
+			i++
+			continue
+		}
+		switch r, size := utf8.DecodeRuneInString(s[i:]); {
+		case r == utf8.RuneError && size == 1:
+			n += 6 // invalid UTF-8 becomes the \ufffd escape
+			i++
+		case r == '\u2028' || r == '\u2029':
+			n += 6 // the JSON line/paragraph separators are escaped
+			i += size
+		default:
+			n += int64(size)
+			i += size
+		}
+	}
+	return n
 }
 
 func (node *Node) marshalJSON(b []byte) []byte {

--- a/jawstree/node_benchmark_test.go
+++ b/jawstree/node_benchmark_test.go
@@ -59,10 +59,10 @@ func TestResolveIndexZeroAllocs(t *testing.T) {
 }
 
 // BenchmarkJSONStringLen compares the non-allocating escaped-length counter New uses to
-// weigh a node name against the previous json.Marshal-and-measure approach, across a
-// typical short label, a large label, and a hostile over-budget name. "counter" stays
-// allocation-free and, given a budget, stops early; "marshal" always allocates and
-// encodes the whole string before its length can be measured.
+// weigh a node name against a json.Marshal-and-measure baseline, across a typical short
+// label, a large label, and a hostile over-budget name. "counter" stays allocation-free
+// and, given a budget, stops early; "marshal" always allocates and encodes the whole
+// string before its length can be measured.
 func BenchmarkJSONStringLen(b *testing.B) {
 	cases := []struct {
 		name  string

--- a/jawstree/node_benchmark_test.go
+++ b/jawstree/node_benchmark_test.go
@@ -1,13 +1,17 @@
 package jawstree
 
 import (
+	"encoding/json"
+	"math"
+	"strings"
 	"sync"
 	"testing"
 )
 
 var (
-	resolveIndexBenchSink *Node
-	applyDeltaBenchSink   bool
+	resolveIndexBenchSink  *Node
+	applyDeltaBenchSink    bool
+	jsonStringLenBenchSink int64
 )
 
 func benchTree(b *testing.B) *Tree {
@@ -51,6 +55,50 @@ func TestResolveIndexZeroAllocs(t *testing.T) {
 	})
 	if allocs != 0 {
 		t.Errorf("resolveIndex allocated %g times, want 0", allocs)
+	}
+}
+
+// BenchmarkJSONStringLen compares the non-allocating escaped-length counter New uses to
+// weigh a node name against the previous json.Marshal-and-measure approach, across a
+// typical short label, a large label, and a hostile over-budget name. "counter" stays
+// allocation-free and, given a budget, stops early; "marshal" always allocates and
+// encodes the whole string before its length can be measured.
+func BenchmarkJSONStringLen(b *testing.B) {
+	cases := []struct {
+		name  string
+		s     string
+		limit int64
+	}{
+		{"short", "a typical node label", math.MaxInt64},
+		{"large", strings.Repeat("node label ", 1024), math.MaxInt64}, // ~11 KiB
+		{"hostile", strings.Repeat("x", 4<<20), 64},                   // 4 MiB, tiny budget
+	}
+	for _, tc := range cases {
+		b.Run(tc.name+"/counter", func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				jsonStringLenBenchSink = jsonStringLen(tc.s, tc.limit)
+			}
+		})
+		b.Run(tc.name+"/marshal", func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				enc, _ := json.Marshal(tc.s)
+				jsonStringLenBenchSink = int64(len(enc))
+			}
+		})
+	}
+}
+
+// TestJSONStringLenZeroAllocs pins the escaped-length counter at zero allocations, the
+// contract that lets New measure an untrusted, arbitrarily large name without allocating.
+func TestJSONStringLenZeroAllocs(t *testing.T) {
+	name := strings.Repeat("x", 4096)
+	allocs := testing.AllocsPerRun(100, func() {
+		jsonStringLenBenchSink = jsonStringLen(name, math.MaxInt64)
+	})
+	if allocs != 0 {
+		t.Errorf("jsonStringLen allocated %g times, want 0", allocs)
 	}
 }
 

--- a/jawstree/tree.go
+++ b/jawstree/tree.go
@@ -39,14 +39,15 @@ const MaxTreeDepth = 128
 // name, positional-path ID, and fixed structural bytes).
 //
 // The browser holds each node's whole serialized data — its potentially large
-// [Node.Name] included — in the init payload and in the data-node-data of its own
-// element and each rendered ancestor's. A node at depth d therefore has its data held
-// d+1 times: once in the payload, once on its own element, and once on each of its d-1
-// rendered ancestors. This depth-weighted sum is what the independent [MaxTreeNodes] and
-// [MaxTreeDepth] bounds do not cap: a shallow spine with a wide, deep fan-out, or a deep
-// chain of large names, passes them yet duplicates its data across every level. [New]
-// rejects a tree whose depth-weighted serialized size exceeds this limit with
-// [ErrInvalidTree].
+// [Node.Name] included — in the init payload and in the data-node-data of every element
+// whose subtree contains it. The root is not rendered, so its data is held once (the
+// payload). A non-root node at depth d is held d+1 times: once in the payload, once on
+// its own element, and once on each of its d-1 rendered ancestors. Weighting each node
+// by depth+1 covers both cases. This depth-weighted sum is what the independent
+// [MaxTreeNodes] and [MaxTreeDepth] bounds do not cap: a shallow spine with a wide, deep
+// fan-out, or a deep chain of large names, passes them yet duplicates its data across
+// every level. [New] rejects a tree whose depth-weighted serialized size exceeds this
+// limit with [ErrInvalidTree].
 //
 // The bound is on the retained serialized node data (the per-element data plus the init
 // payload), which is a proxy for, not the exact size of, client memory: the renderer
@@ -73,8 +74,10 @@ const nodeJSONOverhead = 80
 // [MaxTreeDepth], and [MaxTreeRenderBytes] bounds. Only the selection may change
 // afterward, through [Tree.SetSelected] or browser events (safe under the lock); each
 // node's Name, Disabled, assigned ID, and the topology (Children) are fixed. Changing any
-// of them is unsupported: it breaks the identity mapping and, because rendering
-// re-serializes the live tree, can defeat the size bounds New enforced.
+// of them is unsupported, with a different consequence per field: altering the topology
+// or an ID breaks the wire-index-to-node identity mapping; enlarging a Name defeats the
+// size bounds New enforced (rendering re-serializes the live tree); toggling Disabled can
+// desync the selection policy.
 type Tree struct {
 	bind.RWLocker         // guards root selection state and is the concurrency contract for Node accessors
 	key           string  // browser correlation key, unique per Tree
@@ -182,9 +185,10 @@ func (t *Tree) index(node *Node, jsPath string, seen map[*Node]bool, renderBytes
 		return fmt.Errorf("%w: exceeds MaxTreeDepth (%d)", ErrInvalidTree, MaxTreeDepth)
 	}
 	// The browser retains this node's whole wire object (name, ID, structure) in the init
-	// payload and on its own element plus each rendered ancestor's: depth+1 copies. Charge
-	// that, measuring the name only up to the budget that still fits so an over-long name
-	// is rejected without encoding all of it and the product cannot overflow.
+	// payload and, for a non-root node, on its own element plus its d-1 rendered ancestors:
+	// depth+1 copies (the unrendered root is held once, in the payload). Charge that,
+	// measuring the name only up to the budget that still fits so an over-long name is
+	// rejected without encoding all of it and the product cannot overflow.
 	weight := int64(depth) + 1
 	budget := int64(MaxTreeRenderBytes) - *renderBytes
 	nameLen := jsonStringLen(node.Name, budget/weight-int64(len(jsPath))-nodeJSONOverhead)

--- a/jawstree/tree.go
+++ b/jawstree/tree.go
@@ -24,27 +24,28 @@ const wsInboundLimit = 32 * 1024
 // [ErrInvalidTree]; TestSelectionFrameFitsInboundLimit pins the guarantee.
 const MaxTreeNodes = 180000
 
-// MaxTreePathBytes is the largest total size of the positional-path IDs [New]
-// assigns across all nodes.
-//
-// Each node's ID is its full path from the root ("children.0.children.1"), so a deep
-// tree retains ID data that grows with the square of its depth, independent of the
-// [MaxTreeNodes] count. [New] rejects a tree whose cumulative ID bytes exceed this
-// limit with [ErrInvalidTree], bounding the memory held for IDs (and the matching
-// init payload) to a modest ceiling. Any realistically shaped tree stays well within
-// it; only a pathologically deep tree is rejected.
-const MaxTreePathBytes = 64 << 20 // 64 MiB
-
 // MaxTreeDepth is the deepest nesting [New] accepts, measured in edges from the root
 // (the root is depth 0, its children depth 1).
 //
-// The browser renderer (the vendored Quercus.js treeview) recurses once per level and
-// stores each node's whole subtree on its element, so client stack use and retained
-// data grow with the tree depth (the data roughly with its cube). A tree deeper than a
-// browser can render is therefore rejected here with [ErrInvalidTree] so it never
-// reaches the client. The bound is far above any realistic UI nesting yet well below
-// where the renderer's recursion overflows, keeping worst-case client memory small.
+// The browser renderer (the vendored Quercus.js treeview) recurses once per level, so
+// its stack use grows with the tree depth. A tree deeper than a browser can render is
+// rejected here with [ErrInvalidTree] so it never reaches the client. The bound is far
+// above any realistic UI nesting yet well below where the renderer's recursion
+// overflows.
 const MaxTreeDepth = 128
+
+// MaxTreeRenderBytes is the largest total size of the positional-path IDs [New]
+// accepts, weighted by depth: the sum over all nodes of depth times ID length.
+//
+// The browser renderer stores each node's whole subtree on its element, so a node's ID
+// is retained once for every ancestor that contains it — its depth-fold. Worst-case
+// client retention is therefore this depth-weighted sum, which the independent
+// [MaxTreeNodes], [MaxTreeDepth], and raw ID-byte bounds do not cap: a shallow spine
+// with a wide, deep fan-out passes them all yet duplicates its IDs across every
+// ancestor. [New] rejects a tree whose depth-weighted ID bytes exceed this limit with
+// [ErrInvalidTree], bounding worst-case client memory (and, since the weight is at
+// least one, the server-side ID memory and init payload) to a modest ceiling.
+const MaxTreeRenderBytes = 64 << 20 // 64 MiB
 
 // Tree is the shared, server-authoritative model behind a Quercus.js tree, and the
 // [jaws.UI] that renders it.
@@ -85,8 +86,8 @@ func makeTreeKey() (key string) {
 //
 // It returns [ErrInvalidTree] for a nil root, a cyclic or shared-node graph, a
 // negative or unknown [Option] bit, more than [MaxTreeNodes] nodes, nesting deeper than
-// [MaxTreeDepth], or positional-path IDs totalling more than [MaxTreePathBytes], and
-// [ErrInvalidSelection] when the initial Selected flags violate the selection policy
+// [MaxTreeDepth], or depth-weighted positional-path IDs exceeding [MaxTreeRenderBytes],
+// and [ErrInvalidSelection] when the initial Selected flags violate the selection policy
 // (see [Tree.SetSelected]).
 //
 // New must run before rendering the Tree or using the name-path selection API. The
@@ -115,9 +116,9 @@ func New(l sync.Locker, root *Node, options ...Option) (t *Tree, err error) {
 	// descendants' Parent, so enforce the invariant for the root here (a node reused
 	// as a new root could otherwise carry a stale Parent).
 	root.Parent = nil
-	// index enforces MaxTreeNodes, MaxTreeDepth, and MaxTreePathBytes during traversal,
-	// so byIndex never exceeds the node cap and the depth and retained ID bytes stay
-	// bounded.
+	// index enforces MaxTreeNodes, MaxTreeDepth, and MaxTreeRenderBytes during traversal,
+	// so byIndex never exceeds the node cap and the depth and client-retained ID bytes
+	// stay bounded.
 	if err = t.index(root, "", make(map[*Node]bool), new(int), 0); err != nil {
 		return nil, err
 	}
@@ -147,19 +148,21 @@ func New(l sync.Locker, root *Node, options ...Option) (t *Tree, err error) {
 // the recursion depth to MaxTreeNodes, so a pathologically deep (in particular
 // single-child) tree returns [ErrInvalidTree] instead of overflowing the stack.
 //
-// depth is node's distance from the root and pathBytes accumulates the total size of
-// the IDs assigned so far; index rejects the tree once depth exceeds [MaxTreeDepth] or
-// the IDs exceed [MaxTreePathBytes], bounding the client render depth and the quadratic
-// ID growth of a deep tree that would otherwise stay within MaxTreeNodes.
-func (t *Tree) index(node *Node, jsPath string, seen map[*Node]bool, pathBytes *int, depth int) error {
+// depth is node's distance from the root and renderBytes accumulates the depth-weighted
+// ID size (sum of depth times ID length) assigned so far; index rejects the tree once
+// depth exceeds [MaxTreeDepth] or the depth-weighted bytes exceed [MaxTreeRenderBytes],
+// bounding the client render depth and the client-retained ID data (which the browser
+// duplicates once per ancestor) of a tree that would otherwise stay within MaxTreeNodes.
+func (t *Tree) index(node *Node, jsPath string, seen map[*Node]bool, renderBytes *int, depth int) error {
 	if len(t.byIndex) >= MaxTreeNodes {
 		return fmt.Errorf("%w: exceeds MaxTreeNodes (%d)", ErrInvalidTree, MaxTreeNodes)
 	}
 	if depth > MaxTreeDepth {
 		return fmt.Errorf("%w: exceeds MaxTreeDepth (%d)", ErrInvalidTree, MaxTreeDepth)
 	}
-	if *pathBytes += len(jsPath); *pathBytes > MaxTreePathBytes {
-		return fmt.Errorf("%w: positional-path IDs exceed MaxTreePathBytes (%d)", ErrInvalidTree, MaxTreePathBytes)
+	// Weight by depth: the browser stores this node's ID on each of its depth ancestors.
+	if *renderBytes += depth * len(jsPath); *renderBytes > MaxTreeRenderBytes {
+		return fmt.Errorf("%w: depth-weighted positional-path IDs exceed MaxTreeRenderBytes (%d)", ErrInvalidTree, MaxTreeRenderBytes)
 	}
 	if seen[node] {
 		return fmt.Errorf("%w: node %q is reachable more than once (cyclic or shared graph)", ErrInvalidTree, node.Name)
@@ -173,7 +176,7 @@ func (t *Tree) index(node *Node, jsPath string, seen map[*Node]bool, pathBytes *
 	}
 	for i, child := range node.Children {
 		child.Parent = node
-		if err := t.index(child, jsPath+"children."+strconv.Itoa(i), seen, pathBytes, depth+1); err != nil {
+		if err := t.index(child, jsPath+"children."+strconv.Itoa(i), seen, renderBytes, depth+1); err != nil {
 			return err
 		}
 	}

--- a/jawstree/tree.go
+++ b/jawstree/tree.go
@@ -35,6 +35,17 @@ const MaxTreeNodes = 180000
 // it; only a pathologically deep tree is rejected.
 const MaxTreePathBytes = 64 << 20 // 64 MiB
 
+// MaxTreeDepth is the deepest nesting [New] accepts, measured in edges from the root
+// (the root is depth 0, its children depth 1).
+//
+// The browser renderer (the vendored Quercus.js treeview) recurses once per level and
+// stores each node's whole subtree on its element, so client stack use and retained
+// data grow with the tree depth (the data roughly with its cube). A tree deeper than a
+// browser can render is therefore rejected here with [ErrInvalidTree] so it never
+// reaches the client. The bound is far above any realistic UI nesting yet well below
+// where the renderer's recursion overflows, keeping worst-case client memory small.
+const MaxTreeDepth = 128
+
 // Tree is the shared, server-authoritative model behind a Quercus.js tree, and the
 // [jaws.UI] that renders it.
 //
@@ -73,9 +84,10 @@ func makeTreeKey() (key string) {
 // New returns a shared tree model for root, guarded by l.
 //
 // It returns [ErrInvalidTree] for a nil root, a cyclic or shared-node graph, a
-// negative or unknown [Option] bit, more than [MaxTreeNodes] nodes, or positional-path
-// IDs totalling more than [MaxTreePathBytes], and [ErrInvalidSelection] when the
-// initial Selected flags violate the selection policy (see [Tree.SetSelected]).
+// negative or unknown [Option] bit, more than [MaxTreeNodes] nodes, nesting deeper than
+// [MaxTreeDepth], or positional-path IDs totalling more than [MaxTreePathBytes], and
+// [ErrInvalidSelection] when the initial Selected flags violate the selection policy
+// (see [Tree.SetSelected]).
 //
 // New must run before rendering the Tree or using the name-path selection API. The
 // Tree renders its own container, so no caller-provided HTML id is required.
@@ -103,9 +115,10 @@ func New(l sync.Locker, root *Node, options ...Option) (t *Tree, err error) {
 	// descendants' Parent, so enforce the invariant for the root here (a node reused
 	// as a new root could otherwise carry a stale Parent).
 	root.Parent = nil
-	// index enforces MaxTreeNodes and MaxTreePathBytes during traversal, so byIndex
-	// never exceeds the node cap and the retained ID bytes stay bounded.
-	if err = t.index(root, "", make(map[*Node]bool), new(int)); err != nil {
+	// index enforces MaxTreeNodes, MaxTreeDepth, and MaxTreePathBytes during traversal,
+	// so byIndex never exceeds the node cap and the depth and retained ID bytes stay
+	// bounded.
+	if err = t.index(root, "", make(map[*Node]bool), new(int), 0); err != nil {
 		return nil, err
 	}
 	// Validate the initial selection through the same policy the browser and server
@@ -134,12 +147,16 @@ func New(l sync.Locker, root *Node, options ...Option) (t *Tree, err error) {
 // the recursion depth to MaxTreeNodes, so a pathologically deep (in particular
 // single-child) tree returns [ErrInvalidTree] instead of overflowing the stack.
 //
-// pathBytes accumulates the total size of the IDs assigned so far; index rejects the
-// tree once it exceeds [MaxTreePathBytes], bounding the quadratic ID growth of a deep
-// tree that would otherwise stay within MaxTreeNodes.
-func (t *Tree) index(node *Node, jsPath string, seen map[*Node]bool, pathBytes *int) error {
+// depth is node's distance from the root and pathBytes accumulates the total size of
+// the IDs assigned so far; index rejects the tree once depth exceeds [MaxTreeDepth] or
+// the IDs exceed [MaxTreePathBytes], bounding the client render depth and the quadratic
+// ID growth of a deep tree that would otherwise stay within MaxTreeNodes.
+func (t *Tree) index(node *Node, jsPath string, seen map[*Node]bool, pathBytes *int, depth int) error {
 	if len(t.byIndex) >= MaxTreeNodes {
 		return fmt.Errorf("%w: exceeds MaxTreeNodes (%d)", ErrInvalidTree, MaxTreeNodes)
+	}
+	if depth > MaxTreeDepth {
+		return fmt.Errorf("%w: exceeds MaxTreeDepth (%d)", ErrInvalidTree, MaxTreeDepth)
 	}
 	if *pathBytes += len(jsPath); *pathBytes > MaxTreePathBytes {
 		return fmt.Errorf("%w: positional-path IDs exceed MaxTreePathBytes (%d)", ErrInvalidTree, MaxTreePathBytes)
@@ -156,7 +173,7 @@ func (t *Tree) index(node *Node, jsPath string, seen map[*Node]bool, pathBytes *
 	}
 	for i, child := range node.Children {
 		child.Parent = node
-		if err := t.index(child, jsPath+"children."+strconv.Itoa(i), seen, pathBytes); err != nil {
+		if err := t.index(child, jsPath+"children."+strconv.Itoa(i), seen, pathBytes, depth+1); err != nil {
 			return err
 		}
 	}

--- a/jawstree/tree.go
+++ b/jawstree/tree.go
@@ -38,15 +38,15 @@ const MaxTreeDepth = 128
 // the sum over all nodes of depth times the node's own wire size (its JSON-escaped
 // name, positional-path ID, and fixed structural bytes).
 //
-// The browser renderer stores each node's whole subtree on its element, so a node's
-// serialized data — including its potentially large [Node.Name] — is retained once for
-// every ancestor that contains it, its depth-fold. Worst-case client retention is this
-// depth-weighted sum, which the independent [MaxTreeNodes] and [MaxTreeDepth] bounds do
-// not cap: a shallow spine with a wide, deep fan-out, or a deep chain of large names,
-// passes them yet duplicates its data across every ancestor. [New] rejects a tree whose
-// depth-weighted serialized size exceeds this limit with [ErrInvalidTree], bounding
-// worst-case client memory (and, since the weight is at least one, the server-side node
-// data and init payload) to a modest ceiling.
+// The browser holds each node's whole serialized data — its potentially large
+// [Node.Name] included — once in the init payload and once on every ancestor element
+// that stores its subtree, so each node is retained depth+1 times. Worst-case client
+// retention is this depth-weighted sum, which the independent [MaxTreeNodes] and
+// [MaxTreeDepth] bounds do not cap: a shallow spine with a wide, deep fan-out, or a deep
+// chain of large names, passes them yet duplicates its data across every ancestor. [New]
+// rejects a tree whose depth-weighted serialized size exceeds this limit with
+// [ErrInvalidTree], bounding worst-case client memory (and, since every node is charged
+// at least once, the server-side node data and init payload) to a modest ceiling.
 const MaxTreeRenderBytes = 64 << 20 // 64 MiB
 
 // nodeJSONOverhead upper-bounds a node's fixed structural wire bytes: the object
@@ -125,9 +125,9 @@ func New(l sync.Locker, root *Node, options ...Option) (t *Tree, err error) {
 	// as a new root could otherwise carry a stale Parent).
 	root.Parent = nil
 	// index enforces MaxTreeNodes, MaxTreeDepth, and MaxTreeRenderBytes during traversal,
-	// so byIndex never exceeds the node cap and the depth and client-retained ID bytes
+	// so byIndex never exceeds the node cap and the depth and client-retained node data
 	// stay bounded.
-	if err = t.index(root, "", make(map[*Node]bool), new(int), 0); err != nil {
+	if err = t.index(root, "", make(map[*Node]bool), new(int64), 0); err != nil {
 		return nil, err
 	}
 	// Validate the initial selection through the same policy the browser and server
@@ -157,22 +157,30 @@ func New(l sync.Locker, root *Node, options ...Option) (t *Tree, err error) {
 // single-child) tree returns [ErrInvalidTree] instead of overflowing the stack.
 //
 // depth is node's distance from the root and renderBytes accumulates the depth-weighted
-// serialized node size (sum of depth times each node's own wire size) assigned so far;
-// index rejects the tree once depth exceeds [MaxTreeDepth] or the depth-weighted bytes
-// exceed [MaxTreeRenderBytes], bounding the client render depth and the client-retained
-// node data (which the browser duplicates once per ancestor, [Node.Name] included) of a
-// tree that would otherwise stay within MaxTreeNodes.
-func (t *Tree) index(node *Node, jsPath string, seen map[*Node]bool, renderBytes *int, depth int) error {
+// serialized node size assigned so far; index rejects the tree once depth exceeds
+// [MaxTreeDepth] or the weighted bytes exceed [MaxTreeRenderBytes], bounding the client
+// render depth and the client-retained node data (which the browser holds once in the
+// init payload and once per ancestor element, [Node.Name] included) of a tree that would
+// otherwise stay within MaxTreeNodes.
+//
+// The count is int64 and the name is measured against the remaining budget, so a huge
+// name neither overflows the weighted product on a 32-bit build nor is encoded in full
+// before rejection.
+func (t *Tree) index(node *Node, jsPath string, seen map[*Node]bool, renderBytes *int64, depth int) error {
 	if len(t.byIndex) >= MaxTreeNodes {
 		return fmt.Errorf("%w: exceeds MaxTreeNodes (%d)", ErrInvalidTree, MaxTreeNodes)
 	}
 	if depth > MaxTreeDepth {
 		return fmt.Errorf("%w: exceeds MaxTreeDepth (%d)", ErrInvalidTree, MaxTreeDepth)
 	}
-	// Weight this node's whole serialized size (name, ID, structure) by depth: the
-	// browser retains it on this node's element and on each of its depth ancestors'.
-	nodeBytes := jsonStringBytes(node.Name) + len(jsPath) + nodeJSONOverhead
-	if *renderBytes += depth * nodeBytes; *renderBytes > MaxTreeRenderBytes {
+	// The browser retains this node's whole wire object (name, ID, structure) once in the
+	// init payload and once on each of its depth ancestor elements: depth+1 copies. Charge
+	// that, measuring the name only up to the budget that still fits so an over-long name
+	// is rejected without encoding all of it and the product cannot overflow.
+	weight := int64(depth) + 1
+	budget := int64(MaxTreeRenderBytes) - *renderBytes
+	nameLen := jsonStringLen(node.Name, budget/weight-int64(len(jsPath))-nodeJSONOverhead)
+	if *renderBytes += weight * (nameLen + int64(len(jsPath)) + nodeJSONOverhead); *renderBytes > MaxTreeRenderBytes {
 		return fmt.Errorf("%w: depth-weighted serialized node data exceeds MaxTreeRenderBytes (%d)", ErrInvalidTree, MaxTreeRenderBytes)
 	}
 	if seen[node] {

--- a/jawstree/tree.go
+++ b/jawstree/tree.go
@@ -34,18 +34,26 @@ const MaxTreeNodes = 180000
 // overflows.
 const MaxTreeDepth = 128
 
-// MaxTreeRenderBytes is the largest total size of the positional-path IDs [New]
-// accepts, weighted by depth: the sum over all nodes of depth times ID length.
+// MaxTreeRenderBytes is the largest depth-weighted serialized node size [New] accepts:
+// the sum over all nodes of depth times the node's own wire size (its JSON-escaped
+// name, positional-path ID, and fixed structural bytes).
 //
-// The browser renderer stores each node's whole subtree on its element, so a node's ID
-// is retained once for every ancestor that contains it — its depth-fold. Worst-case
-// client retention is therefore this depth-weighted sum, which the independent
-// [MaxTreeNodes], [MaxTreeDepth], and raw ID-byte bounds do not cap: a shallow spine
-// with a wide, deep fan-out passes them all yet duplicates its IDs across every
-// ancestor. [New] rejects a tree whose depth-weighted ID bytes exceed this limit with
-// [ErrInvalidTree], bounding worst-case client memory (and, since the weight is at
-// least one, the server-side ID memory and init payload) to a modest ceiling.
+// The browser renderer stores each node's whole subtree on its element, so a node's
+// serialized data — including its potentially large [Node.Name] — is retained once for
+// every ancestor that contains it, its depth-fold. Worst-case client retention is this
+// depth-weighted sum, which the independent [MaxTreeNodes] and [MaxTreeDepth] bounds do
+// not cap: a shallow spine with a wide, deep fan-out, or a deep chain of large names,
+// passes them yet duplicates its data across every ancestor. [New] rejects a tree whose
+// depth-weighted serialized size exceeds this limit with [ErrInvalidTree], bounding
+// worst-case client memory (and, since the weight is at least one, the server-side node
+// data and init payload) to a modest ceiling.
 const MaxTreeRenderBytes = 64 << 20 // 64 MiB
+
+// nodeJSONOverhead upper-bounds a node's fixed structural wire bytes: the object
+// braces, the field keys, the quotes around the ID, the optional boolean flag values,
+// the children brackets, and its separator in its parent. Added to the escaped name and
+// ID length to weigh each node's retained serialized size against [MaxTreeRenderBytes].
+const nodeJSONOverhead = 80
 
 // Tree is the shared, server-authoritative model behind a Quercus.js tree, and the
 // [jaws.UI] that renders it.
@@ -86,7 +94,7 @@ func makeTreeKey() (key string) {
 //
 // It returns [ErrInvalidTree] for a nil root, a cyclic or shared-node graph, a
 // negative or unknown [Option] bit, more than [MaxTreeNodes] nodes, nesting deeper than
-// [MaxTreeDepth], or depth-weighted positional-path IDs exceeding [MaxTreeRenderBytes],
+// [MaxTreeDepth], or depth-weighted serialized node data exceeding [MaxTreeRenderBytes],
 // and [ErrInvalidSelection] when the initial Selected flags violate the selection policy
 // (see [Tree.SetSelected]).
 //
@@ -149,10 +157,11 @@ func New(l sync.Locker, root *Node, options ...Option) (t *Tree, err error) {
 // single-child) tree returns [ErrInvalidTree] instead of overflowing the stack.
 //
 // depth is node's distance from the root and renderBytes accumulates the depth-weighted
-// ID size (sum of depth times ID length) assigned so far; index rejects the tree once
-// depth exceeds [MaxTreeDepth] or the depth-weighted bytes exceed [MaxTreeRenderBytes],
-// bounding the client render depth and the client-retained ID data (which the browser
-// duplicates once per ancestor) of a tree that would otherwise stay within MaxTreeNodes.
+// serialized node size (sum of depth times each node's own wire size) assigned so far;
+// index rejects the tree once depth exceeds [MaxTreeDepth] or the depth-weighted bytes
+// exceed [MaxTreeRenderBytes], bounding the client render depth and the client-retained
+// node data (which the browser duplicates once per ancestor, [Node.Name] included) of a
+// tree that would otherwise stay within MaxTreeNodes.
 func (t *Tree) index(node *Node, jsPath string, seen map[*Node]bool, renderBytes *int, depth int) error {
 	if len(t.byIndex) >= MaxTreeNodes {
 		return fmt.Errorf("%w: exceeds MaxTreeNodes (%d)", ErrInvalidTree, MaxTreeNodes)
@@ -160,9 +169,11 @@ func (t *Tree) index(node *Node, jsPath string, seen map[*Node]bool, renderBytes
 	if depth > MaxTreeDepth {
 		return fmt.Errorf("%w: exceeds MaxTreeDepth (%d)", ErrInvalidTree, MaxTreeDepth)
 	}
-	// Weight by depth: the browser stores this node's ID on each of its depth ancestors.
-	if *renderBytes += depth * len(jsPath); *renderBytes > MaxTreeRenderBytes {
-		return fmt.Errorf("%w: depth-weighted positional-path IDs exceed MaxTreeRenderBytes (%d)", ErrInvalidTree, MaxTreeRenderBytes)
+	// Weight this node's whole serialized size (name, ID, structure) by depth: the
+	// browser retains it on this node's element and on each of its depth ancestors'.
+	nodeBytes := jsonStringBytes(node.Name) + len(jsPath) + nodeJSONOverhead
+	if *renderBytes += depth * nodeBytes; *renderBytes > MaxTreeRenderBytes {
+		return fmt.Errorf("%w: depth-weighted serialized node data exceeds MaxTreeRenderBytes (%d)", ErrInvalidTree, MaxTreeRenderBytes)
 	}
 	if seen[node] {
 		return fmt.Errorf("%w: node %q is reachable more than once (cyclic or shared graph)", ErrInvalidTree, node.Name)

--- a/jawstree/tree.go
+++ b/jawstree/tree.go
@@ -39,12 +39,14 @@ const MaxTreeDepth = 128
 // name, positional-path ID, and fixed structural bytes).
 //
 // The browser holds each node's whole serialized data — its potentially large
-// [Node.Name] included — once in the init payload and once on every ancestor element
-// that stores its subtree, so each node's data is retained depth+1 times. This
-// depth-weighted sum is what the independent [MaxTreeNodes] and [MaxTreeDepth] bounds do
-// not cap: a shallow spine with a wide, deep fan-out, or a deep chain of large names,
-// passes them yet duplicates its data across every ancestor. [New] rejects a tree whose
-// depth-weighted serialized size exceeds this limit with [ErrInvalidTree].
+// [Node.Name] included — in the init payload and in the data-node-data of its own
+// element and each rendered ancestor's. A node at depth d therefore has its data held
+// d+1 times: once in the payload, once on its own element, and once on each of its d-1
+// rendered ancestors. This depth-weighted sum is what the independent [MaxTreeNodes] and
+// [MaxTreeDepth] bounds do not cap: a shallow spine with a wide, deep fan-out, or a deep
+// chain of large names, passes them yet duplicates its data across every level. [New]
+// rejects a tree whose depth-weighted serialized size exceeds this limit with
+// [ErrInvalidTree].
 //
 // The bound is on the retained serialized node data (the per-element data plus the init
 // payload), which is a proxy for, not the exact size of, client memory: the renderer
@@ -67,12 +69,12 @@ const nodeJSONOverhead = 80
 // tree; it holds no per-request state, so sharing it is safe.
 //
 // The tree is fixed once [New] returns: it derives each node's identity from its
-// position, and it validates the wire-shaping fields ([Node.Name], [Node.Disabled], and
-// the Children structure) against the [MaxTreeNodes], [MaxTreeDepth], and
-// [MaxTreeRenderBytes] bounds. Mutating selection (through [Tree.SetSelected] or browser
-// events) is safe under the lock, but changing a Name or adding, removing, or reordering
-// Children afterward is unsupported: rendering re-serializes the live tree, so such a
-// change can defeat the size bounds New enforced.
+// position and validates the wire-shaping state against the [MaxTreeNodes],
+// [MaxTreeDepth], and [MaxTreeRenderBytes] bounds. Only the selection may change
+// afterward, through [Tree.SetSelected] or browser events (safe under the lock); each
+// node's Name, Disabled, assigned ID, and the topology (Children) are fixed. Changing any
+// of them is unsupported: it breaks the identity mapping and, because rendering
+// re-serializes the live tree, can defeat the size bounds New enforced.
 type Tree struct {
 	bind.RWLocker         // guards root selection state and is the concurrency contract for Node accessors
 	key           string  // browser correlation key, unique per Tree
@@ -165,9 +167,9 @@ func New(l sync.Locker, root *Node, options ...Option) (t *Tree, err error) {
 // depth is node's distance from the root and renderBytes accumulates the depth-weighted
 // serialized node size assigned so far; index rejects the tree once depth exceeds
 // [MaxTreeDepth] or the weighted bytes exceed [MaxTreeRenderBytes], bounding the client
-// render depth and the client-retained node data (which the browser holds once in the
-// init payload and once per ancestor element, [Node.Name] included) of a tree that would
-// otherwise stay within MaxTreeNodes.
+// render depth and the client-retained node data (which the browser holds in the init
+// payload and on the node's own element plus each rendered ancestor's, [Node.Name]
+// included) of a tree that would otherwise stay within MaxTreeNodes.
 //
 // The count is int64 and the name is measured against the remaining budget, so a huge
 // name neither overflows the weighted product on a 32-bit build nor is encoded in full
@@ -179,8 +181,8 @@ func (t *Tree) index(node *Node, jsPath string, seen map[*Node]bool, renderBytes
 	if depth > MaxTreeDepth {
 		return fmt.Errorf("%w: exceeds MaxTreeDepth (%d)", ErrInvalidTree, MaxTreeDepth)
 	}
-	// The browser retains this node's whole wire object (name, ID, structure) once in the
-	// init payload and once on each of its depth ancestor elements: depth+1 copies. Charge
+	// The browser retains this node's whole wire object (name, ID, structure) in the init
+	// payload and on its own element plus each rendered ancestor's: depth+1 copies. Charge
 	// that, measuring the name only up to the budget that still fits so an over-long name
 	// is rejected without encoding all of it and the product cannot overflow.
 	weight := int64(depth) + 1

--- a/jawstree/tree.go
+++ b/jawstree/tree.go
@@ -35,18 +35,21 @@ const MaxTreeNodes = 180000
 const MaxTreeDepth = 128
 
 // MaxTreeRenderBytes is the largest depth-weighted serialized node size [New] accepts:
-// the sum over all nodes of depth times the node's own wire size (its JSON-escaped
+// the sum over all nodes of (depth+1) times the node's own wire size (its JSON-escaped
 // name, positional-path ID, and fixed structural bytes).
 //
 // The browser holds each node's whole serialized data — its potentially large
 // [Node.Name] included — once in the init payload and once on every ancestor element
-// that stores its subtree, so each node is retained depth+1 times. Worst-case client
-// retention is this depth-weighted sum, which the independent [MaxTreeNodes] and
-// [MaxTreeDepth] bounds do not cap: a shallow spine with a wide, deep fan-out, or a deep
-// chain of large names, passes them yet duplicates its data across every ancestor. [New]
-// rejects a tree whose depth-weighted serialized size exceeds this limit with
-// [ErrInvalidTree], bounding worst-case client memory (and, since every node is charged
-// at least once, the server-side node data and init payload) to a modest ceiling.
+// that stores its subtree, so each node's data is retained depth+1 times. This
+// depth-weighted sum is what the independent [MaxTreeNodes] and [MaxTreeDepth] bounds do
+// not cap: a shallow spine with a wide, deep fan-out, or a deep chain of large names,
+// passes them yet duplicates its data across every ancestor. [New] rejects a tree whose
+// depth-weighted serialized size exceeds this limit with [ErrInvalidTree].
+//
+// The bound is on the retained serialized node data (the per-element data plus the init
+// payload), which is a proxy for, not the exact size of, client memory: the renderer
+// also builds DOM from it, and cascade mode copies descendant data, so actual client
+// memory is a bounded multiple of this ceiling.
 const MaxTreeRenderBytes = 64 << 20 // 64 MiB
 
 // nodeJSONOverhead upper-bounds a node's fixed structural wire bytes: the object
@@ -63,10 +66,13 @@ const nodeJSONOverhead = 80
 // is built once and rendered by every request that should show the same collaborative
 // tree; it holds no per-request state, so sharing it is safe.
 //
-// The tree is structurally fixed once [New] returns: it derives each node's identity
-// from its position. Mutating selection (through [Tree.SetSelected] or browser events)
-// is safe under the lock, but adding, removing, or reordering Children afterward is
-// unsupported.
+// The tree is fixed once [New] returns: it derives each node's identity from its
+// position, and it validates the wire-shaping fields ([Node.Name], [Node.Disabled], and
+// the Children structure) against the [MaxTreeNodes], [MaxTreeDepth], and
+// [MaxTreeRenderBytes] bounds. Mutating selection (through [Tree.SetSelected] or browser
+// events) is safe under the lock, but changing a Name or adding, removing, or reordering
+// Children afterward is unsupported: rendering re-serializes the live tree, so such a
+// change can defeat the size bounds New enforced.
 type Tree struct {
 	bind.RWLocker         // guards root selection state and is the concurrency contract for Node accessors
 	key           string  // browser correlation key, unique per Tree

--- a/jawstree/tree.go
+++ b/jawstree/tree.go
@@ -92,11 +92,9 @@ func New(l sync.Locker, root *Node, options ...Option) (t *Tree, err error) {
 	// descendants' Parent, so enforce the invariant for the root here (a node reused
 	// as a new root could otherwise carry a stale Parent).
 	root.Parent = nil
+	// index enforces MaxTreeNodes during traversal, so byIndex never exceeds it.
 	if err = t.index(root, "", make(map[*Node]bool)); err != nil {
 		return nil, err
-	}
-	if len(t.byIndex) > MaxTreeNodes {
-		return nil, fmt.Errorf("%w: %d nodes exceeds MaxTreeNodes (%d)", ErrInvalidTree, len(t.byIndex), MaxTreeNodes)
 	}
 	// Validate the initial selection through the same policy the browser and server
 	// mutators use, so construction can never produce a state the policy rejects.
@@ -118,7 +116,15 @@ func New(l sync.Locker, root *Node, options ...Option) (t *Tree, err error) {
 // rather than overflowing the stack. Compacting before descending keeps each node's
 // slice index (its ID) matching its position in the wire array emitted by
 // marshalJSON, which skips nils.
+//
+// The [MaxTreeNodes] cap is enforced before indexing each node, so an oversized
+// tree is rejected mid-traversal rather than after being fully indexed. This bounds
+// the recursion depth to MaxTreeNodes, so a pathologically deep (in particular
+// single-child) tree returns [ErrInvalidTree] instead of overflowing the stack.
 func (t *Tree) index(node *Node, jsPath string, seen map[*Node]bool) error {
+	if len(t.byIndex) >= MaxTreeNodes {
+		return fmt.Errorf("%w: exceeds MaxTreeNodes (%d)", ErrInvalidTree, MaxTreeNodes)
+	}
 	if seen[node] {
 		return fmt.Errorf("%w: node %q is reachable more than once (cyclic or shared graph)", ErrInvalidTree, node.Name)
 	}

--- a/jawstree/tree.go
+++ b/jawstree/tree.go
@@ -24,6 +24,17 @@ const wsInboundLimit = 32 * 1024
 // [ErrInvalidTree]; TestSelectionFrameFitsInboundLimit pins the guarantee.
 const MaxTreeNodes = 180000
 
+// MaxTreePathBytes is the largest total size of the positional-path IDs [New]
+// assigns across all nodes.
+//
+// Each node's ID is its full path from the root ("children.0.children.1"), so a deep
+// tree retains ID data that grows with the square of its depth, independent of the
+// [MaxTreeNodes] count. [New] rejects a tree whose cumulative ID bytes exceed this
+// limit with [ErrInvalidTree], bounding the memory held for IDs (and the matching
+// init payload) to a modest ceiling. Any realistically shaped tree stays well within
+// it; only a pathologically deep tree is rejected.
+const MaxTreePathBytes = 64 << 20 // 64 MiB
+
 // Tree is the shared, server-authoritative model behind a Quercus.js tree, and the
 // [jaws.UI] that renders it.
 //
@@ -62,9 +73,9 @@ func makeTreeKey() (key string) {
 // New returns a shared tree model for root, guarded by l.
 //
 // It returns [ErrInvalidTree] for a nil root, a cyclic or shared-node graph, a
-// negative or unknown [Option] bit, or more than [MaxTreeNodes] nodes, and
-// [ErrInvalidSelection] when the initial Selected flags violate the selection policy
-// (see [Tree.SetSelected]).
+// negative or unknown [Option] bit, more than [MaxTreeNodes] nodes, or positional-path
+// IDs totalling more than [MaxTreePathBytes], and [ErrInvalidSelection] when the
+// initial Selected flags violate the selection policy (see [Tree.SetSelected]).
 //
 // New must run before rendering the Tree or using the name-path selection API. The
 // Tree renders its own container, so no caller-provided HTML id is required.
@@ -92,8 +103,9 @@ func New(l sync.Locker, root *Node, options ...Option) (t *Tree, err error) {
 	// descendants' Parent, so enforce the invariant for the root here (a node reused
 	// as a new root could otherwise carry a stale Parent).
 	root.Parent = nil
-	// index enforces MaxTreeNodes during traversal, so byIndex never exceeds it.
-	if err = t.index(root, "", make(map[*Node]bool)); err != nil {
+	// index enforces MaxTreeNodes and MaxTreePathBytes during traversal, so byIndex
+	// never exceeds the node cap and the retained ID bytes stay bounded.
+	if err = t.index(root, "", make(map[*Node]bool), new(int)); err != nil {
 		return nil, err
 	}
 	// Validate the initial selection through the same policy the browser and server
@@ -121,9 +133,16 @@ func New(l sync.Locker, root *Node, options ...Option) (t *Tree, err error) {
 // tree is rejected mid-traversal rather than after being fully indexed. This bounds
 // the recursion depth to MaxTreeNodes, so a pathologically deep (in particular
 // single-child) tree returns [ErrInvalidTree] instead of overflowing the stack.
-func (t *Tree) index(node *Node, jsPath string, seen map[*Node]bool) error {
+//
+// pathBytes accumulates the total size of the IDs assigned so far; index rejects the
+// tree once it exceeds [MaxTreePathBytes], bounding the quadratic ID growth of a deep
+// tree that would otherwise stay within MaxTreeNodes.
+func (t *Tree) index(node *Node, jsPath string, seen map[*Node]bool, pathBytes *int) error {
 	if len(t.byIndex) >= MaxTreeNodes {
 		return fmt.Errorf("%w: exceeds MaxTreeNodes (%d)", ErrInvalidTree, MaxTreeNodes)
+	}
+	if *pathBytes += len(jsPath); *pathBytes > MaxTreePathBytes {
+		return fmt.Errorf("%w: positional-path IDs exceed MaxTreePathBytes (%d)", ErrInvalidTree, MaxTreePathBytes)
 	}
 	if seen[node] {
 		return fmt.Errorf("%w: node %q is reachable more than once (cyclic or shared graph)", ErrInvalidTree, node.Name)
@@ -137,7 +156,7 @@ func (t *Tree) index(node *Node, jsPath string, seen map[*Node]bool) error {
 	}
 	for i, child := range node.Children {
 		child.Parent = node
-		if err := t.index(child, jsPath+"children."+strconv.Itoa(i), seen); err != nil {
+		if err := t.index(child, jsPath+"children."+strconv.Itoa(i), seen, pathBytes); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Fixes #127. Fixes #130.

Unbounded-resource failures in `jawstree.New` → `index`, fixed by independent guards
applied during the single indexing traversal. Each rejects with `ErrInvalidTree`.

## #127 — node cap ran after full recursion
`New` recursed the whole tree before the `len(t.byIndex) > MaxTreeNodes` guard, so a
deep single-child tree could overflow the goroutine stack before rejection. Fixed by
enforcing the cap *inside* `index` (`>=`); the redundant post-loop check is removed.

## #130 — quadratic / catastrophic node retention
`Node.ID` is the full root path (quadratic in depth), and the browser renderer
(`treeview.js:373`) stores each node's **whole serialized subtree** on **every ancestor**
element. Bounded by the guards below; the `Node.ID` wire format is unchanged.

## Guards (final) — all enforced in `index`

| Bound | Caps | Failure mode |
|---|---|---|
| `MaxTreeNodes` = 180000 | node count | wire selection frame; wide trees |
| `MaxTreeDepth` = 128 | nesting depth | browser `_renderTree` **stack overflow** (~2100 levels) |
| `MaxTreeRenderBytes` = 64 MiB | **depth-weighted serialized node size** | **client retention** |

### The render-byte metric (converged over review)
Worst-case serialized-data retention is `Σ_nodes (depth+1) × (own wire bytes)`: the browser holds each
node's whole serialized object — **`Node.Name` included** — in the init payload and in
the `data-node-data` of every element containing it: for the unrendered root, only the payload; for a non-root node at depth d, the payload plus its own element plus d-1 rendered ancestors (depth+1 copies).
The node/depth caps miss this product. Cases caught (all reproduced):
- depth-127 spine + 47,505 leaves → ~67 MiB server IDs, but **~8.5 B** retained chars;
- depth-128 chain sharing a 1 MiB **name** → **~8 GiB** (names weren't counted);
- a **>64 MiB root name** (root is charged once — its init-payload copy);
- a ~20 MiB name at depth 128 (`depth × bytes` **overflowed int32** on the 386 build).

Implementation:
- weight `depth+1`, so **every node is charged at least once** (root included);
- accumulator/products are **`int64`** — no 32-bit overflow (386 CI leg now runs
  `go test -short ./jawstree/...`, exercising `TestNew_RejectsLargeNameNoOverflow`);
- names measured by `jsonStringLen`, a **non-allocating** escaped-length counter that
  **stops at the per-node budget** — a hostile name is rejected without encoding it;
- the count matches `encoding/json` exactly (quotes, escapes, `<>&`, `�`, U+2028/9).

`MaxTreeDepth` is kept as the explicit browser-stack guard (Quercus is upstream, unmodifiable).

### Post-`New` immutability
The bound holds for the tree as validated by `New`. Documented (README + `Tree` +
`Node.Name`): once `New` returns, only the selection changes via `Tree` APIs; `Name`,
`Disabled`, assigned IDs, and topology are fixed — rendering re-serializes the live tree.

## Benchmark — `jsonStringLen` (json.Marshal baseline → non-allocating counter)
`benchstat` over the committed `BenchmarkJSONStringLen`, `-count 8` (amd64):

```
                         │  marshal (before) │        counter (after)         │
                         │      sec/op       │   sec/op     vs base           │
JSONStringLen/short-18         47.60n ± 2%    19.64n ± 1%   -58.74% (p=0.000)
JSONStringLen/large-18         5.671µ ± 0%   10.722µ ± 0%   +89.06% (p=0.000)
JSONStringLen/hostile-18   2030360.0n ± 2%    61.06n ± 0%  -100.00% (p=0.000)

                         │      B/op       │     B/op      vs base    │
JSONStringLen/short-18          40.00 ± 0%      0.00 ± 0%  -100.00%
JSONStringLen/large-18        12.03Ki ± 0%    0.00Ki ± 0%  -100.00%
JSONStringLen/hostile-18      4.057Mi ± 1%   0.000Mi ± 0%  -100.00%

                         │    allocs/op    │ allocs/op   vs base    │
(all three)                     2.000 ± 0%   0.000 ± 0%  -100.00%
```

Tradeoff, as measured: **zero allocations** everywhere (the goal — no allocation before
rejection); typical short names **−59%** time; hostile input **−100%** (2 ms → 61 ns) via
early cutoff; large *valid* names **+89%** time but still zero-alloc. `TestJSONStringLenZeroAllocs`
pins the zero-alloc contract.

## Docs
README `ErrInvalidTree` list documents `MaxTreeDepth` and `MaxTreeRenderBytes`.

## Tests
- `TestNew_NodeCapBoundary` — accepts exactly `MaxTreeNodes`, rejects +1.
- `TestIndexEnforcesCapDuringTraversal` — rejects mid-traversal; `byIndex` ≤ `MaxTreeNodes`.
- `TestNew_RejectsTreeDeeperThanMaxTreeDepth` — accepts at `MaxTreeDepth`, rejects one deeper.
- `TestNew_RejectsWideDeepTreeByRenderBytes` — combined depth-plus-width fan-out.
- `TestNew_RejectsNameHeavyDeepTreeByRenderBytes` — shared-large-name chain (needs name counting).
- `TestNew_RenderBytesBoundary` — root-heavy; pins the exact cutoff to the byte.
- `TestNew_RejectsLargeNameNoOverflow` — 32-bit product overflow guard (runs on the 386 leg).
- `TestJSONStringLen` / `TestJSONStringLenZeroAllocs` — counter matches `encoding/json`, early-cuts, zero-alloc.

Each guard verified load-bearing by surgically disabling it (only its test then fails).
`go test -race ./jawstree/`, `go vet`, `gofumpt`, `staticcheck`, and `GOOS=linux
GOARCH=386 go build` all clean.

Note: `MaxTreeRenderBytes = 64 MiB` is deliberately strict (it bounds the product, so it
also rejects very large *balanced* trees, which genuinely cost hundreds of MB in the
unmodifiable renderer). Tunable in one line.

