### PR TITLE
websocket: normalize default ports for origin verification

### DIFF
--- a/request.go
+++ b/request.go
@@ -763,6 +763,36 @@ func (rq *Request) validateWebSocketOrigin(r *http.Request) (err error) {
 	return
 }
 
+// normalizedWebSocketAcceptRequest returns a request whose Host and Origin omit
+// the Origin scheme's default port.
+//
+// Call it only after validateWebSocketOrigin succeeds. The clone lets
+// coder/websocket perform its own normalized host check without changing the
+// request visible to JaWS.
+func normalizedWebSocketAcceptRequest(r *http.Request) (normalized *http.Request) {
+	normalized = r
+	if u, err := url.Parse(r.Header.Get("Origin")); err == nil {
+		port := ""
+		switch u.Scheme {
+		case "http":
+			port = ":80"
+		case "https":
+			port = ":443"
+		}
+		if port != "" {
+			host := strings.TrimSuffix(r.Host, port)
+			originHost := strings.TrimSuffix(u.Host, port)
+			if host != r.Host || originHost != u.Host {
+				normalized = r.Clone(r.Context())
+				normalized.Host = host
+				u.Host = originHost
+				normalized.Header.Set("Origin", u.String())
+			}
+		}
+	}
+	return
+}
+
 // Log sends an error to the [Jaws.Logger] if set.
 // Has no effect if err is nil or the Logger is nil.
 // Returns err.
