### PR TITLE
wire: interrupt blocked I/O on shutdown

### DIFF
--- a/lib/wire/wsio.go
+++ b/lib/wire/wsio.go
@@ -18,12 +18,17 @@ const writeBatchLimit = 32 * 1024
 //
 // Closes incomingMsgCh on exit.
 //
+// Canceling ctx or closing doneCh interrupts reads in progress and is not
+// reported through ccf.
+//
 // ccf may be nil, in which case errors are not reported and only the loop exits.
 func ReadLoop(ctx context.Context, ccf context.CancelCauseFunc, doneCh <-chan struct{}, incomingMsgCh chan<- WsMsg, ws *websocket.Conn) {
 	var typ websocket.MessageType
 	var txt []byte
 	var err error
 	defer close(incomingMsgCh)
+	ctx, cancel := contextWithDone(ctx, doneCh)
+	defer cancel()
 	for err == nil {
 		// Only parse on a successful read; on error ws.Read returns no usable
 		// payload and the loop exits because the for condition fails.
@@ -39,9 +44,7 @@ func ReadLoop(ctx context.Context, ccf context.CancelCauseFunc, doneCh <-chan st
 			}
 		}
 	}
-	if ccf != nil {
-		ccf(err)
-	}
+	reportError(ctx, doneCh, ccf, err)
 }
 
 // WriteLoop reads messages from outboundMsgCh, formats them, and writes them
@@ -49,9 +52,14 @@ func ReadLoop(ctx context.Context, ccf context.CancelCauseFunc, doneCh <-chan st
 //
 // Closes the WebSocket on exit.
 //
+// Canceling ctx or closing doneCh interrupts writes in progress and is not
+// reported through ccf.
+//
 // ccf may be nil, in which case errors are not reported and only the loop exits.
 func WriteLoop(ctx context.Context, ccf context.CancelCauseFunc, doneCh <-chan struct{}, outboundMsgCh <-chan WsMsg, ws *websocket.Conn) {
 	defer func() { _ = ws.Close(websocket.StatusNormalClosure, "") }()
+	ctx, cancel := contextWithDone(ctx, doneCh)
+	defer cancel()
 	var err error
 	for err == nil {
 		select {
@@ -69,14 +77,15 @@ func WriteLoop(ctx context.Context, ccf context.CancelCauseFunc, doneCh <-chan s
 			}
 		}
 	}
-	if ccf != nil {
-		ccf(err)
-	}
+	reportError(ctx, doneCh, ccf, err)
 }
 
 // PingLoop sends periodic WebSocket pings and reports ping errors through ccf.
 //
 // Returns immediately when interval is non-positive.
+//
+// Canceling ctx or closing doneCh interrupts pings in progress and is not
+// reported through ccf.
 //
 // ccf may be nil, in which case errors are not reported and only the loop exits.
 func PingLoop(ctx context.Context, ccf context.CancelCauseFunc, doneCh <-chan struct{}, interval, timeout time.Duration, ws *websocket.Conn) {
@@ -86,6 +95,8 @@ func PingLoop(ctx context.Context, ccf context.CancelCauseFunc, doneCh <-chan st
 		// (the ctx.Done and doneCh cases below likewise return without ccf).
 		return
 	}
+	ctx, cancel := contextWithDone(ctx, doneCh)
+	defer cancel()
 	t := time.NewTicker(interval)
 	defer t.Stop()
 
@@ -97,13 +108,34 @@ func PingLoop(ctx context.Context, ccf context.CancelCauseFunc, doneCh <-chan st
 		case <-doneCh:
 			return
 		case <-t.C:
-			pingctx, cancel := context.WithTimeout(ctx, timeout)
+			pingctx, pingcancel := context.WithTimeout(ctx, timeout)
 			err = ws.Ping(pingctx)
-			cancel()
+			pingcancel()
 		}
 	}
+	reportError(ctx, doneCh, ccf, err)
+}
+
+func contextWithDone(ctx context.Context, doneCh <-chan struct{}) (ioctx context.Context, cancel context.CancelFunc) {
+	ioctx, cancel = context.WithCancel(ctx)
+	go func() {
+		select {
+		case <-doneCh:
+			cancel()
+		case <-ioctx.Done():
+		}
+	}()
+	return
+}
+
+func reportError(ctx context.Context, doneCh <-chan struct{}, ccf context.CancelCauseFunc, err error) {
 	if ccf != nil {
-		ccf(err)
+		select {
+		case <-ctx.Done():
+		case <-doneCh:
+		default:
+			ccf(err)
+		}
 	}
 }
 

