### PR TITLE
Fix #129: enforce MaxClientJsVarBytes on each browser write

### DIFF
--- a/lib/ui/errjsvar.go
+++ b/lib/ui/errjsvar.go
@@ -29,9 +29,10 @@ var ErrJsVarArgumentType = errors.New("expected jaws.UI or JsVarMaker")
 
 // ErrJsVarTooLarge reports that a client-writable JsVar grew past [MaxClientJsVarBytes].
 //
-// It is returned by [JsVar.JawsRender] when the serialized size of a JsVar that does
-// not implement [PathSetter] exceeds the cap; the [jaws.Request] is aborted. See the
-// [JsVar] SECURITY note.
+// It aborts the [jaws.Request] for a JsVar that does not implement [PathSetter]:
+// [JsVar.JawsInput] returns it on the first browser write whose accounted size
+// exceeds the cap, and [JsVar.JawsRender] returns it when an over-cap value is
+// present at render. See the [JsVar] SECURITY note.
 var ErrJsVarTooLarge = errors.New("jsvar: serialized value exceeds MaxClientJsVarBytes")
 
 // ErrIllegalJsVarPath reports that a JsVar path contained a protocol byte.

--- a/lib/ui/errjsvar.go
+++ b/lib/ui/errjsvar.go
@@ -27,12 +27,12 @@ func (errIllegalJsVarName) Is(target error) bool {
 // argument that is neither a JaWS UI nor a [JsVarMaker].
 var ErrJsVarArgumentType = errors.New("expected jaws.UI or JsVarMaker")
 
-// ErrJsVarTooLarge reports that a client-writable JsVar grew past [MaxClientJsVarBytes].
+// ErrJsVarTooLarge reports a failed client-writable JsVar size check.
 //
 // It aborts the [jaws.Request] for a JsVar that does not implement [PathSetter]:
-// [JsVar.JawsInput] returns it on the first browser write whose accounted size
-// exceeds the cap, and [JsVar.JawsRender] returns it when an over-cap value is
-// present at render. See the [JsVar] SECURITY note.
+// [JsVar.JawsInput] returns it when a boundary confirmation finds the serialized
+// size over the cap or cannot marshal the value, and [JsVar.JawsRender] returns it
+// when an over-cap value is present at render. See the [JsVar] SECURITY note.
 var ErrJsVarTooLarge = errors.New("jsvar: serialized value exceeds MaxClientJsVarBytes")
 
 // ErrIllegalJsVarPath reports that a JsVar path contained a protocol byte.

--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -229,19 +229,23 @@ func (jsvar *JsVar[T]) exceedsClientJsVarCap(n int) bool {
 	return jsvar.capApplies() && n > MaxClientJsVarBytes
 }
 
-// accountClientWrite folds the growth of the latest client mutation into the
-// running serialized-size estimate and reports the resulting size and whether it
-// now exceeds [MaxClientJsVarBytes].
+// accountClientWrite folds the growth of the latest client write into the running
+// serialized-size estimate and reports the resulting size and whether it now
+// exceeds [MaxClientJsVarBytes].
 //
-// valueBytes is the marshaled length of the value just applied. Because
-// [github.com/linkdata/jq.Set] only grows the bound value by appending a single
-// slice element (never creating intermediate structure), the actual serialized
-// growth of any one write is at most valueBytes plus one JSON separator, so adding
-// that upper bound keeps the estimate at or above the true size. When the estimate
-// crosses the cap the true size is confirmed by a single marshal of Ptr, which
-// also reclaims any over-count so a value legitimately under the cap does not force
-// a marshal on every later write. It returns overCap only for a size confirmed by
-// that marshal, never on the estimate alone.
+// valueBytes is the marshaled length of the value the client sent.
+// [github.com/linkdata/jq.Set] grows the bound value only by appending a single
+// slice element (it never creates intermediate structure), so for an accepted append
+// valueBytes plus one JSON separator is an upper bound on the growth and the estimate
+// stays at or above the true size. A rejected append (wrong type, or a zero value the
+// setter reports unchanged) still enlarges the slice and is accounted too; valueBytes
+// may then differ from the stored element's size, but the fold is strictly positive,
+// so the estimate keeps rising until the boundary marshal below reconciles it.
+//
+// When the estimate crosses the cap the true size is confirmed by a single marshal of
+// Ptr, which also reclaims any over-count so a value legitimately under the cap does
+// not force a marshal on every later write. overCap is reported only for a size
+// confirmed by that marshal, never on the estimate alone.
 //
 // It is called only when [JsVar.capApplies] is true and acquires the write lock.
 func (jsvar *JsVar[T]) accountClientWrite(valueBytes int) (size int, overCap bool) {
@@ -282,37 +286,46 @@ func (jsvar *JsVar[T]) setPathAndGetTag(elem *jaws.Element, jsPath string, value
 func (jsvar *JsVar[T]) setPathLock(elem *jaws.Element, jsPath string, value any, clientWrite bool) (broadcasted bool, err error) {
 	jsvar.setMu.Lock()
 	defer jsvar.setMu.Unlock()
+
 	var dirtyTag any
-	if dirtyTag, err = jsvar.setPathAndGetTag(elem, jsPath, value); err != nil {
-		return
-	}
+	dirtyTag, err = jsvar.setPathAndGetTag(elem, jsPath, value)
+
+	// A client write is size-accounted even when the mutation reports an error.
+	// jq.Set grows a slice (SetLen) before it assigns the appended element, so an
+	// append can enlarge the bound value yet still report ErrValueUnchanged (a
+	// zero-value append the assign treats as no change) or a type-mismatch error (a
+	// wrong-typed append that leaves the new element at its zero value). Gating the
+	// cap on a clean mutation would let either append flood grow server state without
+	// bound. Only the broadcast is withheld when the mutation failed.
+	accountSize := clientWrite && jsvar.capApplies()
+	willBroadcast := err == nil && elem != nil && dirtyTag != nil
 
 	// Marshal the applied value once, outside the caller-provided lock: value is the
 	// caller-owned argument (not read from Ptr), and jaws.Broadcast can block on the
 	// broadcast channel under backpressure. The private setMu remains held so
 	// concurrent setters cannot apply a later mutation before this write's size
 	// accounting and broadcast complete. Code sharing the caller-provided locker is
-	// therefore not stalled by transport backpressure.
-	//
-	// dirtyTag is assigned only in JawsRender, so a set before the first render
-	// leaves it nil. A what.Set with a nil Dest would target every element, and there
-	// is nothing to update yet because the initial render carries the value in its
-	// data-jawsdata attribute, so the broadcast is skipped in that case. A client
-	// write still needs the marshaled length to enforce MaxClientJsVarBytes, so the
-	// value is marshaled whenever either the broadcast or the size accounting needs it.
-	willBroadcast := elem != nil && dirtyTag != nil
-	accountSize := clientWrite && jsvar.capApplies()
+	// therefore not stalled by transport backpressure. The size accounting needs the
+	// marshaled length and the broadcast needs the encoded value, so the value is
+	// marshaled whenever either needs it. value came from json.Unmarshal in JawsInput,
+	// so this marshal does not fail in practice; a failure is reported only when no
+	// mutation error already stands.
 	var data []byte
 	if willBroadcast || accountSize {
-		if data, err = json.Marshal(value); err != nil {
+		var marshalErr error
+		if data, marshalErr = json.Marshal(value); marshalErr != nil {
+			if err == nil {
+				err = marshalErr
+			}
 			return
 		}
 	}
 
 	// Enforce MaxClientJsVarBytes on the accumulated growth from untrusted browser
-	// writes, aborting the request on the first over-cap write rather than relying on
-	// a later render that a normally rendered JsVar never performs. Programmatic writes
-	// (JawsSetPath) are trusted and not capped; see MaxClientJsVarBytes.
+	// writes, aborting the request on the first confirmed over-cap write rather than
+	// relying on a later render that a normally rendered JsVar never performs. An
+	// over-cap abort supersedes any mutation error. Programmatic writes (JawsSetPath)
+	// are trusted and not capped; see MaxClientJsVarBytes.
 	if accountSize {
 		if size, overCap := jsvar.accountClientWrite(len(data)); overCap {
 			err = ErrJsVarTooLarge
@@ -323,6 +336,11 @@ func (jsvar *JsVar[T]) setPathLock(elem *jaws.Element, jsPath string, value any,
 		}
 	}
 
+	// dirtyTag is assigned only in JawsRender, so a set before the first render leaves
+	// it nil. A what.Set with a nil Dest would target every element, and there is
+	// nothing to update yet because the initial render carries the value in its
+	// data-jawsdata attribute, so the broadcast is skipped in that case (willBroadcast).
+	//
 	// The broadcast carries the caller's requested value, not the value actually
 	// stored. If a PathSetter coerces or rejects the input (e.g. clamps a number), the
 	// stored Go value and the value seen by peers can differ; the stored value is what
@@ -469,10 +487,12 @@ func elideErrValueUnchanged(err error) error {
 //
 // A single incoming message is already bounded by the connection's WebSocket read
 // limit (SetReadLimit in the request handler). To also bound cumulative growth, a
-// non-[PathSetter] value is size-accounted after each applied write and the request
-// is aborted with [ErrJsVarTooLarge] on the first write that pushes the serialized
-// value past [MaxClientJsVarBytes]. The accounting folds an upper bound on each
-// write's growth into a running total and marshals the whole value only when that
+// non-[PathSetter] value is size-accounted after each browser write — including a
+// write the bound value rejects, because [github.com/linkdata/jq.Set] grows a slice
+// before assigning the appended element, so even a rejected append enlarges server
+// state. The request is aborted with [ErrJsVarTooLarge] on the first write whose
+// confirmed serialized size passes [MaxClientJsVarBytes]. The accounting folds a
+// per-write bound into a running total and marshals the whole value only when that
 // total crosses the cap, so an append flood stays O(n) rather than O(n^2).
 func (jsvar *JsVar[T]) JawsInput(elem *jaws.Element, value string) (err error) {
 	err = jaws.ErrEventUnhandled

--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -153,13 +153,14 @@ var (
 // has no json tag (a json:"-" tag is never writable) — and append to slices one
 // element per message. The size of any single client write is bounded by the
 // WebSocket read limit; to also stop a hostile client growing server state without
-// bound across many writes, a non-[PathSetter] value is size-accounted after each
-// browser write and the [jaws.Request] is aborted with [ErrJsVarTooLarge] on the
-// first write that pushes the serialized value past [MaxClientJsVarBytes] (an
-// over-cap value present at render is likewise rejected). The cap does not prevent
-// a client from setting individual exported fields, so when only some fields/paths
-// should be client-writable, implement [PathSetter] on the bound value to
-// allow-list paths and bound lengths.
+// bound across many writes, a non-[PathSetter] value accumulates raw client-write
+// payload lengths as an approximate size. When the approximation crosses
+// [MaxClientJsVarBytes], [json.Marshal] measures the exact serialized size. An
+// over-cap value or failed measurement aborts the [jaws.Request] with
+// [ErrJsVarTooLarge] (an over-cap value present at render is likewise rejected).
+// The cap does not prevent a client from setting individual exported fields, so
+// when only some fields/paths should be client-writable, implement [PathSetter] on
+// the bound value to allow-list paths and bound lengths.
 // See jawstree's Node for an example that restricts client writes to a single
 // boolean field.
 type JsVar[T any] struct {
@@ -167,7 +168,7 @@ type JsVar[T any] struct {
 	Ptr       *T         // bound Go value
 	setMu     sync.Mutex // serializes each mutation with its broadcast
 	dirtyTag  any        // current dirty tag, set during render; read via JawsGetTag
-	jsonBytes int        // running serialized-size estimate of Ptr; guarded by the write lock, maintained for client writes
+	jsonBytes int        // approximate serialized size of Ptr; guarded by the write lock, maintained for client writes
 }
 
 // MaxClientJsVarBytes bounds the JSON-serialized size of a client-writable [JsVar]
@@ -175,9 +176,10 @@ type JsVar[T any] struct {
 //
 // Without it, a hostile browser could grow such a JsVar's server-side state without
 // bound across many writes (each single write is already bounded by the WebSocket
-// read limit). The serialized size is accounted after each browser write and a value
-// larger than the cap aborts the [jaws.Request] with [ErrJsVarTooLarge] on the first
-// over-cap write; an over-cap value present at render is rejected there instead.
+// read limit). Raw client-write payload lengths are added to an approximate size;
+// whenever it crosses the cap, [json.Marshal] confirms the exact size. A confirmed
+// over-cap value or failed confirmation aborts the [jaws.Request] with
+// [ErrJsVarTooLarge]; an over-cap value present at render is rejected there instead.
 //
 // Set it once before serving requests; a value <= 0 disables the cap, and values
 // that implement [PathSetter] enforce their own bounds and are exempt. It is a
@@ -229,34 +231,28 @@ func (jsvar *JsVar[T]) exceedsClientJsVarCap(n int) bool {
 	return jsvar.capApplies() && n > MaxClientJsVarBytes
 }
 
-// accountClientWrite folds the growth of the latest client write into the running
-// serialized-size estimate and reports the resulting size and whether it now
-// exceeds [MaxClientJsVarBytes].
+// accountClientWrite adds the latest client-write payload to the approximate size
+// and confirms the exact serialized size when the approximation crosses the cap.
 //
-// valueBytes is the marshaled length of the value the client sent.
-// [github.com/linkdata/jq.Set] grows the bound value only by appending a single
-// slice element (it never creates intermediate structure), so for an accepted append
-// valueBytes plus one JSON separator is an upper bound on the growth and the estimate
-// stays at or above the true size. A rejected append (wrong type, or a zero value the
-// setter reports unchanged) still enlarges the slice and is accounted too; valueBytes
-// may then differ from the stored element's size, but the fold is strictly positive,
-// so the estimate keeps rising until the boundary marshal below reconciles it.
+// clientBytes is the length of the raw browser write. The approximation deliberately
+// avoids reproducing [json.Marshal]'s size rules. When it looks too large, marshaling
+// Ptr supplies the authoritative size and resets the approximation. overCap is true
+// only for an exact size confirmed by that marshal.
 //
-// When the estimate crosses the cap the true size is confirmed by a single marshal of
-// Ptr, which also reclaims any over-count so a value legitimately under the cap does
-// not force a marshal on every later write. overCap is reported only for a size
-// confirmed by that marshal, never on the estimate alone.
-//
-// It is called only when [JsVar.capApplies] is true and acquires the write lock.
-func (jsvar *JsVar[T]) accountClientWrite(valueBytes int) (size int, overCap bool) {
+// It is called only when [JsVar.capApplies] is true. clientBytes must be
+// non-negative.
+func (jsvar *JsVar[T]) accountClientWrite(clientBytes int) (size int, overCap bool, err error) {
 	jsvar.Lock()
 	defer jsvar.Unlock()
-	jsvar.jsonBytes += valueBytes + 1
-	if jsvar.jsonBytes > MaxClientJsVarBytes {
-		if data, err := json.Marshal(jsvar.Ptr); err == nil {
+	limit := MaxClientJsVarBytes
+	if jsvar.jsonBytes > limit || clientBytes > limit-jsvar.jsonBytes {
+		var data []byte
+		if data, err = json.Marshal(jsvar.Ptr); err == nil {
 			jsvar.jsonBytes = len(data)
-			overCap = jsvar.jsonBytes > MaxClientJsVarBytes
+			overCap = jsvar.jsonBytes > limit
 		}
+	} else {
+		jsvar.jsonBytes += clientBytes
 	}
 	size = jsvar.jsonBytes
 	return
@@ -283,7 +279,7 @@ func (jsvar *JsVar[T]) setPathAndGetTag(elem *jaws.Element, jsPath string, value
 	return
 }
 
-func (jsvar *JsVar[T]) setPathLock(elem *jaws.Element, jsPath string, value any, clientWrite bool) (broadcasted bool, err error) {
+func (jsvar *JsVar[T]) setPathLock(elem *jaws.Element, jsPath string, value any, clientWrite bool, clientBytes int) (broadcasted bool, abortSize int, abortErr, err error) {
 	jsvar.setMu.Lock()
 	defer jsvar.setMu.Unlock()
 
@@ -299,39 +295,37 @@ func (jsvar *JsVar[T]) setPathLock(elem *jaws.Element, jsPath string, value any,
 	// bound. Only the broadcast is withheld when the mutation failed.
 	accountSize := clientWrite && jsvar.capApplies()
 	willBroadcast := err == nil && elem != nil && dirtyTag != nil
+	if accountSize {
+		size, overCap, accountErr := jsvar.accountClientWrite(clientBytes)
+		if accountErr != nil {
+			// Do not expose an application marshal error through the event-handler
+			// chain: it may match a handler-control error such as ErrEventUnhandled.
+			err = ErrJsVarTooLarge
+			abortErr = accountErr
+			return
+		}
+		if overCap {
+			err = ErrJsVarTooLarge
+			abortSize = size
+			abortErr = ErrJsVarTooLarge
+			return
+		}
+	}
+	// Elide only the setter's unchanged result. In particular, an exact-size
+	// confirmation error must remain visible even if it matches ErrValueUnchanged.
+	if clientWrite {
+		err = elideErrValueUnchanged(err)
+	}
 
 	// Marshal the applied value once, outside the caller-provided lock: value is the
 	// caller-owned argument (not read from Ptr), and jaws.Broadcast can block on the
 	// broadcast channel under backpressure. The private setMu remains held so
 	// concurrent setters cannot apply a later mutation before this write's size
 	// accounting and broadcast complete. Code sharing the caller-provided locker is
-	// therefore not stalled by transport backpressure. The size accounting needs the
-	// marshaled length and the broadcast needs the encoded value, so the value is
-	// marshaled whenever either needs it. value came from json.Unmarshal in JawsInput,
-	// so this marshal does not fail in practice; a failure is reported only when no
-	// mutation error already stands.
+	// therefore not stalled by transport backpressure.
 	var data []byte
-	if willBroadcast || accountSize {
-		var marshalErr error
-		if data, marshalErr = json.Marshal(value); marshalErr != nil {
-			if err == nil {
-				err = marshalErr
-			}
-			return
-		}
-	}
-
-	// Enforce MaxClientJsVarBytes on the accumulated growth from untrusted browser
-	// writes, aborting the request on the first confirmed over-cap write rather than
-	// relying on a later render that a normally rendered JsVar never performs. An
-	// over-cap abort supersedes any mutation error. Programmatic writes (JawsSetPath)
-	// are trusted and not capped; see MaxClientJsVarBytes.
-	if accountSize {
-		if size, overCap := jsvar.accountClientWrite(len(data)); overCap {
-			err = ErrJsVarTooLarge
-			if elem != nil {
-				elem.Request.Cancel(fmt.Errorf("jaws: jsvar serialized size %d exceeds MaxClientJsVarBytes (%d)", size, MaxClientJsVarBytes))
-			}
+	if willBroadcast {
+		if data, err = json.Marshal(value); err != nil {
 			return
 		}
 	}
@@ -357,7 +351,7 @@ func (jsvar *JsVar[T]) setPathLock(elem *jaws.Element, jsPath string, value any,
 	return
 }
 
-func (jsvar *JsVar[T]) setPath(elem *jaws.Element, jsPath string, value any, clientWrite bool) (err error) {
+func (jsvar *JsVar[T]) setPath(elem *jaws.Element, jsPath string, value any, clientWrite bool, clientBytes int) (err error) {
 	// jsPath is written verbatim into a what.Set wire frame (only the value side
 	// is JSON-encoded). The client splits frames on '\n', fields on '\t', and the
 	// JsVar payload at the first '='. Reject any path carrying those protocol
@@ -367,7 +361,19 @@ func (jsvar *JsVar[T]) setPath(elem *jaws.Element, jsPath string, value any, cli
 		return ErrIllegalJsVarPath
 	}
 	var broadcasted bool
-	if broadcasted, err = jsvar.setPathLock(elem, jsPath, value, clientWrite); err == nil && broadcasted {
+	var abortSize int
+	var abortErr error
+	broadcasted, abortSize, abortErr, err = jsvar.setPathLock(elem, jsPath, value, clientWrite, clientBytes)
+	if abortErr != nil && elem != nil && elem.Request != nil {
+		var cause error
+		if abortSize > 0 {
+			cause = fmt.Errorf("%w: serialized size %d exceeds MaxClientJsVarBytes (%d)", ErrJsVarTooLarge, abortSize, MaxClientJsVarBytes)
+		} else {
+			cause = fmt.Errorf("%w: cannot serialize jsvar after client write: %w", ErrJsVarTooLarge, abortErr)
+		}
+		elem.Request.Cancel(cause)
+	}
+	if err == nil && broadcasted {
 		if sp, ok := any(jsvar.Ptr).(SetPather); ok {
 			sp.JawsPathSet(elem, jsPath, value)
 		}
@@ -387,7 +393,7 @@ func (jsvar *JsVar[T]) setPath(elem *jaws.Element, jsPath string, value any, cli
 // page between its initial render and its broadcast subscription; see [JsVar]
 // for the synchronization model.
 func (jsvar *JsVar[T]) JawsSetPath(elem *jaws.Element, jsPath string, value any) (err error) {
-	return jsvar.setPath(elem, jsPath, value, false)
+	return jsvar.setPath(elem, jsPath, value, false, 0)
 }
 
 // JawsSet replaces the root value and broadcasts the change.
@@ -491,15 +497,18 @@ func elideErrValueUnchanged(err error) error {
 // write the bound value rejects, because [github.com/linkdata/jq.Set] grows a slice
 // before assigning the appended element, so even a rejected append enlarges server
 // state. The request is aborted with [ErrJsVarTooLarge] on the first write whose
-// confirmed serialized size passes [MaxClientJsVarBytes]. The accounting folds a
-// per-write bound into a running total and marshals the whole value only when that
-// total crosses the cap, so an append flood stays O(n) rather than O(n^2).
+// confirmed serialized size passes [MaxClientJsVarBytes]. Accounting adds the raw
+// client-write payload length to an approximate running size and marshals the whole
+// value only when that approximation crosses the cap, so an append flood stays O(n)
+// rather than O(n^2). A marshaling error during confirmation also aborts the
+// request and returns [ErrJsVarTooLarge], with the marshal error retained as its
+// cancellation cause.
 func (jsvar *JsVar[T]) JawsInput(elem *jaws.Element, value string) (err error) {
 	err = jaws.ErrEventUnhandled
 	if jsPath, jsValue, found := strings.Cut(value, "="); found {
 		var v any
 		if err = json.Unmarshal([]byte(jsValue), &v); err == nil {
-			err = elideErrValueUnchanged(jsvar.setPath(elem, jsPath, v, true))
+			err = jsvar.setPath(elem, jsPath, v, true, len(value))
 		}
 	}
 	return

--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -153,18 +153,21 @@ var (
 // has no json tag (a json:"-" tag is never writable) — and append to slices one
 // element per message. The size of any single client write is bounded by the
 // WebSocket read limit; to also stop a hostile client growing server state without
-// bound across many writes, a non-[PathSetter] value whose serialized size exceeds
-// [MaxClientJsVarBytes] aborts the [jaws.Request] when it is next rendered
-// ([ErrJsVarTooLarge]). The cap does not prevent a client from setting individual
-// exported fields, so when only some fields/paths should be client-writable,
-// implement [PathSetter] on the bound value to allow-list paths and bound lengths.
+// bound across many writes, a non-[PathSetter] value is size-accounted after each
+// browser write and the [jaws.Request] is aborted with [ErrJsVarTooLarge] on the
+// first write that pushes the serialized value past [MaxClientJsVarBytes] (an
+// over-cap value present at render is likewise rejected). The cap does not prevent
+// a client from setting individual exported fields, so when only some fields/paths
+// should be client-writable, implement [PathSetter] on the bound value to
+// allow-list paths and bound lengths.
 // See jawstree's Node for an example that restricts client writes to a single
 // boolean field.
 type JsVar[T any] struct {
 	bind.RWLocker
-	Ptr      *T         // bound Go value
-	setMu    sync.Mutex // serializes each mutation with its broadcast
-	dirtyTag any        // current dirty tag, set during render; read via JawsGetTag
+	Ptr       *T         // bound Go value
+	setMu     sync.Mutex // serializes each mutation with its broadcast
+	dirtyTag  any        // current dirty tag, set during render; read via JawsGetTag
+	jsonBytes int        // running serialized-size estimate of Ptr; guarded by the write lock, maintained for client writes
 }
 
 // MaxClientJsVarBytes bounds the JSON-serialized size of a client-writable [JsVar]
@@ -172,8 +175,9 @@ type JsVar[T any] struct {
 //
 // Without it, a hostile browser could grow such a JsVar's server-side state without
 // bound across many writes (each single write is already bounded by the WebSocket
-// read limit). A value larger than the cap aborts the [jaws.Request] with
-// [ErrJsVarTooLarge] when next rendered.
+// read limit). The serialized size is accounted after each browser write and a value
+// larger than the cap aborts the [jaws.Request] with [ErrJsVarTooLarge] on the first
+// over-cap write; an over-cap value present at render is rejected there instead.
 //
 // Set it once before serving requests; a value <= 0 disables the cap, and values
 // that implement [PathSetter] enforce their own bounds and are exempt. It is a
@@ -203,16 +207,55 @@ func (jsvar *JsVar[T]) JawsGet(elem *jaws.Element) (value T) {
 	return
 }
 
+// capApplies reports whether client-write size accounting is active for this
+// JsVar: [MaxClientJsVarBytes] is positive and the bound value does not implement
+// [PathSetter]. A PathSetter enforces its own bounds and is exempt.
+//
+// The result depends only on the package global and the static type of Ptr, so it
+// needs no lock.
+func (jsvar *JsVar[T]) capApplies() bool {
+	if MaxClientJsVarBytes <= 0 {
+		return false
+	}
+	_, isPathSetter := any(jsvar.Ptr).(PathSetter)
+	return !isPathSetter
+}
+
 // exceedsClientJsVarCap reports whether n bytes exceeds the configured
 // [MaxClientJsVarBytes] for this JsVar. Values implementing [PathSetter] enforce
 // their own bounds, so the cap does not apply to them, and a non-positive
 // MaxClientJsVarBytes disables it.
 func (jsvar *JsVar[T]) exceedsClientJsVarCap(n int) bool {
-	if MaxClientJsVarBytes <= 0 || n <= MaxClientJsVarBytes {
-		return false
+	return jsvar.capApplies() && n > MaxClientJsVarBytes
+}
+
+// accountClientWrite folds the growth of the latest client mutation into the
+// running serialized-size estimate and reports the resulting size and whether it
+// now exceeds [MaxClientJsVarBytes].
+//
+// valueBytes is the marshaled length of the value just applied. Because
+// [github.com/linkdata/jq.Set] only grows the bound value by appending a single
+// slice element (never creating intermediate structure), the actual serialized
+// growth of any one write is at most valueBytes plus one JSON separator, so adding
+// that upper bound keeps the estimate at or above the true size. When the estimate
+// crosses the cap the true size is confirmed by a single marshal of Ptr, which
+// also reclaims any over-count so a value legitimately under the cap does not force
+// a marshal on every later write. It returns overCap only for a size confirmed by
+// that marshal, never on the estimate alone.
+//
+// It is called only when [JsVar.capApplies] is true and acquires the write lock.
+func (jsvar *JsVar[T]) accountClientWrite(valueBytes int) (size int, overCap bool) {
+	jsvar.Lock()
+	defer jsvar.Unlock()
+	jsvar.jsonBytes += valueBytes + 1
+	if jsvar.jsonBytes > MaxClientJsVarBytes {
+		if data, err := json.Marshal(jsvar.Ptr); err == nil {
+			jsvar.jsonBytes = len(data)
+			overCap = jsvar.jsonBytes > MaxClientJsVarBytes
+		}
 	}
-	_, isPathSetter := any(jsvar.Ptr).(PathSetter)
-	return !isPathSetter
+	size = jsvar.jsonBytes
+	return
 }
 
 // setPathLocked applies the mutation and must be called with the write lock held.
@@ -236,42 +279,67 @@ func (jsvar *JsVar[T]) setPathAndGetTag(elem *jaws.Element, jsPath string, value
 	return
 }
 
-func (jsvar *JsVar[T]) setPathLock(elem *jaws.Element, jsPath string, value any) (broadcasted bool, err error) {
+func (jsvar *JsVar[T]) setPathLock(elem *jaws.Element, jsPath string, value any, clientWrite bool) (broadcasted bool, err error) {
 	jsvar.setMu.Lock()
 	defer jsvar.setMu.Unlock()
-	dirtyTag, err := jsvar.setPathAndGetTag(elem, jsPath, value)
-	// Marshal and broadcast outside the caller-provided lock: value is the
-	// caller-owned argument (not read from Ptr), and jaws.Broadcast can block on
-	// the broadcast channel under backpressure. The private setMu remains held so
-	// concurrent setters cannot apply a later mutation before this broadcast is
-	// queued. Code sharing the caller-provided locker is therefore not stalled by
-	// transport backpressure.
-	//
-	// Note that the broadcast carries the caller's requested value, not the value
-	// actually stored. If a PathSetter coerces or rejects the input (e.g. clamps a
-	// number), the stored Go value and the value seen by peers can differ; the
-	// stored value is what JawsGet returns. Re-broadcast from Ptr inside a
-	// PathSetter if peers must observe the coerced value.
+	var dirtyTag any
+	if dirtyTag, err = jsvar.setPathAndGetTag(elem, jsPath, value); err != nil {
+		return
+	}
+
+	// Marshal the applied value once, outside the caller-provided lock: value is the
+	// caller-owned argument (not read from Ptr), and jaws.Broadcast can block on the
+	// broadcast channel under backpressure. The private setMu remains held so
+	// concurrent setters cannot apply a later mutation before this write's size
+	// accounting and broadcast complete. Code sharing the caller-provided locker is
+	// therefore not stalled by transport backpressure.
 	//
 	// dirtyTag is assigned only in JawsRender, so a set before the first render
-	// leaves it nil. Skip the broadcast in that case: a what.Set with a nil Dest
-	// would target every element, and there is nothing to update yet because the
-	// initial render carries the value in its data-jawsdata attribute.
-	if err == nil && elem != nil && dirtyTag != nil {
-		var data []byte
-		if data, err = json.Marshal(value); err == nil {
-			elem.Jaws.Broadcast(wire.Message{
-				Dest: dirtyTag,
-				What: what.Set,
-				Data: jsPath + "=" + string(data),
-			})
-			broadcasted = true
+	// leaves it nil. A what.Set with a nil Dest would target every element, and there
+	// is nothing to update yet because the initial render carries the value in its
+	// data-jawsdata attribute, so the broadcast is skipped in that case. A client
+	// write still needs the marshaled length to enforce MaxClientJsVarBytes, so the
+	// value is marshaled whenever either the broadcast or the size accounting needs it.
+	willBroadcast := elem != nil && dirtyTag != nil
+	accountSize := clientWrite && jsvar.capApplies()
+	var data []byte
+	if willBroadcast || accountSize {
+		if data, err = json.Marshal(value); err != nil {
+			return
 		}
+	}
+
+	// Enforce MaxClientJsVarBytes on the accumulated growth from untrusted browser
+	// writes, aborting the request on the first over-cap write rather than relying on
+	// a later render that a normally rendered JsVar never performs. Programmatic writes
+	// (JawsSetPath) are trusted and not capped; see MaxClientJsVarBytes.
+	if accountSize {
+		if size, overCap := jsvar.accountClientWrite(len(data)); overCap {
+			err = ErrJsVarTooLarge
+			if elem != nil {
+				elem.Request.Cancel(fmt.Errorf("jaws: jsvar serialized size %d exceeds MaxClientJsVarBytes (%d)", size, MaxClientJsVarBytes))
+			}
+			return
+		}
+	}
+
+	// The broadcast carries the caller's requested value, not the value actually
+	// stored. If a PathSetter coerces or rejects the input (e.g. clamps a number), the
+	// stored Go value and the value seen by peers can differ; the stored value is what
+	// JawsGet returns. Re-broadcast from Ptr inside a PathSetter if peers must observe
+	// the coerced value.
+	if willBroadcast {
+		elem.Jaws.Broadcast(wire.Message{
+			Dest: dirtyTag,
+			What: what.Set,
+			Data: jsPath + "=" + string(data),
+		})
+		broadcasted = true
 	}
 	return
 }
 
-func (jsvar *JsVar[T]) setPath(elem *jaws.Element, jsPath string, value any) (err error) {
+func (jsvar *JsVar[T]) setPath(elem *jaws.Element, jsPath string, value any, clientWrite bool) (err error) {
 	// jsPath is written verbatim into a what.Set wire frame (only the value side
 	// is JSON-encoded). The client splits frames on '\n', fields on '\t', and the
 	// JsVar payload at the first '='. Reject any path carrying those protocol
@@ -281,7 +349,7 @@ func (jsvar *JsVar[T]) setPath(elem *jaws.Element, jsPath string, value any) (er
 		return ErrIllegalJsVarPath
 	}
 	var broadcasted bool
-	if broadcasted, err = jsvar.setPathLock(elem, jsPath, value); err == nil && broadcasted {
+	if broadcasted, err = jsvar.setPathLock(elem, jsPath, value, clientWrite); err == nil && broadcasted {
 		if sp, ok := any(jsvar.Ptr).(SetPather); ok {
 			sp.JawsPathSet(elem, jsPath, value)
 		}
@@ -301,7 +369,7 @@ func (jsvar *JsVar[T]) setPath(elem *jaws.Element, jsPath string, value any) (er
 // page between its initial render and its broadcast subscription; see [JsVar]
 // for the synchronization model.
 func (jsvar *JsVar[T]) JawsSetPath(elem *jaws.Element, jsPath string, value any) (err error) {
-	return jsvar.setPath(elem, jsPath, value)
+	return jsvar.setPath(elem, jsPath, value, false)
 }
 
 // JawsSet replaces the root value and broadcasts the change.
@@ -343,6 +411,9 @@ func (jsvar *JsVar[T]) JawsRender(elem *jaws.Element, w io.Writer, params []any)
 			data, err = json.Marshal(jsvar.Ptr)
 		}
 	}
+	// Seed the client-write size accounting with the rendered size so subsequent
+	// browser writes measure growth from the value the page actually received.
+	jsvar.jsonBytes = len(data)
 	jsvar.Unlock()
 
 	// After the fact: if the value has grown past the cap (e.g. via accumulated
@@ -395,17 +466,20 @@ func elideErrValueUnchanged(err error) error {
 }
 
 // JawsInput applies a browser-side JavaScript variable update.
+//
+// A single incoming message is already bounded by the connection's WebSocket read
+// limit (SetReadLimit in the request handler). To also bound cumulative growth, a
+// non-[PathSetter] value is size-accounted after each applied write and the request
+// is aborted with [ErrJsVarTooLarge] on the first write that pushes the serialized
+// value past [MaxClientJsVarBytes]. The accounting folds an upper bound on each
+// write's growth into a running total and marshals the whole value only when that
+// total crosses the cap, so an append flood stays O(n) rather than O(n^2).
 func (jsvar *JsVar[T]) JawsInput(elem *jaws.Element, value string) (err error) {
-	// No per-write size check: a single incoming message is already bounded by the
-	// connection's WebSocket read limit (SetReadLimit in the request handler), and
-	// cumulative growth of a non-PathSetter value past MaxClientJsVarBytes is caught
-	// after the fact in JawsRender, which avoids re-marshaling on every write (an
-	// append flood would otherwise be O(n^2)).
 	err = jaws.ErrEventUnhandled
 	if jsPath, jsValue, found := strings.Cut(value, "="); found {
 		var v any
 		if err = json.Unmarshal([]byte(jsValue), &v); err == nil {
-			err = elideErrValueUnchanged(jsvar.setPath(elem, jsPath, v))
+			err = elideErrValueUnchanged(jsvar.setPath(elem, jsPath, v, true))
 		}
 	}
 	return

--- a/lib/ui/jsvar_benchmark_test.go
+++ b/lib/ui/jsvar_benchmark_test.go
@@ -115,7 +115,7 @@ func BenchmarkJsVarPathSetterMutation(b *testing.B) {
 // write would make LargeState scale with the slice length.
 func BenchmarkJsVarClientWrite(b *testing.B) {
 	old := MaxClientJsVarBytes
-	MaxClientJsVarBytes = 1 << 40 // effectively unbounded: accounting runs but never confirms
+	MaxClientJsVarBytes = 1 << 30 // effectively unbounded: accounting runs but never confirms
 	b.Cleanup(func() { MaxClientJsVarBytes = old })
 
 	run := func(b *testing.B, initial int) {

--- a/lib/ui/jsvar_benchmark_test.go
+++ b/lib/ui/jsvar_benchmark_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"sync"
 	"testing"
 
@@ -12,6 +13,10 @@ import (
 
 type benchmarkJsVarState struct {
 	Value int `json:"value"`
+}
+
+type benchmarkJsVarSlice struct {
+	Items []string `json:"items"`
 }
 
 func (state *benchmarkJsVarState) JawsSetPath(_ *jaws.Element, _ string, value any) (err error) {
@@ -99,6 +104,54 @@ func BenchmarkJsVarPathSetterMutation(b *testing.B) {
 			}
 		})
 	})
+}
+
+// BenchmarkJsVarClientWrite guards against reintroducing per-write full-value
+// marshaling (the O(n^2) append-flood hazard) in the client input path. It
+// overwrites a single element so the total serialized size stays fixed while the
+// backing slice is either tiny or large. With the running size accounting the
+// per-write cost is independent of the slice length, so SmallState and LargeState
+// report nearly the same ns/op; a regression that marshals the whole value on every
+// write would make LargeState scale with the slice length.
+func BenchmarkJsVarClientWrite(b *testing.B) {
+	old := MaxClientJsVarBytes
+	MaxClientJsVarBytes = 1 << 40 // effectively unbounded: accounting runs but never confirms
+	b.Cleanup(func() { MaxClientJsVarBytes = old })
+
+	run := func(b *testing.B, initial int) {
+		jw, err := jaws.New()
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Cleanup(jw.Close)
+		go jw.Serve()
+		rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+		if rq == nil {
+			b.Fatal("nil request")
+		}
+		var mu sync.Mutex
+		state := benchmarkJsVarSlice{Items: make([]string, initial)}
+		for i := range state.Items {
+			state.Items[i] = "0123456789"
+		}
+		jsvar := NewJsVar(&mu, &state)
+		elem := rq.NewElement(jsvar)
+		if err = jsvar.JawsRender(elem, io.Discard, []any{"bench"}); err != nil {
+			b.Fatal(err)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			// Overwrite the first element with a distinct value; the total size stays
+			// fixed, so per-write cost should not depend on the slice length.
+			if err = jsvar.JawsInput(elem, "items.0="+strconv.Quote(strconv.Itoa(i))); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+
+	b.Run("SmallState", func(b *testing.B) { run(b, 1) })
+	b.Run("LargeState", func(b *testing.B) { run(b, 10000) })
 }
 
 func BenchmarkValidateJsVarName(b *testing.B) {

--- a/lib/ui/jsvar_test.go
+++ b/lib/ui/jsvar_test.go
@@ -467,6 +467,99 @@ func TestJsVar_ClientWriteCapAbortsRequest(t *testing.T) {
 	}
 }
 
+// TestJsVar_ClientWriteCapZeroValueAppend covers an append flood of zero values.
+// jq.Set grows the slice before assigning, and appending the element's zero value
+// ("") reports ErrValueUnchanged, which JawsInput elides to nil — yet the slice grew.
+// Size accounting must still run on that "unchanged" write so the cap aborts the
+// request rather than letting a hostile client append empty strings without bound.
+func TestJsVar_ClientWriteCapZeroValueAppend(t *testing.T) {
+	jw, rq := newCoreRequest(t)
+	go jw.Serve()
+
+	old := MaxClientJsVarBytes
+	MaxClientJsVarBytes = 32
+	defer func() { MaxClientJsVarBytes = old }()
+
+	var mu sync.Mutex
+	v := jsVarSliceData{}
+	jsv := NewJsVar(&mu, &v)
+	elem := rq.NewElement(jsv)
+	var sb strings.Builder
+	if err := jsv.JawsRender(elem, &sb, []any{"v"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var writes int
+	var capErr error
+	for i := 0; i < 200 && capErr == nil; i++ {
+		if err := clientSetFrame(t, jsv, elem, fmt.Sprintf("items.%d", i), ""); err != nil {
+			capErr = err
+			break
+		}
+		writes++
+	}
+
+	if !errors.Is(capErr, ErrJsVarTooLarge) {
+		t.Fatalf("expected ErrJsVarTooLarge from a zero-value append flood, got %v after %d writes", capErr, writes)
+	}
+	if rq.Context().Err() == nil {
+		t.Fatal("expected the request to be aborted by the zero-value append flood")
+	}
+	mu.Lock()
+	data, _ := json.Marshal(&v)
+	mu.Unlock()
+	if len(data) > 4*MaxClientJsVarBytes {
+		t.Fatalf("serialized value grew to %d bytes, past cap %d", len(data), MaxClientJsVarBytes)
+	}
+}
+
+// TestJsVar_ClientWriteCapRejectedAppend covers an append flood the setter rejects.
+// jq.Set grows the slice before the assign, and assigning a number into a []string
+// fails with a type mismatch (not ErrValueUnchanged) while leaving the appended zero
+// element in place. The request loop only logs a handler error, so accounting must
+// run on the rejected write too or the slice grows without bound.
+func TestJsVar_ClientWriteCapRejectedAppend(t *testing.T) {
+	jw, rq := newCoreRequest(t)
+	go jw.Serve()
+
+	old := MaxClientJsVarBytes
+	MaxClientJsVarBytes = 32
+	defer func() { MaxClientJsVarBytes = old }()
+
+	var mu sync.Mutex
+	v := jsVarSliceData{} // Items []string
+	jsv := NewJsVar(&mu, &v)
+	elem := rq.NewElement(jsv)
+	var sb strings.Builder
+	if err := jsv.JawsRender(elem, &sb, []any{"v"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Each write returns a type-mismatch error before the cap is reached; stop when
+	// the request is aborted, mirroring the request loop that stops dispatching once
+	// the context is cancelled.
+	var sawTooLarge bool
+	for i := 0; i < 200 && rq.Context().Err() == nil; i++ {
+		// A number into a []string element: jq grows the slice, then the assign fails.
+		if errors.Is(clientSetFrame(t, jsv, elem, fmt.Sprintf("items.%d", i), i), ErrJsVarTooLarge) {
+			sawTooLarge = true
+		}
+	}
+
+	if !sawTooLarge {
+		t.Fatal("expected ErrJsVarTooLarge from a rejected append flood")
+	}
+	if rq.Context().Err() == nil {
+		t.Fatal("expected the request to be aborted by the rejected append flood")
+	}
+	mu.Lock()
+	data, _ := json.Marshal(&v)
+	mu.Unlock()
+	if len(data) > 4*MaxClientJsVarBytes {
+		t.Fatalf("serialized value grew to %d bytes, past cap %d", len(data), MaxClientJsVarBytes)
+	}
+}
+
 // TestJsVar_ClientWriteCapExemptsPathSetter verifies the documented exemption on the
 // client write path: a PathSetter enforces its own bounds, so browser writes that
 // grow it well past MaxClientJsVarBytes neither error nor abort the request.

--- a/lib/ui/jsvar_test.go
+++ b/lib/ui/jsvar_test.go
@@ -388,6 +388,227 @@ func TestJsVar_RenderSizeCapExemptsPathSetter(t *testing.T) {
 	}
 }
 
+// jsVarSliceData is a non-PathSetter value with a client-growable slice, used to
+// exercise MaxClientJsVarBytes accounting for browser writes.
+type jsVarSliceData struct {
+	Items []string `json:"items"`
+}
+
+// jsVarAppendPathSetter is a PathSetter that appends to a slice on every write. It
+// shows that PathSetter values are exempt from MaxClientJsVarBytes on the client
+// write path, enforcing their own bounds instead.
+type jsVarAppendPathSetter struct {
+	Items []string `json:"items"`
+}
+
+func (d *jsVarAppendPathSetter) JawsSetPath(_ *jaws.Element, _ string, value any) error {
+	d.Items = append(d.Items, fmt.Sprint(value))
+	return nil
+}
+
+// clientSetFrame delivers a browser "set" frame through the incoming input path.
+func clientSetFrame(t *testing.T, jsv IsJsVar, elem *jaws.Element, jsPath string, value any) error {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return jaws.CallEventHandlers(jsv, elem, what.Set, jsPath+"="+string(data))
+}
+
+// TestJsVar_ClientWriteCapAbortsRequest is the regression test for #129: a normally
+// rendered non-PathSetter JsVar is never rendered again, so the cap must be enforced
+// on each browser write. A client appending one slice element per message is stopped
+// with ErrJsVarTooLarge and the request aborted once the serialized value exceeds
+// MaxClientJsVarBytes, rather than growing server state without bound.
+func TestJsVar_ClientWriteCapAbortsRequest(t *testing.T) {
+	jw, rq := newCoreRequest(t)
+	go jw.Serve()
+
+	old := MaxClientJsVarBytes
+	MaxClientJsVarBytes = 32
+	defer func() { MaxClientJsVarBytes = old }()
+
+	var mu sync.Mutex
+	v := jsVarSliceData{}
+	jsv := NewJsVar(&mu, &v)
+	elem := rq.NewElement(jsv)
+	var sb strings.Builder
+	if err := jsv.JawsRender(elem, &sb, []any{"v"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var writes int
+	var capErr error
+	for i := 0; i < 20 && capErr == nil; i++ {
+		if err := clientSetFrame(t, jsv, elem, fmt.Sprintf("items.%d", i), "0123456789"); err != nil {
+			capErr = err
+			break
+		}
+		writes++
+	}
+
+	if !errors.Is(capErr, ErrJsVarTooLarge) {
+		t.Fatalf("expected ErrJsVarTooLarge from a client write, got %v after %d writes", capErr, writes)
+	}
+	if writes == 0 {
+		t.Fatal("expected at least one client write to succeed before the cap aborted the request")
+	}
+	if rq.Context().Err() == nil {
+		t.Fatal("expected the request to be aborted by the over-cap client write")
+	}
+
+	// Server state stayed bounded rather than growing one valid frame at a time.
+	mu.Lock()
+	data, _ := json.Marshal(&v)
+	mu.Unlock()
+	if len(data) > 4*MaxClientJsVarBytes {
+		t.Fatalf("serialized value grew to %d bytes, past cap %d", len(data), MaxClientJsVarBytes)
+	}
+}
+
+// TestJsVar_ClientWriteCapExemptsPathSetter verifies the documented exemption on the
+// client write path: a PathSetter enforces its own bounds, so browser writes that
+// grow it well past MaxClientJsVarBytes neither error nor abort the request.
+func TestJsVar_ClientWriteCapExemptsPathSetter(t *testing.T) {
+	jw, rq := newCoreRequest(t)
+	go jw.Serve()
+
+	old := MaxClientJsVarBytes
+	MaxClientJsVarBytes = 32
+	defer func() { MaxClientJsVarBytes = old }()
+
+	var mu sync.Mutex
+	v := jsVarAppendPathSetter{}
+	jsv := NewJsVar(&mu, &v)
+	elem := rq.NewElement(jsv)
+	var sb strings.Builder
+	if err := jsv.JawsRender(elem, &sb, []any{"v"}); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 50; i++ {
+		if err := clientSetFrame(t, jsv, elem, fmt.Sprintf("items.%d", i), "0123456789"); err != nil {
+			t.Fatalf("PathSetter client write %d: unexpected error %v", i, err)
+		}
+	}
+	if rq.Context().Err() != nil {
+		t.Fatalf("request must not be aborted for a PathSetter JsVar, got %v", rq.Context().Err())
+	}
+	mu.Lock()
+	got := len(v.Items)
+	mu.Unlock()
+	if got != 50 {
+		t.Fatalf("expected 50 appended items, got %d", got)
+	}
+}
+
+// TestJsVar_ClientWriteCapDisabled verifies that a non-positive MaxClientJsVarBytes
+// disables the accounting entirely: browser writes may grow a non-PathSetter value
+// past the (disabled) cap without aborting the request.
+func TestJsVar_ClientWriteCapDisabled(t *testing.T) {
+	jw, rq := newCoreRequest(t)
+	go jw.Serve()
+
+	old := MaxClientJsVarBytes
+	MaxClientJsVarBytes = 0
+	defer func() { MaxClientJsVarBytes = old }()
+
+	var mu sync.Mutex
+	v := jsVarSliceData{}
+	jsv := NewJsVar(&mu, &v)
+	elem := rq.NewElement(jsv)
+	var sb strings.Builder
+	if err := jsv.JawsRender(elem, &sb, []any{"v"}); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 50; i++ {
+		if err := clientSetFrame(t, jsv, elem, fmt.Sprintf("items.%d", i), "0123456789"); err != nil {
+			t.Fatalf("client write %d with cap disabled: unexpected error %v", i, err)
+		}
+	}
+	if rq.Context().Err() != nil {
+		t.Fatalf("request must not be aborted when the cap is disabled, got %v", rq.Context().Err())
+	}
+}
+
+// TestJsVar_ServerWriteNotCapped verifies that programmatic (server-side) writes are
+// trusted and not size-capped: JawsSetPath may grow a non-PathSetter value past
+// MaxClientJsVarBytes without error or aborting the request. Only browser writes are
+// bounded.
+func TestJsVar_ServerWriteNotCapped(t *testing.T) {
+	jw, rq := newCoreRequest(t)
+	go jw.Serve()
+
+	old := MaxClientJsVarBytes
+	MaxClientJsVarBytes = 32
+	defer func() { MaxClientJsVarBytes = old }()
+
+	var mu sync.Mutex
+	v := jsVarSliceData{}
+	jsv := NewJsVar(&mu, &v)
+	elem := rq.NewElement(jsv)
+	var sb strings.Builder
+	if err := jsv.JawsRender(elem, &sb, []any{"v"}); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 20; i++ {
+		if err := jsv.JawsSetPath(elem, fmt.Sprintf("items.%d", i), "0123456789"); err != nil {
+			t.Fatalf("server write %d: unexpected error %v", i, err)
+		}
+	}
+	if rq.Context().Err() != nil {
+		t.Fatalf("server writes must not abort the request, got %v", rq.Context().Err())
+	}
+	mu.Lock()
+	data, _ := json.Marshal(&v)
+	mu.Unlock()
+	if len(data) <= MaxClientJsVarBytes {
+		t.Fatalf("test precondition: server value %d did not exceed cap %d", len(data), MaxClientJsVarBytes)
+	}
+}
+
+// TestJsVar_ClientWriteCapReclaimsOvercount verifies that the running estimate is a
+// safe over-count that a confirming marshal reclaims: many browser writes that only
+// replace an existing element (never growing the value past the cap) must not abort
+// the request even though the accumulated estimate repeatedly crosses the cap.
+func TestJsVar_ClientWriteCapReclaimsOvercount(t *testing.T) {
+	jw, rq := newCoreRequest(t)
+	go jw.Serve()
+
+	old := MaxClientJsVarBytes
+	MaxClientJsVarBytes = 64
+	defer func() { MaxClientJsVarBytes = old }()
+
+	var mu sync.Mutex
+	v := jsVarSliceData{}
+	jsv := NewJsVar(&mu, &v)
+	elem := rq.NewElement(jsv)
+	var sb strings.Builder
+	if err := jsv.JawsRender(elem, &sb, []any{"v"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Append once, then repeatedly overwrite the single element with distinct values
+	// of the same size; the serialized value stays well under the cap throughout.
+	for i := 0; i < 200; i++ {
+		if err := clientSetFrame(t, jsv, elem, "items.0", fmt.Sprintf("val-%05d", i)); err != nil {
+			t.Fatalf("client overwrite %d: unexpected error %v", i, err)
+		}
+	}
+	if rq.Context().Err() != nil {
+		t.Fatalf("bounded overwrites must not abort the request, got %v", rq.Context().Err())
+	}
+	mu.Lock()
+	got := len(v.Items)
+	mu.Unlock()
+	if got != 1 {
+		t.Fatalf("expected the slice to stay length 1, got %d", got)
+	}
+}
+
 func TestJsVar_PathHooksAndRequestWriter(t *testing.T) {
 	jw, rq := newCoreRequest(t)
 	go jw.Serve()
@@ -401,7 +622,7 @@ func TestJsVar_PathHooksAndRequestWriter(t *testing.T) {
 	if err := jsv.JawsRender(elem, &sb, []any{"pvar"}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := jsv.setPathLock(elem, "value", "b"); err != nil {
+	if _, err := jsv.setPathLock(elem, "value", "b", false); err != nil {
 		t.Fatal(err)
 	}
 	if v.Value != "b" || v.setCalls == 0 {

--- a/lib/ui/jsvar_test.go
+++ b/lib/ui/jsvar_test.go
@@ -2,11 +2,13 @@ package ui
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"html"
 	"html/template"
+	"math"
 	"strings"
 	"sync"
 	"testing"
@@ -394,6 +396,41 @@ type jsVarSliceData struct {
 	Items []string `json:"items"`
 }
 
+// Wrap handler-control errors to ensure an exact-size confirmation failure cannot
+// be mistaken for either an unchanged value or an unhandled event.
+var errJsVarMarshalFailure = fmt.Errorf("jsvar marshal failure: %w", errors.Join(jaws.ErrValueUnchanged, jaws.ErrEventUnhandled))
+
+type jsVarMarshalFailureData struct {
+	Items []string `json:"items"`
+}
+
+func (data jsVarMarshalFailureData) MarshalJSON() ([]byte, error) {
+	if len(data.Items) > 0 {
+		return nil, errJsVarMarshalFailure
+	}
+	type plain jsVarMarshalFailureData
+	return json.Marshal(plain(data))
+}
+
+type jsVarSetMuProbeLogger struct {
+	jsvar   *JsVar[jsVarSliceData]
+	setMuOK chan bool
+}
+
+func (*jsVarSetMuProbeLogger) Info(string, ...any) {}
+func (*jsVarSetMuProbeLogger) Warn(string, ...any) {}
+
+func (logger *jsVarSetMuProbeLogger) Error(string, ...any) {
+	ok := logger.jsvar.setMu.TryLock()
+	if ok {
+		logger.jsvar.setMu.Unlock()
+	}
+	select {
+	case logger.setMuOK <- ok:
+	default:
+	}
+}
+
 // jsVarAppendPathSetter is a PathSetter that appends to a slice on every write. It
 // shows that PathSetter values are exempt from MaxClientJsVarBytes on the client
 // write path, enforcing their own bounds instead.
@@ -464,6 +501,121 @@ func TestJsVar_ClientWriteCapAbortsRequest(t *testing.T) {
 	mu.Unlock()
 	if len(data) > 4*MaxClientJsVarBytes {
 		t.Fatalf("serialized value grew to %d bytes, past cap %d", len(data), MaxClientJsVarBytes)
+	}
+}
+
+// TestJsVar_ClientWriteEstimateUsesPayloadLength verifies that ordinary client
+// writes only add their raw payload length to the running approximation.
+func TestJsVar_ClientWriteEstimateUsesPayloadLength(t *testing.T) {
+	jw, rq := newCoreRequest(t)
+	go jw.Serve()
+
+	old := MaxClientJsVarBytes
+	MaxClientJsVarBytes = 1024
+	defer func() { MaxClientJsVarBytes = old }()
+
+	var mu sync.Mutex
+	v := jsVarSliceData{}
+	jsv := NewJsVar(&mu, &v)
+	elem := rq.NewElement(jsv)
+	if err := jsv.JawsRender(elem, &strings.Builder{}, []any{"v"}); err != nil {
+		t.Fatal(err)
+	}
+	jsv.RLock()
+	before := jsv.jsonBytes
+	jsv.RUnlock()
+	payload := `items.0="x"`
+	if err := jaws.CallEventHandlers(jsv, elem, what.Set, payload); err != nil {
+		t.Fatal(err)
+	}
+	jsv.RLock()
+	got := jsv.jsonBytes
+	jsv.RUnlock()
+	if want := before + len(payload); got != want {
+		t.Fatalf("approximate size = %d, want %d", got, want)
+	}
+}
+
+// TestJsVar_ClientWriteEstimateDoesNotOverflow verifies that crossing the cap
+// is detected without overflowing the approximate byte count.
+func TestJsVar_ClientWriteEstimateDoesNotOverflow(t *testing.T) {
+	old := MaxClientJsVarBytes
+	MaxClientJsVarBytes = math.MaxInt
+	defer func() { MaxClientJsVarBytes = old }()
+
+	v := jsVarSliceData{}
+	jsv := NewJsVar(new(sync.Mutex), &v)
+	jsv.jsonBytes = math.MaxInt - 1
+	size, overCap, err := jsv.accountClientWrite(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(&v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if size != len(data) || overCap {
+		t.Fatalf("accounted size, over cap = %d, %t; want %d, false", size, overCap, len(data))
+	}
+}
+
+// TestJsVar_ClientWriteCapFailsClosedOnMarshalError verifies that an exact-size
+// confirmation error aborts the request instead of disabling the cap.
+func TestJsVar_ClientWriteCapFailsClosedOnMarshalError(t *testing.T) {
+	jw, rq := newCoreRequest(t)
+	go jw.Serve()
+
+	old := MaxClientJsVarBytes
+	MaxClientJsVarBytes = 16
+	defer func() { MaxClientJsVarBytes = old }()
+
+	var mu sync.Mutex
+	v := jsVarMarshalFailureData{}
+	jsv := NewJsVar(&mu, &v)
+	elem := rq.NewElement(jsv)
+	if err := jsv.JawsRender(elem, &strings.Builder{}, []any{"v"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := clientSetFrame(t, jsv, elem, "items.0", "x"); !errors.Is(err, ErrJsVarTooLarge) {
+		t.Fatalf("client write error = %v, want ErrJsVarTooLarge", err)
+	}
+	if rq.Context().Err() == nil {
+		t.Fatal("marshal failure did not abort the request")
+	}
+	if cause := context.Cause(rq.Context()); !errors.Is(cause, errJsVarMarshalFailure) {
+		t.Fatalf("cancellation cause = %v, want marshal failure", cause)
+	}
+}
+
+// TestJsVar_ClientWriteCapCancelsOutsideSetMu verifies that cancellation and its
+// synchronous logger run after the mutation-ordering lock is released.
+func TestJsVar_ClientWriteCapCancelsOutsideSetMu(t *testing.T) {
+	jw, rq := newCoreRequest(t)
+	go jw.Serve()
+
+	old := MaxClientJsVarBytes
+	MaxClientJsVarBytes = 16
+	defer func() { MaxClientJsVarBytes = old }()
+
+	var mu sync.Mutex
+	v := jsVarSliceData{}
+	jsv := NewJsVar(&mu, &v)
+	setMuOK := make(chan bool, 1)
+	jw.Logger = &jsVarSetMuProbeLogger{jsvar: jsv, setMuOK: setMuOK}
+	elem := rq.NewElement(jsv)
+	if err := jsv.JawsRender(elem, &strings.Builder{}, []any{"v"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := clientSetFrame(t, jsv, elem, "items.0", "0123456789"); !errors.Is(err, ErrJsVarTooLarge) {
+		t.Fatalf("client write error = %v, want ErrJsVarTooLarge", err)
+	}
+	select {
+	case ok := <-setMuOK:
+		if !ok {
+			t.Fatal("request cancellation logged while JsVar.setMu was held")
+		}
+	default:
+		t.Fatal("request cancellation was not logged")
 	}
 }
 
@@ -663,10 +815,10 @@ func TestJsVar_ServerWriteNotCapped(t *testing.T) {
 	}
 }
 
-// TestJsVar_ClientWriteCapReclaimsOvercount verifies that the running estimate is a
-// safe over-count that a confirming marshal reclaims: many browser writes that only
-// replace an existing element (never growing the value past the cap) must not abort
-// the request even though the accumulated estimate repeatedly crosses the cap.
+// TestJsVar_ClientWriteCapReclaimsOvercount verifies that a confirming marshal
+// resets the running approximation: many browser writes that only replace an
+// existing element (never growing the value past the cap) must not abort the
+// request even though the accumulated estimate repeatedly crosses the cap.
 func TestJsVar_ClientWriteCapReclaimsOvercount(t *testing.T) {
 	jw, rq := newCoreRequest(t)
 	go jw.Serve()
@@ -715,7 +867,7 @@ func TestJsVar_PathHooksAndRequestWriter(t *testing.T) {
 	if err := jsv.JawsRender(elem, &sb, []any{"pvar"}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := jsv.setPathLock(elem, "value", "b", false); err != nil {
+	if _, _, _, err := jsv.setPathLock(elem, "value", "b", false, 0); err != nil {
 		t.Fatal(err)
 	}
 	if v.Value != "b" || v.setCalls == 0 {


### PR DESCRIPTION
Fixes #129.

## Problem

`MaxClientJsVarBytes` did not bound a non-`PathSetter` `JsVar` after its normal initial render. The only cap check lived in `JsVar.JawsRender`, but a normally rendered JsVar is never rendered again. A browser could therefore append one slice element per `Set` write and keep growing server-side state.

## Fix

Enforce the cap in the client input path while keeping the common path O(1):

- Seed `jsonBytes` with the exact JSON length produced by the initial render.
- Add the length of each raw client-write payload to that approximate count, including rejected appends that still grow a slice.
- When the approximation crosses `MaxClientJsVarBytes`, use `json.Marshal` once to calculate the exact current length. Reset the approximation to that length when it remains under the cap; otherwise abort the request with `ErrJsVarTooLarge`.
- Use a subtraction guard for the boundary check so the approximate count cannot overflow on 32-bit or 64-bit systems.
- Treat an exact-size marshal failure as a failed size check: return `ErrJsVarTooLarge`, abort the request, and retain the underlying marshal error in the cancellation cause.
- Format the cancellation cause and cancel the request after releasing `JsVar.setMu` and the caller-provided value lock.

This deliberately does not duplicate `encoding/json` sizing rules. Exact JSON work happens only when the raw-byte approximation looks too high.

Programmatic `JawsSetPath` writes remain trusted and uncapped. `PathSetter` values remain exempt because they enforce their own path and size policy. The render-time check remains for values already over the cap at initial render.

## Tests and benchmark

Regression coverage includes:

- valid, zero-value, and rejected append floods;
- raw client-payload accumulation and exact-size reconciliation;
- integer-overflow-safe boundary detection;
- fail-closed exact marshaling without leaking handler-control errors;
- request cancellation after internal locks are released;
- `PathSetter`, disabled-cap, and server-write exemptions;
- Linux/386 test-binary compilation.

`BenchmarkJsVarClientWrite` remains as the O(1)-per-write regression guard. Six-run `benchstat` comparison against the previous PR head (`-benchtime=300ms -count=6`) is statistically unchanged:

```
                              previous   final
SmallState                    883.6 ns   882.9 ns
LargeState                    892.9 ns   883.9 ns
Bytes/op                      272        272
Allocations/op                12         12
```

Verified with `go test -race -count=1 ./...`, `go vet ./...`, `staticcheck ./...`, `golangci-lint run ./...`, `gosec ./...`, `gofumpt`, `go build ./...`, and Linux/386 test compilation.
