### PR TITLE
radiogroup: emit generated name=/for= on a fresh slice, first

### DIFF
--- a/lib/ui/radiogroup.go
+++ b/lib/ui/radiogroup.go
@@ -54,16 +54,27 @@ func (st *radioState) radioElem() *jaws.Element {
 
 // Radio renders an HTML input element of type radio.
 //
+// The group's generated name= attribute takes precedence over any name= passed
+// in params: it is emitted first and the HTML parser keeps the first of
+// duplicate attributes, preserving the invariant that every radio in the group
+// shares the same request-scoped name.
+//
 // Render errors are reported through [jaws.Jaws.MustLog], which panics when
 // no [jaws.Jaws.Logger] is configured.
 func (re RadioElement) Radio(params ...any) template.HTML {
 	radio := re.st.radioElem()
 	var sb strings.Builder
-	radio.Jaws.MustLog(radio.JawsRender(&sb, append(params, re.st.group.nameAttr)))
+	// A fresh slice with nameAttr first avoids mutating the caller's variadic
+	// backing array and makes the group name win over any caller-supplied name=.
+	radio.Jaws.MustLog(radio.JawsRender(&sb, append([]any{re.st.group.nameAttr}, params...)))
 	return template.HTML(sb.String()) // #nosec G203
 }
 
 // Label renders an HTML label element.
+//
+// The generated for= attribute referencing the radio's id takes precedence over
+// any for= passed in params: it is emitted first and the HTML parser keeps the
+// first of duplicate attributes, so the label always targets its own radio.
 //
 // Render errors are reported through [jaws.Jaws.MustLog], which panics when
 // no [jaws.Jaws.Logger] is configured.
@@ -74,7 +85,9 @@ func (re RadioElement) Label(params ...any) template.HTML {
 	}
 	var sb strings.Builder
 	forAttr := string(radio.Jid().AppendQuote([]byte("for=")))
-	re.st.label.Jaws.MustLog(re.st.label.JawsRender(&sb, append(params, forAttr)))
+	// A fresh slice with forAttr first avoids mutating the caller's variadic
+	// backing array and makes the generated for= win over any caller-supplied for=.
+	re.st.label.Jaws.MustLog(re.st.label.JawsRender(&sb, append([]any{forAttr}, params...)))
 	return template.HTML(sb.String()) // #nosec G203
 }
 

--- a/lib/ui/radiogroup_test.go
+++ b/lib/ui/radiogroup_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"html/template"
 	"strings"
 	"testing"
 
@@ -17,14 +18,64 @@ func TestRequest_RadioGroup(t *testing.T) {
 	rel := rw.RadioGroup(nba)
 
 	gotHTML := string(rel[0].Radio("radioattr"))
-	if gotHTML != `<input id="Jid.1" type="radio" radioattr name="Jid.1">` {
+	if gotHTML != `<input id="Jid.1" type="radio" name="Jid.1" radioattr>` {
 		t.Errorf("unexpected radio HTML %q", gotHTML)
 	}
 
-	wantHTML := "<label id=\"Jid.2\" labelattr for=\"Jid.1\">one</label>"
+	wantHTML := "<label id=\"Jid.2\" for=\"Jid.1\" labelattr>one</label>"
 	gotHTML = string(rel[0].Label("labelattr"))
 	if gotHTML != wantHTML {
 		t.Errorf("got %q, want %q", gotHTML, wantHTML)
+	}
+}
+
+// TestRequest_RadioGroup_DoesNotMutateCallerParams verifies Radio and Label do
+// not write their generated attribute into the caller's variadic backing array
+// when it has spare capacity (cap > len).
+func TestRequest_RadioGroup_DoesNotMutateCallerParams(t *testing.T) {
+	_, rq := newCoreRequest(t)
+	rw := RequestWriter{Request: rq, Writer: &strings.Builder{}}
+
+	nba := named.NewBoolArray(false)
+	nba.Add("1", "one")
+	rel := rw.RadioGroup(nba)
+
+	// len 1, spare capacity: a buggy append(params, internalAttr) would write the
+	// framework attribute into index 1, past the caller's length.
+	radioParams := make([]any, 1, 4)
+	radioParams[0] = template.HTMLAttr(`class="x"`)
+	_ = rel[0].Radio(radioParams...)
+	if full := radioParams[:cap(radioParams)]; full[1] != nil {
+		t.Fatalf("Radio mutated caller params backing array: %v", full)
+	}
+
+	labelParams := make([]any, 1, 4)
+	labelParams[0] = template.HTMLAttr(`class="y"`)
+	_ = rel[0].Label(labelParams...)
+	if full := labelParams[:cap(labelParams)]; full[1] != nil {
+		t.Fatalf("Label mutated caller params backing array: %v", full)
+	}
+}
+
+// TestRequest_RadioGroup_GeneratedAttrWins verifies the framework-controlled
+// name= / for= attribute takes precedence over a caller-supplied duplicate: it
+// is emitted first, and the HTML parser keeps the first of duplicate attributes.
+func TestRequest_RadioGroup_GeneratedAttrWins(t *testing.T) {
+	_, rq := newCoreRequest(t)
+	rw := RequestWriter{Request: rq, Writer: &strings.Builder{}}
+
+	nba := named.NewBoolArray(false)
+	nba.Add("1", "one")
+	rel := rw.RadioGroup(nba)
+
+	got := string(rel[0].Radio(template.HTMLAttr(`name="caller"`)))
+	if want := `<input id="Jid.1" type="radio" name="Jid.1" name="caller">`; got != want {
+		t.Errorf("Radio: got %q, want %q", got, want)
+	}
+
+	gotLabel := string(rel[0].Label(template.HTMLAttr(`for="caller"`)))
+	if want := `<label id="Jid.2" for="Jid.1" for="caller">one</label>`; gotLabel != want {
+		t.Errorf("Label: got %q, want %q", gotLabel, want)
 	}
 }
 


### PR DESCRIPTION
Fixes #128.

## Problem

`RadioElement.Radio` and `RadioElement.Label` did `append(params, internalAttr)` on the caller's variadic slice, which caused two defects:

1. **Slice aliasing (the reported bug).** When a caller passed a slice with spare capacity (`re.Radio(mySlice...)`), `append` wrote the generated attribute into the caller's backing array past its length — a stray attribute the caller could later observe.

2. **Attribute precedence (raised in the issue thread).** The generated `name=` / `for=` was appended *after* the caller's params. A caller-supplied `name=`/`for=` therefore appeared first, and since the HTML parser keeps the first of duplicate attributes, the caller's value won. That violated RadioGroup's documented invariant that every radio shares its request-scoped generated name, and could make a `Label` target the wrong element.

## Fix

Build the render params on a **fresh** `[]any` with the framework-controlled attribute **first**, then the caller's params:

```go
radio.JawsRender(&sb, append([]any{re.st.group.nameAttr}, params...))
```

- A fresh slice never touches the caller's backing array (aliasing fixed).
- Emitting the generated attribute first makes it win the duplicate-attribute rule (precedence fixed).

This mirrors the existing precedent in `renderFloatInput`, which prepends `value=""` for the same reason ("the HTML parser keeps the first of duplicate attributes").

## Tests

- `TestRequest_RadioGroup_DoesNotMutateCallerParams` — asserts a spare-capacity caller slice is untouched after `Radio`/`Label`.
- `TestRequest_RadioGroup_GeneratedAttrWins` — asserts the generated `name=`/`for=` is emitted before a caller-supplied duplicate.
- Updated the existing `TestRequest_RadioGroup` expectations for the new (correct) attribute order.

`go test -race ./...` passes.