--- a/lib/wire/wsio_test.go
+++ b/lib/wire/wsio_test.go
@@ -52,27 +52,32 @@ func TestReadLoop_RespectsContextDone(t *testing.T) {
 }
 
 func TestReadLoop_RespectsDone(t *testing.T) {
-	msg := WsMsg{Jid: jid.Jid(1234), What: what.Input}
-	inCh := make(chan WsMsg)
-	jawsDoneCh := make(chan struct{})
-	client, server := pipe(t)
-	defer func() { _ = client.CloseNow() }()
-	defer func() { _ = server.CloseNow() }()
+	synctest.Test(t, func(t *testing.T) {
+		msg := WsMsg{Jid: jid.Jid(1234), What: what.Input}
+		inCh := make(chan WsMsg)
+		doneCh := make(chan struct{})
+		client, server := pipe(t)
+		ctx, cancel := context.WithCancelCause(t.Context())
+		loopDone := make(chan struct{})
+		defer closeWireBubble(cancel, client, server)()
 
-	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
-	defer cancel()
+		go func() {
+			ReadLoop(ctx, cancel, doneCh, inCh, server)
+			close(loopDone)
+		}()
 
-	readDoneCh := make(chan struct{})
-	go func() {
-		defer close(readDoneCh)
-		ReadLoop(ctx, nil, jawsDoneCh, inCh, server)
-	}()
-
-	if err := client.Write(ctx, websocket.MessageText, []byte(msg.Format())); err != nil {
-		t.Fatal(err)
-	}
-	close(jawsDoneCh)
-	waitDone(t, readDoneCh, "ReadLoop after done close")
+		if err := client.Write(ctx, websocket.MessageText, []byte(msg.Format())); err != nil {
+			t.Fatal(err)
+		}
+		// ReadLoop is durably blocked sending the decoded message to inCh.
+		synctest.Wait()
+		close(doneCh)
+		synctest.Wait()
+		assertClosedNow(t, loopDone, "ReadLoop")
+		if err := ctx.Err(); err != nil {
+			t.Fatalf("parent context was canceled: %v", err)
+		}
+	})
 }
 
 func TestReadLoop_RespectsDoneWhileReading(t *testing.T) {

--- a/lib/wire/wsio_test.go
+++ b/lib/wire/wsio_test.go
@@ -439,6 +439,14 @@ func TestReportError_IgnoresDone(t *testing.T) {
 	}, errors.New("websocket closed"))
 }
 
+func TestReportError_IgnoresContextDone(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	reportError(ctx, make(chan struct{}), func(err error) {
+		t.Fatalf("reported canceled-context error: %v", err)
+	}, errors.New("websocket closed"))
+}
+
 func TestPingLoop_NonPositiveIntervalReturns(t *testing.T) {
 	client, server := pipe(t)
 	defer func() { _ = client.CloseNow() }()

--- a/lib/wire/wsio_test.go
+++ b/lib/wire/wsio_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/coder/websocket"
@@ -72,6 +73,31 @@ func TestReadLoop_RespectsDone(t *testing.T) {
 	}
 	close(jawsDoneCh)
 	waitDone(t, readDoneCh, "ReadLoop after done close")
+}
+
+func TestReadLoop_RespectsDoneWhileReading(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancelCause(t.Context())
+		doneCh := make(chan struct{})
+		inCh := make(chan WsMsg)
+		client, server := pipe(t)
+		loopDone := make(chan struct{})
+		defer closeWireBubble(cancel, client, server)()
+
+		go func() {
+			ReadLoop(ctx, cancel, doneCh, inCh, server)
+			close(loopDone)
+		}()
+
+		// ReadLoop is durably blocked in ws.Read on the idle peer.
+		synctest.Wait()
+		close(doneCh)
+		synctest.Wait()
+		assertClosedNow(t, loopDone, "ReadLoop")
+		if err := ctx.Err(); err != nil {
+			t.Fatalf("parent context was canceled: %v", err)
+		}
+	})
 }
 
 func TestWriteLoop_SendsThePayload(t *testing.T) {
@@ -300,6 +326,36 @@ func TestWriteLoop_RespectsDone(t *testing.T) {
 	waitDone(t, writeDoneCh, "WriteLoop after done close")
 }
 
+func TestWriteLoop_RespectsDoneWhileWriting(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancelCause(t.Context())
+		doneCh := make(chan struct{})
+		outCh := make(chan WsMsg, 1)
+		outCh <- WsMsg{
+			Jid:  jid.Jid(1234),
+			What: what.Inner,
+			Data: strings.Repeat("x", writeBatchLimit),
+		}
+		client, server := pipe(t)
+		loopDone := make(chan struct{})
+		defer closeWireBubble(cancel, client, server)()
+
+		go func() {
+			WriteLoop(ctx, cancel, doneCh, outCh, server)
+			close(loopDone)
+		}()
+
+		// The large frame is durably blocked because the peer does not read.
+		synctest.Wait()
+		close(doneCh)
+		synctest.Wait()
+		assertClosedNow(t, loopDone, "WriteLoop")
+		if err := ctx.Err(); err != nil {
+			t.Fatalf("parent context was canceled: %v", err)
+		}
+	})
+}
+
 func TestWriteLoop_RespectsOutboundClosed(t *testing.T) {
 	outCh := make(chan WsMsg)
 	jawsDoneCh := make(chan struct{})
@@ -370,6 +426,14 @@ func TestReadLoop_ReportsError(t *testing.T) {
 	}
 }
 