@@ -831,6 +861,7 @@ func (rq *Request) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		var err error
+		acceptRequest := r
 		if r.Header.Get("Sec-WebSocket-Key") != "" {
 			if err = rq.validateWebSocketOrigin(r); err != nil {
 				http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
@@ -838,9 +869,10 @@ func (rq *Request) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			rq.ensureAutoSession(w, r)
+			acceptRequest = normalizedWebSocketAcceptRequest(r)
 		}
 		var ws *websocket.Conn
-		ws, err = websocket.Accept(w, r, nil)
+		ws, err = websocket.Accept(w, acceptRequest, nil)
 		if err == nil {
 			ws.SetReadLimit(webSocketReadLimit)
 			if err = rq.onConnect(); err == nil {

--- a/request_test.go
+++ b/request_test.go
@@ -1598,6 +1598,72 @@ func TestRequest_validateWebSocketOrigin_NoInitialFailsClosed(t *testing.T) {
 	}
 }
 
+func TestNormalizedWebSocketAcceptRequest(t *testing.T) {
+	tests := []struct {
+		name       string
+		host       string
+		origin     string
+		wantHost   string
+		wantOrigin string
+		wantClone  bool
+	}{
+		{
+			name:       "HTTP Host default port removed",
+			host:       "example.test:80",
+			origin:     "http://example.test",
+			wantHost:   "example.test",
+			wantOrigin: "http://example.test",
+			wantClone:  true,
+		},
+		{
+			name:       "HTTP Origin default port removed",
+			host:       "example.test",
+			origin:     "http://example.test:80",
+			wantHost:   "example.test",
+			wantOrigin: "http://example.test",
+			wantClone:  true,
+		},
+		{
+			name:       "HTTPS IPv6 default port removed",
+			host:       "[2001:db8::1]:443",
+			origin:     "https://[2001:db8::1]:443",
+			wantHost:   "[2001:db8::1]",
+			wantOrigin: "https://[2001:db8::1]",
+			wantClone:  true,
+		},
+		{
+			name:       "non-default port preserved",
+			host:       "example.test:8080",
+			origin:     "http://example.test:8080",
+			wantHost:   "example.test:8080",
+			wantOrigin: "http://example.test:8080",
+			wantClone:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/jaws/key", nil)
+			r.Host = tt.host
+			r.Header.Set("Origin", tt.origin)
+
+			normalized := normalizedWebSocketAcceptRequest(r)
+			if normalized.Host != tt.wantHost {
+				t.Errorf("Host = %q, want %q", normalized.Host, tt.wantHost)
+			}
+			if origin := normalized.Header.Get("Origin"); origin != tt.wantOrigin {
+				t.Errorf("Origin = %q, want %q", origin, tt.wantOrigin)
+			}
+			if cloned := normalized != r; cloned != tt.wantClone {
+				t.Errorf("cloned = %t, want %t", cloned, tt.wantClone)
+			}
+			if r.Host != tt.host || r.Header.Get("Origin") != tt.origin {
+				t.Errorf("original request mutated: Host = %q, Origin = %q", r.Host, r.Header.Get("Origin"))
+			}
+		})
+	}
+}
+
 func TestRequest_Log(t *testing.T) {
 	wantErr := errors.New("request log test")
 
@@ -2765,6 +2831,61 @@ func TestWS_UnclaimedRequestIsGone(t *testing.T) {
 	}
 }
 
+func TestWS_AcceptsSameOriginDefaultPort(t *testing.T) {
+	tests := []struct {
+		name   string
+		host   string
+		origin string
+		secure bool
+	}{
+		{
+			name:   "Host has explicit port",
+			host:   "example.test:80",
+			origin: "http://example.test",
+		},
+		{
+			name:   "Origin has explicit port",
+			host:   "example.test",
+			origin: "http://example.test:80",
+		},
+		{
+			name:   "HTTPS Host has explicit port",
+			host:   "example.test:443",
+			origin: "https://example.test",
+			secure: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newTestServer(t)
+			defer ts.Close()
+
+			ts.hr.Host = tt.host
+			if tt.secure {
+				ts.hr.TLS = &tls.ConnectionState{}
+			}
+			hdr := http.Header{}
+			hdr.Set("Origin", tt.origin)
+			conn, resp, err := websocket.Dial(ts.ctx, ts.Url(), &websocket.DialOptions{
+				HTTPHeader: hdr,
+				Host:       tt.host,
+			})
+			if err != nil {
+				status := 0
+				if resp != nil {
+					status = resp.StatusCode
+				}
+				t.Fatalf("same-origin callback rejected: status=%d err=%v", status, err)
+			}
+			defer func() { _ = conn.CloseNow() }()
+			if resp.StatusCode != http.StatusSwitchingProtocols {
+				t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusSwitchingProtocols)
+			}
+		})
+	}
+}
+
 func TestWS_RejectsMissingOrigin(t *testing.T) {
 	ts := newTestServer(t)
 	defer ts.Close()
@@ -2810,6 +2931,32 @@ func TestWS_RejectsCrossOrigin(t *testing.T) {
 	}
 	if resp.StatusCode != http.StatusForbidden {
 		t.Errorf("status %d", resp.StatusCode)
+	}
+}
+
+func TestWS_RejectsCallbackHostMismatch(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Close()
+
+	ts.hr.Host = "example.test"
+	hdr := http.Header{}
+	hdr.Set("Origin", "http://example.test")
+	conn, resp, err := websocket.Dial(ts.ctx, ts.Url(), &websocket.DialOptions{
+		HTTPHeader: hdr,
+		Host:       "other.test:80",
+	})
+	if conn != nil {
+		_ = conn.Close(websocket.StatusNormalClosure, "")
+		t.Fatal("expected handshake to be rejected")
+	}
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if resp == nil {
+		t.Fatal("expected response")
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
 	}
 }
 


### PR DESCRIPTION
## Summary

- accept same-origin WebSocket callbacks when `Host` and `Origin` differ only by an explicit scheme-default port
- pass `coder/websocket` a cloned request with only `:80` for HTTP or `:443` for HTTPS normalized away
- leave the original request unchanged and preserve non-default ports

## Security rationale

This does not use `InsecureSkipVerify`. JaWS still validates the Origin against the initial page request, and `coder/websocket` still verifies the Origin against the current callback Host using the narrowly normalized clone. Cross-origin requests and callback Host mismatches remain rejected.

## Tests

- `go generate ./...`
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec -quiet ./...`
- `JAWS_REQUIRE_NODE=1 go test -race -coverprofile=coverage.out ./...`
- `go build ./...`

Added unit coverage for HTTP/HTTPS default ports, IPv6, non-default ports, and request immutability, plus real WebSocket integration coverage for default-port equivalence and callback Host mismatch rejection.

Closes #133
