### PR TITLE
jawstree: run production regression pages under jsdom

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,10 +54,16 @@ jobs:
         with:
           args: ./...
 
+      - name: Install jsdom
+        # The jawstree production regressions load their pages under jsdom; the
+        # runner image ships node and npm, but no npm packages.
+        run: npm install --no-save jsdom
+
       - name: Test
         env:
           # Fail rather than skip the node-driven JS behavior tests; the runner
-          # has node installed, so a missing node here is a CI misconfiguration.
+          # has node and jsdom installed, so either one missing here is a CI
+          # misconfiguration.
           JAWS_REQUIRE_NODE: "1"
         run: go test -race -coverprofile=coverage.out ./...
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ coverage*
 AGENTS.md
 .DS_Store
 /examples/minesweeper/minesweeper
+# npm artifacts from installing jsdom for the jawstree regression tests
+node_modules/
+package.json
+package-lock.json

--- a/jawstree/dynamic_insert_production_regression_test.go
+++ b/jawstree/dynamic_insert_production_regression_test.go
@@ -2,13 +2,8 @@ package jawstree
 
 import (
 	"encoding/json"
-	"image/color"
-	"image/png"
-	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -28,23 +23,6 @@ type dynamicTreeContainer struct {
 
 func (c *dynamicTreeContainer) JawsContains(*jaws.Element) []jaws.UI {
 	return c.contents
-}
-
-func jawstreeFirefoxPath(t *testing.T) string {
-	t.Helper()
-	for _, name := range []string{"firefox", "firefox-esr"} {
-		if filename, err := exec.LookPath(name); err == nil {
-			return filename
-		}
-	}
-	if runtime.GOOS == "darwin" {
-		const filename = "/Applications/Firefox.app/Contents/MacOS/firefox"
-		if _, err := os.Stat(filename); err == nil {
-			return filename
-		}
-	}
-	t.Skip("Firefox is required for the dynamic Tree production regression")
-	return ""
 }
 
 func TestTreeDynamicInitializationWithClientAssets(t *testing.T) {
@@ -109,7 +87,7 @@ func TestTreeDynamicInitializationWithClientAssets(t *testing.T) {
 
 	// Select a node server-side and dirty the tree immediately after insertion. The
 	// production writer may coalesce this jawstreeSelection with the
-	// Append/Order/initializer messages above, so the browser regression replays all
+	// Append/Order/initializer messages above, so the regression page replays all
 	// four in one WebSocket frame. Only selection is synced (not names/structure), so
 	// the update carries the selected index rather than a relabel.
 	if err := tree.SetSelected([][]string{{"Documents"}}); err != nil {
@@ -212,37 +190,8 @@ window.addEventListener("DOMContentLoaded", function() {
 </body></html>`
 
 	htmlPath := filepath.Join(dir, "dynamic-tree.html")
-	screenshotPath := filepath.Join(dir, "dynamic-tree.png")
-	profilePath := filepath.Join(dir, "firefox-profile")
 	if err := os.WriteFile(htmlPath, []byte(htmlText), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Mkdir(profilePath, 0o700); err != nil {
-		t.Fatal(err)
-	}
-
-	pageURL := (&url.URL{Scheme: "file", Path: htmlPath}).String()
-	cmd := exec.CommandContext(t.Context(), jawstreeFirefoxPath(t),
-		"--headless", "--new-instance", "--profile", profilePath,
-		"--screenshot", screenshotPath, "--window-size", "64,64", pageURL)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("Firefox failed: %v\n%s", err, output)
-	}
-
-	f, err := os.Open(screenshotPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	img, decodeErr := png.Decode(f)
-	closeErr := f.Close()
-	if decodeErr != nil {
-		t.Fatal(decodeErr)
-	}
-	if closeErr != nil {
-		t.Fatal(closeErr)
-	}
-	pixel := color.RGBAModel.Convert(img.At(32, 32)).(color.RGBA)
-	if pixel.R > 32 || pixel.G < 224 || pixel.B > 32 {
-		t.Fatalf("dynamic Tree did not initialize through shipped assets; center pixel = %#v, want green", pixel)
-	}
+	jawstreeRunJsdomPage(t, htmlPath)
 }

--- a/jawstree/jsdom_test.go
+++ b/jawstree/jsdom_test.go
@@ -1,0 +1,84 @@
+package jawstree
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// jawstreeJsdomRunner loads the page given as its argument under jsdom and exits
+// zero only once the page has turned its #result element green. On failure it
+// reports the element's background and any jsdom errors for diagnosis.
+const jawstreeJsdomRunner = `
+const { JSDOM, VirtualConsole } = require("jsdom");
+const { readFileSync } = require("fs");
+const { pathToFileURL } = require("url");
+const htmlPath = process.argv[1];
+const errors = [];
+const vc = new VirtualConsole();
+vc.on("jsdomError", function (e) { errors.push(String((e && e.message) || e)); });
+const dom = new JSDOM(readFileSync(htmlPath, "utf8"), {
+	url: pathToFileURL(htmlPath).href,
+	runScripts: "dangerously",
+	resources: "usable",
+	pretendToBeVisual: true,
+	virtualConsole: vc,
+});
+const window = dom.window;
+const deadline = Date.now() + 10000;
+const timer = setInterval(function () {
+	const result = window.document.getElementById("result");
+	const bg = result ? result.style.background.replace(/\s/g, "") : "";
+	const green = bg === "rgb(0,255,0)";
+	if (green || errors.length > 0 || Date.now() > deadline) {
+		clearInterval(timer);
+		if (!green) {
+			console.error("#result background = " + JSON.stringify(bg) + "; jsdom errors = " + JSON.stringify(errors));
+		}
+		process.exit(green ? 0 : 1);
+	}
+}, 25);
+`
+
+// jawstreeNodeWithJsdom returns the node executable and the environment needed
+// for require("jsdom") to resolve: nil when jsdom is reachable from this package
+// directory (an ancestor node_modules), or one with NODE_PATH pointing at the
+// npm global root. It skips the test when node or jsdom is unavailable, or fails
+// instead when JAWS_REQUIRE_NODE is set.
+func jawstreeNodeWithJsdom(t *testing.T) (node string, env []string) {
+	t.Helper()
+	node, err := exec.LookPath("node")
+	if err == nil {
+		if exec.Command(node, "-e", `require.resolve("jsdom")`).Run() == nil {
+			return node, nil
+		}
+		if npm, e := exec.LookPath("npm"); e == nil {
+			if out, e := exec.Command(npm, "root", "-g").Output(); e == nil {
+				env = append(os.Environ(), "NODE_PATH="+strings.TrimSpace(string(out)))
+				cmd := exec.Command(node, "-e", `require.resolve("jsdom")`)
+				cmd.Env = env
+				if cmd.Run() == nil {
+					return node, env
+				}
+			}
+		}
+	}
+	if os.Getenv("JAWS_REQUIRE_NODE") != "" {
+		t.Fatal("node with the jsdom package not available but JAWS_REQUIRE_NODE is set")
+	}
+	t.Skip("node with the jsdom package is required (npm install jsdom)")
+	return
+}
+
+// jawstreeRunJsdomPage loads htmlPath under jsdom and fails the test unless the
+// page turns its #result element green within the runner's deadline.
+func jawstreeRunJsdomPage(t *testing.T, htmlPath string) {
+	t.Helper()
+	node, env := jawstreeNodeWithJsdom(t)
+	cmd := exec.CommandContext(t.Context(), node, "-e", jawstreeJsdomRunner, htmlPath)
+	cmd.Env = env
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("jsdom: %v\n%s", err, output)
+	}
+}

--- a/jawstree/reconcile_production_regression_test.go
+++ b/jawstree/reconcile_production_regression_test.go
@@ -1,21 +1,17 @@
 package jawstree
 
 import (
-	"image/color"
-	"image/png"
-	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 )
 
 // TestReconcileWithRealWidget drives jawstreeReconcile against the actual vendored
-// Quercus widget (treeview.js) in headless Firefox, not the test mock, covering the
+// Quercus widget (treeview.js) under jsdom, not the test mock, covering the
 // collateral-effect cases that broke the earlier one-pass reconcile: a single-select
 // switch keeping only the new node, a cascade parent-deselect keeping the still-desired
-// children, cascade select-all, and empty-desired. The page turns a fixed pixel green
-// only if every assertion against the real DOM passes.
+// children, cascade select-all, and empty-desired. The page turns its #result element
+// green only if every assertion against the real DOM passes.
 func TestReconcileWithRealWidget(t *testing.T) {
 	treeviewJS, err := assetsFS.ReadFile("assets/treeview.js")
 	if err != nil {
@@ -75,37 +71,8 @@ window.addEventListener("DOMContentLoaded", function () {
 
 	dir := t.TempDir()
 	htmlPath := filepath.Join(dir, "reconcile.html")
-	screenshotPath := filepath.Join(dir, "reconcile.png")
-	profilePath := filepath.Join(dir, "firefox-profile")
 	if err := os.WriteFile(htmlPath, []byte(htmlText), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Mkdir(profilePath, 0o700); err != nil {
-		t.Fatal(err)
-	}
-
-	pageURL := (&url.URL{Scheme: "file", Path: htmlPath}).String()
-	cmd := exec.CommandContext(t.Context(), jawstreeFirefoxPath(t),
-		"--headless", "--new-instance", "--profile", profilePath,
-		"--screenshot", screenshotPath, "--window-size", "64,64", pageURL)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("Firefox failed: %v\n%s", err, output)
-	}
-
-	f, err := os.Open(screenshotPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	img, decodeErr := png.Decode(f)
-	closeErr := f.Close()
-	if decodeErr != nil {
-		t.Fatal(decodeErr)
-	}
-	if closeErr != nil {
-		t.Fatal(closeErr)
-	}
-	pixel := color.RGBAModel.Convert(img.At(32, 32)).(color.RGBA)
-	if pixel.R > 32 || pixel.G < 224 || pixel.B > 32 {
-		t.Fatalf("reconcile against the real widget failed; center pixel = %#v, want green", pixel)
-	}
+	jawstreeRunJsdomPage(t, htmlPath)
 }


### PR DESCRIPTION
## Why

The two jawstree production regression tests launch headless Firefox to render a page and screenshot it. On macOS this intermittently aborts at Firefox startup — `_RegisterApplication(), unable to get application ASN from launchservicesd` (SIGABRT in `TransformProcessType`) — which fails the test run and pops a "Firefox has quit unexpectedly" crash dialog. The failure is environmental (GUI-session registration can be refused for processes launched from sandboxed/unattended contexts), so no browser-based harness avoids it.

## What

- New `jawstree/jsdom_test.go` harness: loads a generated page under jsdom via `node -e` (`runScripts: "dangerously"`, `resources: "usable"`, `pretendToBeVisual` for the widget's `requestAnimationFrame` use) and passes only when the page turns its `#result` element green. On failure it reports the element state and any jsdom errors instead of an opaque red pixel.
- Both regression tests keep their pages and assertions byte-for-byte, only the loader changes; the screenshot/PNG-pixel readout is gone. No GUI process is launched, so the launchservicesd failure mode cannot occur on any platform.
- jsdom resolves from an ancestor `node_modules` (e.g. `npm install jsdom` at the repo root) or from the npm global root via `NODE_PATH`. Tests skip when node or jsdom is unavailable and fail instead when `JAWS_REQUIRE_NODE` is set, matching the existing node-driven test convention.
- GitHub runner images ship node/npm but no npm packages, so the build workflow installs jsdom (`npm install --no-save jsdom`) before the test step; `.gitignore` covers local npm artifacts. The 386 leg intentionally skips these tests (no jsdom there).

## Verification

- Without jsdom: both tests skip; with `JAWS_REQUIRE_NODE=1` they fail loudly.
- With jsdom: both pass, including under `-race`; a deliberately never-green page makes the runner exit non-zero with diagnostics.
- Full local gate: `go vet`, `gofmt -l`, `staticcheck`, `golangci-lint`, `gosec`, `go build`, `go test -race ./...` all clean.