+func TestReportError_IgnoresDone(t *testing.T) {
+	doneCh := make(chan struct{})
+	close(doneCh)
+	reportError(t.Context(), doneCh, func(err error) {
+		t.Fatalf("reported shutdown error: %v", err)
+	}, errors.New("websocket closed"))
+}
+
 func TestPingLoop_NonPositiveIntervalReturns(t *testing.T) {
 	client, server := pipe(t)
 	defer func() { _ = client.CloseNow() }()
@@ -419,6 +483,38 @@ func TestPingLoop_RespectsDone(t *testing.T) {
 	waitDone(t, pingDoneCh, "PingLoop after done close")
 }
 
+func TestPingLoop_RespectsDoneWhileWaitingForPong(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancelCause(t.Context())
+		doneCh := make(chan struct{})
+		pingSeen := make(chan struct{})
+		client, server := pipeWithDialOptions(t, websocket.DialOptions{
+			OnPingReceived: func(context.Context, []byte) bool {
+				close(pingSeen)
+				return false // Suppress the automatic pong.
+			},
+		})
+		loopDone := make(chan struct{})
+		defer closeWireBubble(cancel, client, server)()
+
+		client.CloseRead(ctx)
+		go func() {
+			PingLoop(ctx, cancel, doneCh, time.Second, time.Hour, server)
+			close(loopDone)
+		}()
+
+		<-pingSeen
+		// PingLoop is waiting for the deliberately omitted pong.
+		synctest.Wait()
+		close(doneCh)
+		synctest.Wait()
+		assertClosedNow(t, loopDone, "PingLoop")
+		if err := ctx.Err(); err != nil {
+			t.Fatalf("parent context was canceled: %v", err)
+		}
+	})
+}
+
 func TestPingLoop_ReportsErrorWhenPeerDoesNotPong(t *testing.T) {
 	jawsDoneCh := make(chan struct{})
 	client, server := pipe(t)
@@ -453,19 +549,41 @@ func waitDone(t *testing.T, doneCh <-chan struct{}, what string) {
 	}
 }
 
+func assertClosedNow(t *testing.T, ch <-chan struct{}, what string) {
+	t.Helper()
+	select {
+	case <-ch:
+	default:
+		t.Fatalf("%s did not return", what)
+	}
+}
+
+func closeWireBubble(cancel context.CancelCauseFunc, conns ...*websocket.Conn) func() {
+	return func() {
+		cancel(nil)
+		for _, conn := range conns {
+			_ = conn.CloseNow()
+		}
+		synctest.Wait()
+	}
+}
+
 // adapted from nhooyr.io/websocket/internal/test/wstest.Pipe
 func pipe(t *testing.T) (clientConn, serverConn *websocket.Conn) {
 	t.Helper()
-	dialOpts := &websocket.DialOptions{
-		HTTPClient: &http.Client{
-			Transport: fakeTransport{
-				h: func(w http.ResponseWriter, r *http.Request) {
-					serverConn, _ = websocket.Accept(w, r, nil)
-				},
+	return pipeWithDialOptions(t, websocket.DialOptions{})
+}
+
+func pipeWithDialOptions(t *testing.T, dialOpts websocket.DialOptions) (clientConn, serverConn *websocket.Conn) {
+	t.Helper()
+	dialOpts.HTTPClient = &http.Client{
+		Transport: fakeTransport{
+			h: func(w http.ResponseWriter, r *http.Request) {
+				serverConn, _ = websocket.Accept(w, r, nil)
 			},
 		},
 	}
-	clientConn, _, _ = websocket.Dial(t.Context(), "ws://localhost", dialOpts)
+	clientConn, _, _ = websocket.Dial(t.Context(), "ws://localhost", &dialOpts)
 	return clientConn, serverConn
 }
 


### PR DESCRIPTION
## Summary

- derive each WebSocket loop I/O context from both the caller context and doneCh
- treat shutdown cancellation, including sibling-loop socket closure, as a normal exit without invoking ccf
- add deterministic regressions for idle reads, backpressured writes, and pings waiting for pong
- make the done-while-delivering test deterministic, bringing lib/wire to exact 100% statement coverage
- document the shutdown behavior on ReadLoop, WriteLoop, and PingLoop

## Verification

- go generate ./...
- gofmt -l .
- go vet ./...
- staticcheck ./...
- golangci-lint run
- gosec ./...
- go test -race -coverprofile=wire-coverage.out ./lib/wire (100.0%; no uncovered statement ranges)
- go test -race -run TestReadLoop_RespectsDone -count=50 ./lib/wire
- JAWS_REQUIRE_NODE=1 go test -race -coverprofile=coverage.out ./...
- go build -v ./...

Fixes #138