### PR TITLE
websocket: create AutoSession session only on accepted handshakes

### DIFF
--- a/jaws.go
+++ b/jaws.go
@@ -144,7 +144,7 @@ type Jid = jid.Jid // convenience alias
 // concurrency behavior and may be called concurrently when stated.
 type Jaws struct {
 	CookieName              string          // Name for session cookies; defaults to a name derived from the executable ([assets.DefaultCookieName]), falling back to "jaws"
-	AutoSession             bool            // Create a session during WebSocket upgrade when a Request has none. Defaults to false.
+	AutoSession             bool            // Create a session during a successful WebSocket upgrade when a Request has none. Defaults to false.
 	TrustForwardedHeaders   bool            // Trust X-Forwarded-* headers: governs the session cookie Secure flag (X-Forwarded-Proto) and the client IP used for session/request binding (X-Forwarded-For/X-Real-IP). Defaults to false; only enable behind a single reverse proxy you control that sets these headers.
 	Logger                  Logger          // Optional logger to use
 	Debug                   bool            // Set to true to enable debug info in generated HTML code. Call GenerateHeadHTML after changing it.

--- a/request.go
+++ b/request.go
@@ -793,6 +793,40 @@ func normalizedWebSocketAcceptRequest(r *http.Request) (normalized *http.Request
 	return
 }
 
+// autoSessionWriter defers AutoSession creation to the moment websocket.Accept
+// commits to the handshake by writing [http.StatusSwitchingProtocols], so a
+// rejected handshake (a non-101 error response) never registers a session nor
+// sets a session cookie.
+//
+// Accept writes the 101 through the [http.ResponseWriter] it was given before
+// hijacking the connection, so the Set-Cookie header is in the header map in
+// time. Should the hijack itself fail after the 101, the session already
+// exists and expires through the normal session grace period.
+type autoSessionWriter struct {
+	http.ResponseWriter
+	rq *Request
+	r  *http.Request
+}
+
+// Unwrap exposes the wrapped ResponseWriter so websocket.Accept can locate
+// the [http.Hijacker], matching the [http.ResponseController] convention.
+func (asw *autoSessionWriter) Unwrap() http.ResponseWriter { return asw.ResponseWriter }
+
+// WriteHeaderNow forwards gin's deferred header flush when the wrapped writer
+// supports it; websocket.Accept probes for this method after writing the 101.
+func (asw *autoSessionWriter) WriteHeaderNow() {
+	if whn, ok := asw.ResponseWriter.(interface{ WriteHeaderNow() }); ok {
+		whn.WriteHeaderNow()
+	}
+}
+
+func (asw *autoSessionWriter) WriteHeader(statusCode int) {
+	if statusCode == http.StatusSwitchingProtocols {
+		asw.rq.ensureAutoSession(asw.ResponseWriter, asw.r)
+	}
+	asw.ResponseWriter.WriteHeader(statusCode)
+}
+
 // Log sends an error to the [Jaws.Logger] if set.
 // Has no effect if err is nil or the Logger is nil.
 // Returns err.
@@ -862,17 +896,23 @@ func (rq *Request) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		var err error
 		acceptRequest := r
+		acceptWriter := w
 		if r.Header.Get("Sec-WebSocket-Key") != "" {
 			if err = rq.validateWebSocketOrigin(r); err != nil {
 				http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
 				rq.cancel(err)
 				return
 			}
-			rq.ensureAutoSession(w, r)
+			if rq.Jaws.AutoSession && rq.Session() == nil {
+				// Defer AutoSession creation to the handshake commit point so a
+				// handshake websocket.Accept rejects leaves no session or cookie
+				// behind (see autoSessionWriter).
+				acceptWriter = &autoSessionWriter{ResponseWriter: w, rq: rq, r: r}
+			}
 			acceptRequest = normalizedWebSocketAcceptRequest(r)
 		}
 		var ws *websocket.Conn
-		ws, err = websocket.Accept(w, acceptRequest, nil)
+		ws, err = websocket.Accept(acceptWriter, acceptRequest, nil)
 		if err == nil {
 			ws.SetReadLimit(webSocketReadLimit)
 			if err = rq.onConnect(); err == nil {

--- a/request_test.go
+++ b/request_test.go
@@ -3104,6 +3104,83 @@ func TestWS_AutoSessionRejectDoesNotCreateSession(t *testing.T) {
 	}
 }
 
+func TestWS_AutoSessionFailedHandshakeDoesNotCreateSession(t *testing.T) {
+	// websocket.Dial always sends a well-formed handshake, so these defects
+	// that only websocket.Accept detects must be sent as raw HTTP requests.
+	tests := []struct {
+		name       string
+		hdrs       map[string]string
+		wantStatus int
+	}{
+		{
+			name:       "missing Connection and Upgrade headers",
+			hdrs:       map[string]string{"Sec-WebSocket-Version": "13"},
+			wantStatus: http.StatusUpgradeRequired,
+		},
+		{
+			name: "unsupported Sec-WebSocket-Version",
+			hdrs: map[string]string{
+				"Connection":            "Upgrade",
+				"Upgrade":               "websocket",
+				"Sec-WebSocket-Version": "12",
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// A Request serves only once even on a failed handshake, so each
+			// variant needs its own testServer.
+			ts := newTestServerNoSession(t)
+			defer ts.Close()
+			ts.jw.AutoSession = true
+
+			req, err := http.NewRequestWithContext(ts.ctx, http.MethodGet, ts.Url(), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("Origin", ts.origin())
+			req.Header.Set("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+			for k, v := range tt.hdrs {
+				req.Header.Set(k, v)
+			}
+			resp, err := ts.srv.Client().Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != tt.wantStatus {
+				t.Errorf("status %d, want %d", resp.StatusCode, tt.wantStatus)
+			}
+			if cookies := resp.Cookies(); len(cookies) != 0 {
+				t.Fatalf("expected no cookies, got %v", cookies)
+			}
+			if got := ts.jw.SessionCount(); got != 0 {
+				t.Fatalf("expected no sessions, got %d", got)
+			}
+			if sess := ts.rq.Session(); sess != nil {
+				t.Fatalf("expected request session to remain nil, got %v", sess)
+			}
+		})
+	}
+}
+
+type writeHeaderNowRecorder struct {
+	*httptest.ResponseRecorder
+	calledWriteHeaderNow bool
+}
+
+func (w *writeHeaderNowRecorder) WriteHeaderNow() { w.calledWriteHeaderNow = true }
+
+func TestAutoSessionWriter_ForwardsWriteHeaderNow(t *testing.T) {
+	rec := &writeHeaderNowRecorder{ResponseRecorder: httptest.NewRecorder()}
+	asw := &autoSessionWriter{ResponseWriter: rec}
+	asw.WriteHeaderNow()
+	if !rec.calledWriteHeaderNow {
+		t.Fatal("expected WriteHeaderNow to be forwarded to the wrapped writer")
+	}
+}
+
 func TestWS_ConnectFnFails(t *testing.T) {
 	const nope = "nope"
 	ts := newTestServer(t)


### PR DESCRIPTION
## Summary

- With `Jaws.AutoSession` enabled, any request carrying a nonempty `Sec-WebSocket-Key` registered a session and wrote its `Set-Cookie` before `websocket.Accept` validated the handshake, so a malformed/rejected handshake left an orphaned session resident for the grace period and a session cookie on the error response.
- Defer session creation to the handshake commit point: `coder/websocket.Accept` writes `101 Switching Protocols` through the `http.ResponseWriter` it is given right before hijacking the connection, so a thin `autoSessionWriter` wrapper creates and attaches the session (and its cookie) inside `WriteHeader` only when the status is 101. On any rejection the hook never fires — no session, no cookie, nothing to roll back.
- The wrapper forwards `Unwrap` so `Accept` still locates the `http.Hijacker` (`http.ResponseController` convention), and `WriteHeaderNow` so gin's deferred header flush keeps working.
- Non-AutoSession and already-has-session paths pass the original writer unchanged.
- Tightened the `AutoSession` field doc to match the README: the session is created during a *successful* WebSocket upgrade.

## Tests

- New `TestWS_AutoSessionFailedHandshakeDoesNotCreateSession` sends raw HTTP handshakes with defects only `websocket.Accept` catches (missing `Connection`/`Upgrade` headers per the issue repro; unsupported `Sec-WebSocket-Version`) and asserts the error status, no `Set-Cookie`, `SessionCount() == 0`, and a nil request session. Both variants fail against the previous behavior (cookie set, session registered) and pass with this change.
- New `TestAutoSessionWriter_ForwardsWriteHeaderNow` covers the gin-forwarding branch.
- `gofmt -l`, `go vet ./...`, `staticcheck ./...`, `golangci-lint run`, `gosec -quiet ./...` all clean; `go test -race ./...` passes with 100.0% statement coverage on the root package.

Closes #139