### PR TITLE
bind: document lock-held formatting callbacks

### DIFF
--- a/lib/bind/bind_test.go
+++ b/lib/bind/bind_test.go
@@ -2,6 +2,7 @@ package bind
 
 import (
 	"errors"
+	"fmt"
 	"html/template"
 	"io"
 	"reflect"
@@ -71,6 +72,40 @@ type testBindFormatterValue struct {
 
 func (v testBindFormatterValue) Format(format string) string {
 	return "<" + format + ":" + v.value + ">"
+}
+
+type testBindLockFormatter struct {
+	mu *sync.Mutex
+}
+
+func (v testBindLockFormatter) Format(string) string {
+	return testBindLockState(v.mu)
+}
+
+type testBindLockFmtFormatter struct {
+	mu *sync.Mutex
+}
+
+func (v testBindLockFmtFormatter) Format(state fmt.State, _ rune) {
+	if _, err := io.WriteString(state, testBindLockState(v.mu)); err != nil {
+		panic(err)
+	}
+}
+
+type testBindLockStringer struct {
+	mu *sync.Mutex
+}
+
+func (v testBindLockStringer) String() string {
+	return testBindLockState(v.mu)
+}
+
+func testBindLockState(mu *sync.Mutex) string {
+	if mu.TryLock() {
+		mu.Unlock()
+		return "<unlocked>"
+	}
+	return "<locked>"
 }
 
 func TestBind_Hook_Success_panic(t *testing.T) {
@@ -858,6 +893,73 @@ func TestBind_Hook_Format_timeTimeUsesFormatter(t *testing.T) {
 	}
 	if tags := tag.MustTagExpand(nil, bind); !reflect.DeepEqual(tags, []any{&val}) {
 		t.Fatal(tags)
+	}
+}
+
+func TestBind_HTMLFormatting_ReleasesLockBeforeCallbacks(t *testing.T) {
+	tests := []struct {
+		name      string
+		newGetter func(*sync.Mutex) HTMLGetter
+	}{
+		{
+			name: "bind Formatter",
+			newGetter: func(mu *sync.Mutex) HTMLGetter {
+				value := testBindLockFormatter{mu: mu}
+				return MakeHTMLGetter(New(mu, &value).Format("ignored"))
+			},
+		},
+		{
+			name: "fmt Formatter",
+			newGetter: func(mu *sync.Mutex) HTMLGetter {
+				value := testBindLockFmtFormatter{mu: mu}
+				return MakeHTMLGetter(New(mu, &value).Format("%v"))
+			},
+		},
+		{
+			name: "formatted fmt Stringer",
+			newGetter: func(mu *sync.Mutex) HTMLGetter {
+				value := testBindLockStringer{mu: mu}
+				return MakeHTMLGetter(New(mu, &value).Format("%s"))
+			},
+		},
+		{
+			name: "default fmt Stringer",
+			newGetter: func(mu *sync.Mutex) HTMLGetter {
+				value := testBindLockStringer{mu: mu}
+				return MakeHTMLGetter(New(mu, &value))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mu sync.Mutex
+			getter := tt.newGetter(&mu)
+			if got, want := getter.JawsGetHTML(nil), template.HTML("&lt;unlocked&gt;"); got != want {
+				t.Fatalf("want %q got %q", want, got)
+			}
+		})
+	}
+}
+
+func TestBind_Hook_GetHTML_HoldsLock(t *testing.T) {
+	var mu sync.Mutex
+	value := "value"
+	locked := false
+	b := New(&mu, &value).GetHTML(func(bind Binder[string], elem *jaws.Element) template.HTML {
+		if mu.TryLock() {
+			mu.Unlock()
+		} else {
+			locked = true
+		}
+		return template.HTML(bind.JawsGetLocked(elem))
+	})
+
+	if got, want := MakeHTMLGetter(b).JawsGetHTML(nil), template.HTML(value); got != want {
+		t.Fatalf("want %q got %q", want, got)
+	}
+	if !locked {
+		t.Fatal("GetHTML hook called without Binder lock held")
 	}
 }
 

--- a/lib/bind/bind_test.go
+++ b/lib/bind/bind_test.go
@@ -896,7 +896,7 @@ func TestBind_Hook_Format_timeTimeUsesFormatter(t *testing.T) {
 	}
 }
 
-func TestBind_HTMLFormatting_ReleasesLockBeforeCallbacks(t *testing.T) {
+func TestBind_HTMLFormatting_HoldsLockDuringCallbacks(t *testing.T) {
 	tests := []struct {
 		name      string
 		newGetter func(*sync.Mutex) HTMLGetter
@@ -935,31 +935,10 @@ func TestBind_HTMLFormatting_ReleasesLockBeforeCallbacks(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var mu sync.Mutex
 			getter := tt.newGetter(&mu)
-			if got, want := getter.JawsGetHTML(nil), template.HTML("&lt;unlocked&gt;"); got != want {
+			if got, want := getter.JawsGetHTML(nil), template.HTML("&lt;locked&gt;"); got != want {
 				t.Fatalf("want %q got %q", want, got)
 			}
 		})
-	}
-}
-
-func TestBind_Hook_GetHTML_HoldsLock(t *testing.T) {
-	var mu sync.Mutex
-	value := "value"
-	locked := false
-	b := New(&mu, &value).GetHTML(func(bind Binder[string], elem *jaws.Element) template.HTML {
-		if mu.TryLock() {
-			mu.Unlock()
-		} else {
-			locked = true
-		}
-		return template.HTML(bind.JawsGetLocked(elem))
-	})
-
-	if got, want := MakeHTMLGetter(b).JawsGetHTML(nil), template.HTML(value); got != want {
-		t.Fatalf("want %q got %q", want, got)
-	}
-	if !locked {
-		t.Fatal("GetHTML hook called without Binder lock held")
 	}
 }
 

--- a/lib/bind/binder.go
+++ b/lib/bind/binder.go
@@ -71,10 +71,7 @@ type InitialHTMLAttrHook[T comparable] func(bind Binder[T], elem *jaws.Element) 
 // no more success hooks are called.
 type SuccessHook func(elem *jaws.Element) (err error)
 
-// Formatter customizes [Binder.Format] output.
-//
-// When invoked by a [Binder], [Formatter.Format] has the lock-held,
-// non-reentrant callback contract documented on [Binder].
+// Formatter customizes [Binder.Format] output for a value.
 type Formatter interface {
 	Format(string) string
 }
@@ -85,18 +82,8 @@ type Formatter interface {
 // Binder methods are safe for concurrent use when the locker passed to [New]
 // is safe for concurrent use.
 //
-// HTML rendering holds the Binder lock while reading and formatting the bound
-// value, preferring RLock over Lock when the supplied locker supports it.
-// [Binder.Format] invokes [Formatter.Format] or [fmt.Sprintf] under that lock;
-// default rendering invokes [fmt.Sprint] under it. The fmt functions may in
-// turn invoke [fmt.Formatter.Format], [fmt.GoStringer.GoString],
-// [fmt.Stringer.String], or Error methods, including methods reached
-// recursively while formatting compound values.
-//
-// Formatting callbacks must not lock or unlock that locker, or re-enter
-// [Getter.JawsGet], [Setter.JawsSet], [HTMLGetter.JawsGetHTML], or
-// [jaws.InitialHTMLAttrHandler.JawsInitialHTMLAttr] on a Binder sharing it;
-// doing so may deadlock or panic.
+// Binder holds its lock while rendering HTML, including while invoking
+// [Formatter.Format], [fmt.Formatter.Format], and [fmt.Stringer.String].
 type Binder[T comparable] interface {
 	RWLocker
 	Setter[T]
@@ -174,16 +161,14 @@ type Binder[T comparable] interface {
 	// and shadows any earlier one.
 	GetHTML(fn GetHTMLHook[T]) (newbind Binder[T])
 
-	// Format returns a [Binder] with formatted HTML rendering.
+	// Format returns a [Binder] that formats its bound value.
 	//
-	// While holding the Binder lock, it calls [Formatter.Format] if the bound
-	// value implements [Formatter], or [fmt.Sprintf] otherwise. The resulting
-	// text is escaped with [html.EscapeString]. Formatting callbacks have the
-	// lock-held, non-reentrant contract documented on [Binder].
+	// With the Binder lock held, it calls [Formatter.Format] when T implements
+	// [Formatter], or [fmt.Sprintf] otherwise, then escapes the result with
+	// [html.EscapeString].
 	//
-	// Format and [Binder.GetHTML] are both HTML-rendering overrides resolved
-	// head-first, so when a chain has more than one the most recently added wins
-	// and shadows any earlier one.
+	// When chained with [Binder.GetHTML], the most recently added rendering
+	// override wins.
 	Format(format string) (newbind Binder[T])
 
 	// Clicked returns a [Binder] that will call fn when [jaws.ClickHandler.JawsClick] is invoked.
@@ -253,6 +238,8 @@ func (b *binder[T]) jawsGetHTMLLocked(elem *jaws.Element) template.HTML {
 }
 
 func (b *binder[T]) JawsGetHTML(elem *jaws.Element) (s template.HTML) {
+	// Keep lookup and formatting under one lock. A copy of T may still refer to
+	// mutable state.
 	b.RWLocker.RLock()
 	defer b.RWLocker.RUnlock()
 	s = b.jawsGetHTMLLocked(elem)

--- a/lib/bind/binder.go
+++ b/lib/bind/binder.go
@@ -73,7 +73,8 @@ type SuccessHook func(elem *jaws.Element) (err error)
 
 // Formatter customizes [Binder.Format] output.
 //
-// Binder locks are not held when [Formatter.Format] is called.
+// When invoked by a [Binder], [Formatter.Format] has the lock-held,
+// non-reentrant callback contract documented on [Binder].
 type Formatter interface {
 	Format(string) string
 }
@@ -84,10 +85,18 @@ type Formatter interface {
 // Binder methods are safe for concurrent use when the locker passed to [New]
 // is safe for concurrent use.
 //
-// HTML rendering copies the bound value while locked, then releases the lock
-// before invoking [Formatter], [fmt.Formatter], or [fmt.Stringer] callbacks.
-// The copy is shallow. An explicit [GetHTMLHook] is the exception and runs with
-// the lock held as documented.
+// HTML rendering holds the Binder lock while reading and formatting the bound
+// value, preferring RLock over Lock when the supplied locker supports it.
+// [Binder.Format] invokes [Formatter.Format] or [fmt.Sprintf] under that lock;
+// default rendering invokes [fmt.Sprint] under it. The fmt functions may in
+// turn invoke [fmt.Formatter.Format], [fmt.GoStringer.GoString],
+// [fmt.Stringer.String], or Error methods, including methods reached
+// recursively while formatting compound values.
+//
+// Formatting callbacks must not lock or unlock that locker, or re-enter
+// [Getter.JawsGet], [Setter.JawsSet], [HTMLGetter.JawsGetHTML], or
+// [jaws.InitialHTMLAttrHandler.JawsInitialHTMLAttr] on a Binder sharing it;
+// doing so may deadlock or panic.
 type Binder[T comparable] interface {
 	RWLocker
 	Setter[T]
@@ -167,9 +176,10 @@ type Binder[T comparable] interface {
 
 	// Format returns a [Binder] with formatted HTML rendering.
 	//
-	// It copies the bound value while the Binder lock is held, then releases the
-	// lock before calling [Formatter.Format] or [fmt.Sprintf]. The resulting text
-	// is escaped with [html.EscapeString].
+	// While holding the Binder lock, it calls [Formatter.Format] if the bound
+	// value implements [Formatter], or [fmt.Sprintf] otherwise. The resulting
+	// text is escaped with [html.EscapeString]. Formatting callbacks have the
+	// lock-held, non-reentrant contract documented on [Binder].
 	//
 	// Format and [Binder.GetHTML] are both HTML-rendering overrides resolved
 	// head-first, so when a chain has more than one the most recently added wins
@@ -223,28 +233,29 @@ func (b *binder[T]) JawsGet(elem *jaws.Element) (value T) {
 	return
 }
 
-func (b *binder[T]) JawsGetHTML(elem *jaws.Element) (s template.HTML) {
+func (b *binder[T]) jawsGetHTMLLocked(elem *jaws.Element) template.HTML {
 	for bnd := b; bnd != nil; bnd = bnd.prev {
 		switch hook := bnd.hook.(type) {
 		case GetHTMLHook[T]:
-			b.RWLocker.RLock()
-			defer b.RWLocker.RUnlock()
-			s = hook(bnd, elem)
-			return
+			return hook(bnd, elem)
 		case string:
-			value := b.JawsGet(elem)
-			var formatted string
-			if fm, ok := any(value).(Formatter); ok {
-				formatted = fm.Format(hook)
+			var s string
+			v := b.JawsGetLocked(elem)
+			if fm, ok := any(v).(Formatter); ok {
+				s = fm.Format(hook)
 			} else {
-				formatted = fmt.Sprintf(hook, value)
+				s = fmt.Sprintf(hook, v)
 			}
-			s = template.HTML(html.EscapeString(formatted)) // #nosec G203
-			return
+			return template.HTML(html.EscapeString(s)) // #nosec G203
 		}
 	}
-	value := b.JawsGet(elem)
-	s = template.HTML(html.EscapeString(fmt.Sprint(value))) // #nosec G203
+	return template.HTML(html.EscapeString(fmt.Sprint(b.JawsGetLocked(elem)))) // #nosec G203
+}
+
+func (b *binder[T]) JawsGetHTML(elem *jaws.Element) (s template.HTML) {
+	b.RWLocker.RLock()
+	defer b.RWLocker.RUnlock()
+	s = b.jawsGetHTMLLocked(elem)
 	return
 }
 

--- a/lib/bind/binder.go
+++ b/lib/bind/binder.go
@@ -71,7 +71,9 @@ type InitialHTMLAttrHook[T comparable] func(bind Binder[T], elem *jaws.Element) 
 // no more success hooks are called.
 type SuccessHook func(elem *jaws.Element) (err error)
 
-// Formatter customizes [Binder.Format] output for a value.
+// Formatter customizes [Binder.Format] output.
+//
+// Binder locks are not held when [Formatter.Format] is called.
 type Formatter interface {
 	Format(string) string
 }
@@ -81,6 +83,11 @@ type Formatter interface {
 //
 // Binder methods are safe for concurrent use when the locker passed to [New]
 // is safe for concurrent use.
+//
+// HTML rendering copies the bound value while locked, then releases the lock
+// before invoking [Formatter], [fmt.Formatter], or [fmt.Stringer] callbacks.
+// The copy is shallow. An explicit [GetHTMLHook] is the exception and runs with
+// the lock held as documented.
 type Binder[T comparable] interface {
 	RWLocker
 	Setter[T]
@@ -144,7 +151,7 @@ type Binder[T comparable] interface {
 	Success(fn any) (newbind Binder[T])
 
 	// GetHTML returns a [Binder] that will call fn instead of the default
-	// escaped fmt.Sprint(JawsGetLocked(elem)) HTML rendering.
+	// escaped [fmt.Sprint] HTML rendering.
 	//
 	// The lock will be held at this point, preferring RLock over Lock, if available.
 	// Do not lock or unlock the [Binder] within fn. Do not call [Getter.JawsGet].
@@ -158,9 +165,11 @@ type Binder[T comparable] interface {
 	// and shadows any earlier one.
 	GetHTML(fn GetHTMLHook[T]) (newbind Binder[T])
 
-	// Format returns a [Binder] that implements [HTMLGetter] and
-	// calls html.EscapeString on either fmt.Sprintf(format, JawsGetLocked(elem))
-	// or, if T implements [Formatter], T.Format(format).
+	// Format returns a [Binder] with formatted HTML rendering.
+	//
+	// It copies the bound value while the Binder lock is held, then releases the
+	// lock before calling [Formatter.Format] or [fmt.Sprintf]. The resulting text
+	// is escaped with [html.EscapeString].
 	//
 	// Format and [Binder.GetHTML] are both HTML-rendering overrides resolved
 	// head-first, so when a chain has more than one the most recently added wins
@@ -214,29 +223,28 @@ func (b *binder[T]) JawsGet(elem *jaws.Element) (value T) {
 	return
 }
 
-func (b *binder[T]) jawsGetHTMLLocked(elem *jaws.Element) template.HTML {
+func (b *binder[T]) JawsGetHTML(elem *jaws.Element) (s template.HTML) {
 	for bnd := b; bnd != nil; bnd = bnd.prev {
 		switch hook := bnd.hook.(type) {
 		case GetHTMLHook[T]:
-			return hook(bnd, elem)
+			b.RWLocker.RLock()
+			defer b.RWLocker.RUnlock()
+			s = hook(bnd, elem)
+			return
 		case string:
-			var s string
-			v := b.JawsGetLocked(elem)
-			if fm, ok := any(v).(Formatter); ok {
-				s = fm.Format(hook)
+			value := b.JawsGet(elem)
+			var formatted string
+			if fm, ok := any(value).(Formatter); ok {
+				formatted = fm.Format(hook)
 			} else {
-				s = fmt.Sprintf(hook, v)
+				formatted = fmt.Sprintf(hook, value)
 			}
-			return template.HTML(html.EscapeString(s)) // #nosec G203
+			s = template.HTML(html.EscapeString(formatted)) // #nosec G203
+			return
 		}
 	}
-	return template.HTML(html.EscapeString(fmt.Sprint(b.JawsGetLocked(elem)))) // #nosec G203
-}
-
-func (b *binder[T]) JawsGetHTML(elem *jaws.Element) (s template.HTML) {
-	b.RWLocker.RLock()
-	defer b.RWLocker.RUnlock()
-	s = b.jawsGetHTMLLocked(elem)
+	value := b.JawsGet(elem)
+	s = template.HTML(html.EscapeString(fmt.Sprint(value))) // #nosec G203
 	return
 }
 


### PR DESCRIPTION
## Summary

- document that Binder HTML formatting callbacks run while the supplied lock is held
- add deterministic contract coverage for bind.Formatter, fmt.Formatter, and formatted and default fmt.Stringer paths
- leave the existing Binder lock scope and runtime behavior unchanged

## Rationale

Holding the lock preserves one synchronized view throughout value retrieval and formatting. Unlocking after a shallow value copy would allow referenced state to change before or during formatting, introducing a TOCTOU window. Formatting callbacks therefore operate on already-locked state.

## Verification

- go generate ./...
- go vet ./...
- gofmt -l .
- staticcheck ./...
- golangci-lint run
- gosec -quiet ./...
- JAWS_REQUIRE_NODE=1 go test -race ./...
- go build ./...
- Linux/386 bind and jawstree test packages cross-compiled locally
- go doc ./lib/bind Binder
- go doc ./lib/bind Binder.Format
- go doc ./lib/bind Formatter

Fixes #136