### PR TITLE
jawstree: keep cascade-only selections representable

### DIFF
--- a/jawstree/README.md
+++ b/jawstree/README.md
@@ -167,6 +167,18 @@ the Tree's lock; read them with `Tree.GetSelected` or change them with
 rendered clients with `Tree.Dirty`:
 
 ```go
-_ = tree.SetSelected([][]string{{"Documents", "report.pdf"}})
-tree.Dirty(jw)
+if err := tree.SetSelected([][]string{{"Documents", "report.pdf"}}); err != nil {
+	// handle the rejected selection
+} else {
+	tree.Dirty(jw)
+}
 ```
+
+The selection policy follows the configured mode. With neither
+`MultiSelectEnabled` nor `CascadeSelectChildren`, at most one node may be selected.
+With cascade but not multi-select, the selection is empty or one connected rooted
+subtree: descendant branches may be pruned, but every selected descendant must have
+its selectable ancestors selected back to the subtree root. Disabled ancestors are
+transparent. `Tree.SetSelected` returns `ErrInvalidSelection` for a selection the
+browser cannot represent, and a new browser cascade replaces the previous subtree.
+`MultiSelectEnabled` permits independent selected nodes.

--- a/jawstree/assets/jawstree.js
+++ b/jawstree/assets/jawstree.js
@@ -5,18 +5,19 @@
 // Server -> client uses two verbs, both element-scoped JsCalls:
 //   jawstreeInit({jid, options, data})   build the widget once
 //   jawstreeSelection({jid, s:[idx...] | b:"<base64 bitmap>"})   absolute selection
-// Client -> server sends one Input frame per interaction carrying either a delta
-// {"d":{"add":[idx...],"remove":[idx...]}} of preorder node indices, or, when that
-// would be large, an absolute bitmap {"b":"<base64>"}.
+// Client -> server sends one Input frame per interaction carrying a delta
+// {"d":{"add":[idx...],"remove":[idx...]}} of preorder node indices, a sparse
+// absolute cascade-only selection {"s":[idx...]}, or, when either list would be
+// large, an absolute bitmap {"b":"<base64>"}.
 //
 // Selection is reconciled with the public selectNodeById only; the widget is never
 // rebuilt for a selection change, so the client's local expansion state survives.
 // Node identity on the wire is the preorder index; the DOM data-id stays the
 // positional path Quercus renders.
 
-// jawstreeDeltaThreshold is the encoded-delta size (bytes) above which the adapter
-// sends an absolute bitmap instead, keeping every frame within the jaws 32 KiB
-// inbound WebSocket limit even for a select-all over a very large tree.
+// jawstreeDeltaThreshold is the encoded delta or sparse-absolute size (bytes) above
+// which the adapter sends a bitmap instead, keeping every frame within the jaws
+// 32 KiB inbound WebSocket limit even for a select-all over a very large tree.
 var jawstreeDeltaThreshold = 24 * 1024;
 
 function jawstreeTopSelectedChildren(children, parentSelected) {
@@ -65,16 +66,21 @@ function jawstreeDecodeOptions(options) {
 }
 
 // jawstreeBuildIndex walks the wire tree in the same preorder the server uses,
-// numbering root as 0 and each descendant in order, and returns the index<->id maps
-// plus the total node count. The root carries no id and is never selectable.
+// numbering root as 0 and each descendant in order, and returns the index<->id maps,
+// authoritative selected-index Set, and total node count. The root carries no id and
+// is never selectable.
 function jawstreeBuildIndex(root) {
     var idByIndex = [];
     var indexById = {};
+    var selected = new Set();
     var next = 0;
     (function walk(node) {
         idByIndex[next] = node.id;
         if (node.id !== undefined) {
             indexById[node.id] = next;
+            if (node.selected) {
+                selected.add(next);
+            }
         }
         next++;
         if (node.children) {
@@ -83,7 +89,7 @@ function jawstreeBuildIndex(root) {
             }
         }
     })(root);
-    return { idByIndex: idByIndex, indexById: indexById, count: next };
+    return { idByIndex: idByIndex, indexById: indexById, selected: selected, count: next };
 }
 
 // jawstreeSelectedIndexSet returns the currently selected nodes of t as a Set of
@@ -171,15 +177,16 @@ function jawstreeSend(jid, data) {
 // t.jawsReconciling is set so the resulting onSelectionChange callbacks do not echo
 // back to the server.
 function jawstreeReconcile(t, desired) {
-    if (jawstreeSetsEqual(jawstreeSelectedIndexSet(t), desired)) {
-        t.lastServerSet = desired;
+    var current = jawstreeSelectedIndexSet(t);
+    if (jawstreeSetsEqual(current, desired)) {
+        t.lastServerSet = current;
         return;
     }
     t.jawsReconciling = true;
     try {
         var bound = 2 * t.jawsNodeCount + 2;
         for (var iter = 0; iter < bound; iter++) {
-            var current = jawstreeSelectedIndexSet(t);
+            current = jawstreeSelectedIndexSet(t);
             var pick = -1;
             var select = false;
             // Prefer selecting a desired-but-missing node; otherwise deselect an
@@ -211,13 +218,17 @@ function jawstreeReconcile(t, desired) {
         }
     } finally {
         t.jawsReconciling = false;
-        t.lastServerSet = desired;
+        current = jawstreeSelectedIndexSet(t);
+        if (jawstreeSetsEqual(current, desired)) {
+            t.lastServerSet = current;
+        }
     }
 }
 
-// jawstreeOnSelectionChange reports a user selection change to the server as the
-// delta versus the last applied server state, falling back to an absolute bitmap
-// when the delta would be large.
+// jawstreeOnSelectionChange reports a user selection change to the server. Ordinary
+// modes use a delta versus the last applied server state; cascade-only additions use
+// the full sparse selection while remove-only changes remain composable deltas.
+// Either form falls back to an absolute bitmap when it is large.
 function jawstreeOnSelectionChange(t, selectedNodesData) {
     var newSet = new Set();
     for (var i = 0; i < selectedNodesData.length; i++) {
@@ -242,7 +253,15 @@ function jawstreeOnSelectionChange(t, selectedNodesData) {
         t.lastServerSet = newSet;
         return;
     }
-    var encoded = JSON.stringify({ d: { add: add, remove: remove } });
+    var encoded;
+    if (t.jawsModes.cascadeSelectChildren && !t.jawsModes.multiSelectEnabled && add.length > 0) {
+        // A single-cascade gesture replaces the selected subtree. Send the complete
+        // state so concurrent changes and overlap with the prior baseline cannot turn
+        // it into a disconnected server selection.
+        encoded = JSON.stringify({ s: Array.from(newSet) });
+    } else {
+        encoded = JSON.stringify({ d: { add: add, remove: remove } });
+    }
     if (encoded.length > jawstreeDeltaThreshold) {
         encoded = JSON.stringify({ b: jawstreeEncodeBitmap(newSet, t.jawsNodeCount) });
     }
@@ -302,9 +321,11 @@ function jawstreeInit(arg) {
     // One Tree may be rendered by several elements on a page. Each container owns
     // its widget, so removing the element also releases the only adapter reference.
     container.jawsTreeview = t;
-    // Baseline the outgoing-delta reference to the selection Quercus applied from
-    // arg.data, then re-enable the callback for genuine user actions.
+    // Baseline the live selection Quercus applied, then reconcile it to the raw
+    // authoritative flags. This is needed for a pruned single-cascade subtree:
+    // Quercus initially selects every descendant of its selected root.
     t.lastServerSet = jawstreeSelectedIndexSet(t);
+    jawstreeReconcile(t, index.selected);
     applying = false;
     return t;
 }

--- a/jawstree/errinvalidselection.go
+++ b/jawstree/errinvalidselection.go
@@ -2,8 +2,10 @@ package jawstree
 
 import "errors"
 
-// ErrInvalidSelection is returned by [New] and [Tree.SetSelected] when a requested
-// selection violates the tree's selection policy: more than one selected node when
-// the tree is single-select (neither [MultiSelectEnabled] nor [CascadeSelectChildren]
-// is set), or a selected node that is disabled or the root. Match with [errors.Is].
+// ErrInvalidSelection identifies a selection rejected by a Tree policy.
+//
+// [New] and [Tree.SetSelected] return it for more than one selected node in ordinary
+// single-select mode, a disconnected selection in cascade-only mode, selection on a
+// tree configured with [NodeSelectionDisabled], or a selected node that is disabled
+// or the root. Match with [errors.Is].
 var ErrInvalidSelection = errors.New("jawstree: invalid selection")

--- a/jawstree/errpathrejected.go
+++ b/jawstree/errpathrejected.go
@@ -2,8 +2,11 @@ package jawstree
 
 import "errors"
 
-// ErrPathRejected is returned when a browser-initiated selection write is refused
-// by [Tree.JawsInput]: a malformed payload, an out-of-range or root node index,
-// a disabled node, or a single-select bitmap carrying more than one bit. The error
-// text carries the specific reason; match the class with [errors.Is].
+// ErrPathRejected identifies structurally invalid browser selection input.
+//
+// [Tree.JawsInput] uses it for a malformed payload, an out-of-range or root node
+// index, a disabled node, or an absolute selection that the configured mode cannot
+// represent. Other selection-policy failures may match [ErrInvalidSelection]
+// instead. The error text carries the specific reason; match the class with
+// [errors.Is].
 var ErrPathRejected = errors.New("jawstree: refusing client selection write")

--- a/jawstree/gate_test.go
+++ b/jawstree/gate_test.go
@@ -26,6 +26,11 @@ func TestNew_Validation(t *testing.T) {
 		{"disabled selected", &Node{Children: []*Node{{Name: "a", Selected: true, Disabled: true}}}, nil, ErrInvalidSelection},
 		{"single-select two selected", &Node{Children: []*Node{{Name: "a", Selected: true}, {Name: "b", Selected: true}}}, nil, ErrInvalidSelection},
 		{"multi-select two selected ok", &Node{Children: []*Node{{Name: "a", Selected: true}, {Name: "b", Selected: true}}}, []Option{MultiSelectEnabled}, nil},
+		{"cascade-only rooted selection ok", &Node{Children: []*Node{{Name: "a", Selected: true, Children: []*Node{{Name: "a1", Selected: true}, {Name: "a2"}}}}}, []Option{CascadeSelectChildren}, nil},
+		{"cascade-only disabled bridge ok", &Node{Children: []*Node{{Name: "a", Selected: true, Children: []*Node{{Name: "disabled", Disabled: true, Children: []*Node{{Name: "leaf", Selected: true}}}}}}}, []Option{CascadeSelectChildren}, nil},
+		{"cascade-only disjoint selection", &Node{Children: []*Node{{Name: "a", Selected: true}, {Name: "b", Selected: true}}}, []Option{CascadeSelectChildren}, ErrInvalidSelection},
+		{"cascade-only ancestor gap", &Node{Children: []*Node{{Name: "a", Selected: true, Children: []*Node{{Name: "a1", Children: []*Node{{Name: "leaf", Selected: true}}}}}}}, []Option{CascadeSelectChildren}, ErrInvalidSelection},
+		{"multi-cascade disjoint selection ok", &Node{Children: []*Node{{Name: "a", Selected: true}, {Name: "b", Selected: true}}}, []Option{MultiSelectEnabled, CascadeSelectChildren}, nil},
 		{"node-selection-disabled with initial selection", &Node{Children: []*Node{{Name: "a", Selected: true}}}, []Option{NodeSelectionDisabled}, ErrInvalidSelection},
 		{"node-selection-disabled empty ok", &Node{Children: []*Node{{Name: "a"}}}, []Option{NodeSelectionDisabled}, nil},
 	}
@@ -300,6 +305,40 @@ func TestApplyClientDelta_Gate(t *testing.T) {
 	}
 }
 
+func TestApplyClientDelta_CascadeOnlyRejectsUnrepresentableDelta(t *testing.T) {
+	t.Run("disjoint add roots", func(t *testing.T) {
+		var mu sync.Mutex
+		tree := mustNew(t, &mu, &Node{Children: []*Node{{Name: "a"}, {Name: "b"}}}, CascadeSelectChildren)
+		tree.Lock()
+		_, err := tree.applyClientDelta([]int{1, 2}, nil)
+		tree.Unlock()
+		if !errors.Is(err, ErrPathRejected) {
+			t.Fatalf("err = %v, want ErrPathRejected", err)
+		}
+		if got := tree.selectedIndexes(); len(got) != 0 {
+			t.Fatalf("rejected add changed state to %v", got)
+		}
+	})
+
+	t.Run("remove creates ancestor gap", func(t *testing.T) {
+		var mu sync.Mutex
+		tree := mustNew(t, &mu, &Node{Children: []*Node{{
+			Name: "a", Selected: true, Children: []*Node{{
+				Name: "a1", Selected: true, Children: []*Node{{Name: "leaf", Selected: true}},
+			}},
+		}}}, CascadeSelectChildren)
+		tree.Lock()
+		_, err := tree.applyClientDelta(nil, []int{2})
+		tree.Unlock()
+		if !errors.Is(err, ErrInvalidSelection) {
+			t.Fatalf("err = %v, want ErrInvalidSelection", err)
+		}
+		if got := tree.selectedIndexes(); !reflect.DeepEqual(got, []int{1, 2, 3}) {
+			t.Fatalf("rejected remove changed state to %v", got)
+		}
+	})
+}
+
 func TestNodeSelectionDisabledRejectsSelection(t *testing.T) {
 	var mu sync.Mutex
 	tree := mustNew(t, &mu, &Node{Children: []*Node{{Name: "a"}}}, NodeSelectionDisabled)
@@ -323,6 +362,33 @@ func TestApplyClientAbsolute_SingleSelectRejectsMultiple(t *testing.T) {
 	tree.Unlock()
 	if !errors.Is(err, ErrPathRejected) {
 		t.Fatalf("err = %v, want ErrPathRejected", err)
+	}
+}
+
+func TestApplyClientAbsolute_CascadeOnlyRejectsDisconnectedSelection(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		indices []int
+	}{
+		{"disjoint roots", []int{1, 4}},
+		{"selectable ancestor gap", []int{1, 3}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var mu sync.Mutex
+			tree := mustNew(t, &mu, &Node{Children: []*Node{
+				{Name: "a", Children: []*Node{{Name: "a1", Children: []*Node{{Name: "leaf"}}}}},
+				{Name: "b"},
+			}}, CascadeSelectChildren)
+			tree.Lock()
+			_, err := tree.applyClientAbsolute(tc.indices)
+			tree.Unlock()
+			if !errors.Is(err, ErrPathRejected) {
+				t.Fatalf("err = %v, want ErrPathRejected", err)
+			}
+			if got := tree.selectedIndexes(); len(got) != 0 {
+				t.Fatalf("rejected selection changed state to %v", got)
+			}
+		})
 	}
 }
 

--- a/jawstree/js_test.go
+++ b/jawstree/js_test.go
@@ -59,6 +59,7 @@ function addContainer(id) {
 }
 var container = addContainer("Jid.1");
 addContainer("Jid.2");
+addContainer("Jid.3");
 global.document = { getElementById: function (id) { return containers[id] || null; } };
 
 function Treeview(options) {
@@ -237,10 +238,42 @@ process.stdout.write(JSON.stringify({
 	}
 }
 
+func TestJawstreeJS_InitReconcilesCascadeOnlySelection(t *testing.T) {
+	raw := runJawstreeJSSnippet(t, jsMock+`
+var data = { children: [{ id: "children.0", name: "P", selected: true, children: [
+	{ id: "children.0.children.0", name: "c1", selected: true },
+	{ id: "children.0.children.1", name: "c2" }
+] }] };
+jawstreeInit({ jid: "Jid.1", options: (1<<7), data: data });
+var t = container.jawsTreeview;
+process.stdout.write(JSON.stringify({
+	selected: selectedIds(t), baseline: Array.from(t.lastServerSet).sort(), sends: sends
+}));
+`)
+	var got struct {
+		Selected []string `json:"selected"`
+		Baseline []int    `json:"baseline"`
+		Sends    []string `json:"sends"`
+	}
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unexpected JSON %q: %v", raw, err)
+	}
+	if !reflect.DeepEqual(got.Selected, []string{"children.0", "children.0.children.0"}) {
+		t.Fatalf("initial selection = %v, want parent and c1 only", got.Selected)
+	}
+	if !reflect.DeepEqual(got.Baseline, []int{1, 2}) {
+		t.Fatalf("initial baseline = %v, want [1 2]", got.Baseline)
+	}
+	if len(got.Sends) != 0 {
+		t.Fatalf("initial reconcile produced outbound frames: %v", got.Sends)
+	}
+}
+
 // TestJawstreeJS_SelectionReconcile drives the reconcile against the faithful mock in
 // the two modes whose collateral effects broke the naive one-pass reconcile: a
 // single-select switch must leave only the new node (not clear everything), and a
-// cascade parent-deselect must keep the still-desired children.
+// cascade parent-deselect must keep the still-desired children. It also covers an
+// exact pruned cascade-only update.
 func TestJawstreeJS_SelectionReconcile(t *testing.T) {
 	raw := runJawstreeJSSnippet(t, jsMock+`
 var flat = { children: [{ id: "children.0", name: "A" }, { id: "children.1", name: "B" }] };
@@ -264,9 +297,16 @@ var afterAll = selectedIds(c);
 jawstreeSelection({ jid: "Jid.2", s: [2, 3] }); // parent deselected server-side
 var afterParentDrop = selectedIds(c);
 
+jawstreeInit({ jid: "Jid.3", options: (1<<7), data: tree }); // cascade only
+var o = containers["Jid.3"].jawsTreeview;
+jawstreeSelection({ jid: "Jid.3", s: [1, 2] });
+var afterPruned = selectedIds(o);
+var prunedBaseline = Array.from(o.lastServerSet).sort();
+
 process.stdout.write(JSON.stringify({
 	afterA: afterA, afterSwitch: afterSwitch, afterClear: afterClear,
-	afterAll: afterAll, afterParentDrop: afterParentDrop, sends: sends
+	afterAll: afterAll, afterParentDrop: afterParentDrop,
+	afterPruned: afterPruned, prunedBaseline: prunedBaseline, sends: sends
 }));
 `)
 	var got struct {
@@ -275,6 +315,8 @@ process.stdout.write(JSON.stringify({
 		AfterClear      []string `json:"afterClear"`
 		AfterAll        []string `json:"afterAll"`
 		AfterParentDrop []string `json:"afterParentDrop"`
+		AfterPruned     []string `json:"afterPruned"`
+		PrunedBaseline  []int    `json:"prunedBaseline"`
 		Sends           []string `json:"sends"`
 	}
 	if err := json.Unmarshal([]byte(raw), &got); err != nil {
@@ -295,8 +337,50 @@ process.stdout.write(JSON.stringify({
 	if !reflect.DeepEqual(got.AfterParentDrop, []string{"children.0.children.0", "children.0.children.1"}) {
 		t.Fatalf("cascade parent-drop = %v, want the two children kept (blocker 2)", got.AfterParentDrop)
 	}
+	if !reflect.DeepEqual(got.AfterPruned, []string{"children.0", "children.0.children.0"}) ||
+		!reflect.DeepEqual(got.PrunedBaseline, []int{1, 2}) {
+		t.Fatalf("cascade-only pruned update = %v baseline %v, want parent+c1 and [1 2]", got.AfterPruned, got.PrunedBaseline)
+	}
 	if len(got.Sends) != 0 {
 		t.Fatalf("reconcile produced %d outbound frames, want 0 (echo guard)", len(got.Sends))
+	}
+}
+
+func TestJawstreeJS_UnreachableReconcileDoesNotAdvanceBaseline(t *testing.T) {
+	raw := runJawstreeJSSnippet(t, jsMock+`
+var data = { children: [{ id: "children.0", name: "A" }, { id: "children.1", name: "B" }] };
+jawstreeInit({ jid: "Jid.1", options: (1<<7), data: data });
+var t = container.jawsTreeview;
+jawstreeSelection({ jid: "Jid.1", s: [1] });
+var before = Array.from(t.lastServerSet);
+jawstreeSelection({ jid: "Jid.1", s: [1, 2] });
+process.stdout.write(JSON.stringify({
+	before: before,
+	selected: Array.from(jawstreeSelectedIndexSet(t)).sort(),
+	baseline: Array.from(t.lastServerSet).sort(),
+	sends: sends
+}));
+`)
+	var got struct {
+		Before   []int    `json:"before"`
+		Selected []int    `json:"selected"`
+		Baseline []int    `json:"baseline"`
+		Sends    []string `json:"sends"`
+	}
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unexpected JSON %q: %v", raw, err)
+	}
+	if !reflect.DeepEqual(got.Before, []int{1}) {
+		t.Fatalf("converged baseline = %v, want [1]", got.Before)
+	}
+	if reflect.DeepEqual(got.Selected, []int{1, 2}) {
+		t.Fatalf("unreachable selection unexpectedly converged: %v", got.Selected)
+	}
+	if !reflect.DeepEqual(got.Baseline, []int{1}) {
+		t.Fatalf("baseline after failed reconcile = %v, want prior [1]", got.Baseline)
+	}
+	if len(got.Sends) != 0 {
+		t.Fatalf("reconcile produced outbound frames: %v", got.Sends)
 	}
 }
 
@@ -325,6 +409,56 @@ process.stdout.write(JSON.stringify({ sends: sends, baseline: Array.from(t.lastS
 	}
 	if !reflect.DeepEqual(got.Baseline, []int{1}) {
 		t.Fatalf("baseline advanced to %v on successful send, want [1]", got.Baseline)
+	}
+}
+
+func TestJawstreeJS_CascadeOnlySendsAbsoluteSelection(t *testing.T) {
+	raw := runJawstreeJSSnippet(t, jsMock+`
+var data = { children: [{ id: "children.0", name: "P", children: [
+	{ id: "children.0.children.0", name: "q", selected: true },
+	{ id: "children.0.children.1", name: "r" }
+] }] };
+jawstreeInit({ jid: "Jid.1", options: (1<<7), data: data });
+var t = container.jawsTreeview;
+// Selecting P overlaps the already-selected q subtree. The absolute payload must
+// carry q as well as the nodes newly added by this gesture.
+t.selectNodeById("children.0", true);
+t.selectNodeById("children.0", false);
+process.stdout.write(JSON.stringify({ sends: sends, baseline: Array.from(t.lastServerSet).sort() }));
+`)
+	var got struct {
+		Sends    []string `json:"sends"`
+		Baseline []int    `json:"baseline"`
+	}
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unexpected JSON %q: %v", raw, err)
+	}
+	wantSends := []string{
+		"Input\tJid.1\t{\"s\":[1,2,3]}\n",
+		"Input\tJid.1\t{\"d\":{\"add\":[],\"remove\":[1,2,3]}}\n",
+	}
+	if !reflect.DeepEqual(got.Sends, wantSends) {
+		t.Fatalf("cascade-only frames = %v, want absolute select and delta clear", got.Sends)
+	}
+	if len(got.Baseline) != 0 {
+		t.Fatalf("cascade-only baseline after clear = %v, want empty", got.Baseline)
+	}
+}
+
+func TestJawstreeJS_CascadeOnlyAbsoluteFallsBackToBitmap(t *testing.T) {
+	raw := runJawstreeJSSnippet(t, jsMock+`
+jawstreeDeltaThreshold = 1;
+var data = { children: [{ id: "children.0", name: "a" }] };
+jawstreeInit({ jid: "Jid.1", options: (1<<7), data: data });
+container.jawsTreeview.selectNodeById("children.0", true);
+process.stdout.write(JSON.stringify(sends));
+`)
+	var got []string
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unexpected JSON %q: %v", raw, err)
+	}
+	if !reflect.DeepEqual(got, []string{"Input\tJid.1\t{\"b\":\"Ag==\"}\n"}) {
+		t.Fatalf("cascade-only bitmap frames = %v, want index 1 bitmap", got)
 	}
 }
 

--- a/jawstree/option.go
+++ b/jawstree/option.go
@@ -4,14 +4,14 @@ package jawstree
 type Option int
 
 // The bit positions below are wired one-to-one to the literal bit tests in
-// jawstreeNew (assets/jawstree.js); do not reorder or insert constants
+// jawstreeDecodeOptions (assets/jawstree.js); do not reorder or insert constants
 // mid-block without updating that script.
 const (
 	// SearchEnabled enables tree search controls.
 	SearchEnabled Option = (1 << iota)
 	// InitiallyExpanded renders nodes expanded initially.
 	InitiallyExpanded
-	// MultiSelectEnabled allows multiple selected nodes.
+	// MultiSelectEnabled allows independent selected nodes.
 	MultiSelectEnabled
 	// ShowSelectAllButton shows a select-all control.
 	ShowSelectAllButton
@@ -22,6 +22,10 @@ const (
 	// NodeSelectionDisabled disables node selection.
 	NodeSelectionDisabled
 	// CascadeSelectChildren cascades selection to child nodes.
+	//
+	// Without [MultiSelectEnabled], the selection is empty or one connected rooted
+	// subtree with disabled nodes treated as transparent, and selecting a new node
+	// replaces the previous subtree.
 	CascadeSelectChildren
 	// CheckboxSelectionEnabled renders checkbox selection controls.
 	CheckboxSelectionEnabled

--- a/jawstree/reconcile_production_regression_test.go
+++ b/jawstree/reconcile_production_regression_test.go
@@ -10,8 +10,9 @@ import (
 // Quercus widget (treeview.js) under jsdom, not the test mock, covering the
 // collateral-effect cases that broke the earlier one-pass reconcile: a single-select
 // switch keeping only the new node, a cascade parent-deselect keeping the still-desired
-// children, cascade select-all, and empty-desired. The page turns its #result element
-// green only if every assertion against the real DOM passes.
+// children, cascade select-all, empty-desired, and exact cascade-only initialization
+// and updates. The page turns its #result element green only if every assertion
+// against the real DOM passes.
 func TestReconcileWithRealWidget(t *testing.T) {
 	treeviewJS, err := assetsFS.ReadFile("assets/treeview.js")
 	if err != nil {
@@ -31,6 +32,7 @@ func TestReconcileWithRealWidget(t *testing.T) {
 </head><body>
 <div id="treeS"></div>
 <div id="treeC"></div>
+<div id="treeO"></div>
 <div id="result"></div>
 <script>
 window.addEventListener("DOMContentLoaded", function () {
@@ -63,6 +65,20 @@ window.addEventListener("DOMContentLoaded", function () {
 	ck(eq(ids("treeC"), ["children.0.children.0", "children.0.children.1"]));
 	jawstreeSelection({ jid: "treeC", s: [] });
 	ck(eq(ids("treeC"), []));
+
+	// Cascade-only initialization must preserve a pruned rooted selection instead
+	// of leaving every child selected by the widget's initial cascade.
+	jawstreeInit({ jid: "treeO", options: (1 << 7), data: { children: [
+		{ id: "children.0", name: "P", selected: true, children: [
+			{ id: "children.0.children.0", name: "c1", selected: true },
+			{ id: "children.0.children.1", name: "c2" }
+		] }
+	] } });
+	ck(eq(ids("treeO"), ["children.0", "children.0.children.0"]));
+	ck(eq(Array.from(document.getElementById("treeO").jawsTreeview.lastServerSet).sort(), [1, 2]));
+	jawstreeSelection({ jid: "treeO", s: [1, 3] });
+	ck(eq(ids("treeO"), ["children.0", "children.0.children.1"]));
+	ck(eq(Array.from(document.getElementById("treeO").jawsTreeview.lastServerSet).sort(), [1, 3]));
 
 	if (ok) { document.getElementById("result").style.background = "rgb(0,255,0)"; }
 });

--- a/jawstree/render.go
+++ b/jawstree/render.go
@@ -65,6 +65,7 @@ func (t *Tree) JawsInput(elem *jaws.Element, value string) error {
 			Add    []int `json:"add"`
 			Remove []int `json:"remove"`
 		} `json:"d"`
+		S *[]int `json:"s"`
 		B string `json:"b"`
 	}
 	var err error
@@ -74,6 +75,8 @@ func (t *Tree) JawsInput(elem *jaws.Element, value string) error {
 		switch {
 		case msg.D != nil:
 			changed, err = t.applyClientDelta(msg.D.Add, msg.D.Remove)
+		case msg.S != nil:
+			changed, err = t.applyClientAbsolute(*msg.S)
 		case msg.B != "":
 			var indices []int
 			if indices, err = decodeSelectionBitmap(msg.B, len(t.byIndex)); err == nil {

--- a/jawstree/tree.go
+++ b/jawstree/tree.go
@@ -208,12 +208,44 @@ func (t *Tree) strictSingle() bool {
 	return t.options&MultiSelectEnabled == 0 && t.options&CascadeSelectChildren == 0
 }
 
+// cascadeOnly reports whether selection cascades without ordinary multi-select.
+func (t *Tree) cascadeOnly() bool {
+	return t.options&MultiSelectEnabled == 0 && t.options&CascadeSelectChildren != 0
+}
+
+// cascadeSelectionValid reports whether want is empty or one connected rooted
+// selection after disabled nodes are treated as transparent.
+//
+// The caller must first reject the root and disabled nodes from want. A selected
+// node begins a component when its nearest selectable parent is the hidden root or
+// is not selected; Quercus can represent the selection exactly when there is at
+// most one such component.
+func (t *Tree) cascadeSelectionValid(want map[*Node]bool) (valid bool) {
+	roots := 0
+	valid = true
+	for node := range want {
+		parent := node.Parent
+		for parent != nil && parent != t.root && parent.Disabled {
+			parent = parent.Parent
+		}
+		if parent == nil || parent == t.root || !want[parent] {
+			roots++
+			if roots > 1 {
+				valid = false
+				return
+			}
+		}
+	}
+	return
+}
+
 // applySelection sets the selection to exactly want and returns the changed nodes.
 //
-// It is the single selection policy, shared by [New], [Tree.SetSelected], and
-// browser input. It returns [ErrInvalidSelection] when want holds any node on a
-// tree with [NodeSelectionDisabled], more than one node in a single-select tree, or
-// any disabled or root node. Callers on a rendered Tree must hold the write lock.
+// It is the selection policy shared by [New], [Tree.SetSelected], and browser input.
+// It returns [ErrInvalidSelection] when want holds any node on a tree with
+// [NodeSelectionDisabled], more than one node in a single-select tree, a
+// disconnected cascade-only selection, or any disabled or root node. Callers on a
+// rendered Tree must hold the write lock.
 func (t *Tree) applySelection(want map[*Node]bool) (changed []*Node, err error) {
 	if t.options&NodeSelectionDisabled != 0 && len(want) > 0 {
 		return nil, fmt.Errorf("%w: node selection is disabled", ErrInvalidSelection)
@@ -229,12 +261,70 @@ func (t *Tree) applySelection(want map[*Node]bool) (changed []*Node, err error) 
 			return nil, fmt.Errorf("%w: node %q is disabled", ErrInvalidSelection, node.ID)
 		}
 	}
+	if t.cascadeOnly() && !t.cascadeSelectionValid(want) {
+		return nil, fmt.Errorf("%w: cascade-only selection must form one rooted subtree", ErrInvalidSelection)
+	}
 	for _, node := range t.byIndex {
 		if node.Selected != want[node] {
 			node.Selected = want[node]
 			changed = append(changed, node)
 		}
 	}
+	return
+}
+
+// cascadeClientSelection reconstructs the selection made by one legacy
+// cascade-only add delta.
+//
+// Quercus clears the previous selection and selects one node plus all selectable
+// descendants. The delta can omit descendants that were already selected in the
+// client's baseline, so the added nodes identify the selected root but are not an
+// absolute selection by themselves.
+func (t *Tree) cascadeClientSelection(add []int) (want map[*Node]bool, err error) {
+	added := make(map[*Node]bool, len(add))
+	for _, i := range add {
+		var node *Node
+		if node, err = t.resolveIndex(i); err != nil {
+			return
+		}
+		if node.Disabled {
+			err = fmt.Errorf("%w: node %q is disabled", ErrPathRejected, node.ID)
+			return
+		}
+		added[node] = true
+	}
+	var selectedRoot *Node
+	for node := range added {
+		hasAddedAncestor := false
+		for parent := node.Parent; parent != nil && parent != t.root; parent = parent.Parent {
+			if added[parent] {
+				hasAddedAncestor = true
+				break
+			}
+		}
+		if !hasAddedAncestor {
+			if selectedRoot != nil {
+				err = fmt.Errorf("%w: cascade-only add has disjoint roots", ErrPathRejected)
+				return
+			}
+			selectedRoot = node
+		}
+	}
+	if selectedRoot == nil {
+		err = fmt.Errorf("%w: cascade-only add has no root", ErrPathRejected)
+		return
+	}
+	want = make(map[*Node]bool)
+	var selectSubtree func(*Node)
+	selectSubtree = func(node *Node) {
+		if !node.Disabled {
+			want[node] = true
+		}
+		for _, child := range node.Children {
+			selectSubtree(child)
+		}
+	}
+	selectSubtree(selectedRoot)
 	return
 }
 
@@ -263,8 +353,10 @@ func (t *Tree) selectedSet() map[*Node]bool {
 //
 // In a single-select tree the last valid add replaces the whole selection (the
 // authoritative "deselect previous"); with no add, a remove that hits the current
-// selection clears it and anything else is a no-op. Otherwise the delta merges, so
-// concurrent multi-select edits from different clients compose rather than clobber.
+// selection clears it and anything else is a no-op. Cascade-only and multi-select
+// deltas merge when the result remains representable. If a cascade-only add would
+// disconnect the selection, its legacy delta identifies and replaces the selected
+// subtree. This lets concurrent remove-only edits compose rather than clobber.
 func (t *Tree) applyClientDelta(add, remove []int) (changed bool, err error) {
 	var want map[*Node]bool
 	if t.strictSingle() {
@@ -317,6 +409,11 @@ func (t *Tree) applyClientDelta(add, remove []int) (changed bool, err error) {
 			}
 			want[node] = true
 		}
+		if t.cascadeOnly() && len(add) > 0 && !t.cascadeSelectionValid(want) {
+			if want, err = t.cascadeClientSelection(add); err != nil {
+				return
+			}
+		}
 	}
 	var chg []*Node
 	if chg, err = t.applySelection(want); err == nil {
@@ -325,8 +422,8 @@ func (t *Tree) applyClientDelta(add, remove []int) (changed bool, err error) {
 	return
 }
 
-// applyClientAbsolute replaces the selection with exactly the given indices (the
-// bitmap fallback) under the write lock, enforcing the policy.
+// applyClientAbsolute replaces the selection with exactly the given sparse or
+// bitmap indices under the write lock, enforcing the policy.
 func (t *Tree) applyClientAbsolute(indices []int) (changed bool, err error) {
 	want := make(map[*Node]bool, len(indices))
 	for _, i := range indices {
@@ -341,6 +438,9 @@ func (t *Tree) applyClientAbsolute(indices []int) (changed bool, err error) {
 	}
 	if t.strictSingle() && len(want) > 1 {
 		return false, fmt.Errorf("%w: single-select selection has %d nodes", ErrPathRejected, len(want))
+	}
+	if t.cascadeOnly() && !t.cascadeSelectionValid(want) {
+		return false, fmt.Errorf("%w: cascade-only selection must form one rooted subtree", ErrPathRejected)
 	}
 	var chg []*Node
 	if chg, err = t.applySelection(want); err == nil {
@@ -364,8 +464,9 @@ func (t *Tree) GetSelected() (nameLists [][]string) {
 //
 // It runs under the write lock and enforces the selection policy, returning
 // [ErrInvalidSelection] when the match violates it (for example matching more than
-// one node in a single-select tree, or a disabled node). Matching is by name-path
-// and lossy for duplicate sibling names; see [Node.GetSelected].
+// one node in a single-select tree, a disconnected selection with
+// [CascadeSelectChildren] but not [MultiSelectEnabled], or a disabled node). Matching
+// is by name-path and lossy for duplicate sibling names; see [Node.GetSelected].
 func (t *Tree) SetSelected(nameLists [][]string) (err error) {
 	t.Lock()
 	defer t.Unlock()

--- a/jawstree/tree.go
+++ b/jawstree/tree.go
@@ -279,19 +279,12 @@ func (t *Tree) applySelection(want map[*Node]bool) (changed []*Node, err error) 
 // Quercus clears the previous selection and selects one node plus all selectable
 // descendants. The delta can omit descendants that were already selected in the
 // client's baseline, so the added nodes identify the selected root but are not an
-// absolute selection by themselves.
+// absolute selection by themselves. The caller must pass at least one index after
+// resolving every index and rejecting disabled nodes.
 func (t *Tree) cascadeClientSelection(add []int) (want map[*Node]bool, err error) {
 	added := make(map[*Node]bool, len(add))
 	for _, i := range add {
-		var node *Node
-		if node, err = t.resolveIndex(i); err != nil {
-			return
-		}
-		if node.Disabled {
-			err = fmt.Errorf("%w: node %q is disabled", ErrPathRejected, node.ID)
-			return
-		}
-		added[node] = true
+		added[t.byIndex[i]] = true
 	}
 	var selectedRoot *Node
 	for node := range added {
@@ -309,10 +302,6 @@ func (t *Tree) cascadeClientSelection(add []int) (want map[*Node]bool, err error
 			}
 			selectedRoot = node
 		}
-	}
-	if selectedRoot == nil {
-		err = fmt.Errorf("%w: cascade-only add has no root", ErrPathRejected)
-		return
 	}
 	want = make(map[*Node]bool)
 	var selectSubtree func(*Node)

--- a/jawstree/tree_test.go
+++ b/jawstree/tree_test.go
@@ -139,6 +139,41 @@ func TestTreeSetSelectedNamePath(t *testing.T) {
 	}
 }
 
+func TestTreeSetSelectedCascadeOnly(t *testing.T) {
+	root := &Node{Name: "root", Children: []*Node{
+		{Name: "a", Children: []*Node{
+			{Name: "a1"},
+			{Name: "a2", Children: []*Node{{Name: "leaf"}}},
+		}},
+		{Name: "b"},
+	}}
+	var mu deadlock.RWMutex
+	tree := mustNew(t, &mu, root, CascadeSelectChildren)
+
+	// A rooted selection may prune whole descendant branches.
+	maybeError(t, tree.SetSelected([][]string{{"a"}, {"a", "a1"}}))
+	if got := tree.GetSelected(); !reflect.DeepEqual(got, [][]string{{"a"}, {"a", "a1"}}) {
+		t.Fatalf("rooted selection = %#v, want [[a] [a a1]]", got)
+	}
+
+	for _, tc := range []struct {
+		name string
+		want [][]string
+	}{
+		{"disjoint roots", [][]string{{"a"}, {"b"}}},
+		{"selectable ancestor gap", [][]string{{"a"}, {"a", "a2", "leaf"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tree.SetSelected(tc.want); !errors.Is(err, ErrInvalidSelection) {
+				t.Fatalf("SetSelected(%v) err = %v, want ErrInvalidSelection", tc.want, err)
+			}
+			if got := tree.GetSelected(); !reflect.DeepEqual(got, [][]string{{"a"}, {"a", "a1"}}) {
+				t.Fatalf("rejected selection changed state to %#v", got)
+			}
+		})
+	}
+}
+
 func TestTreeSetSelectedDuplicateSiblingNames(t *testing.T) {
 	build := func() *Node {
 		root := &Node{Name: "root"}
@@ -452,6 +487,37 @@ func TestTreeJawsInputSelectsAndReconverges(t *testing.T) {
 	}
 }
 
+func TestTreeJawsInputAppliesSparseAbsoluteSelection(t *testing.T) {
+	jw, err := jaws.New()
+	maybeError(t, err)
+	defer jw.Close()
+	go jw.Serve()
+	rq := jawstest.NewTestRequest(jw, nil)
+	defer rq.Close()
+	<-rq.ReadyCh
+
+	root := &Node{Name: "root", Children: []*Node{
+		{Name: "a", Children: []*Node{{Name: "a1"}}},
+		{Name: "b"},
+	}}
+	var mu deadlock.RWMutex
+	tree := mustNew(t, &mu, root, CascadeSelectChildren)
+	elem := rq.NewElement(tree)
+	var sb strings.Builder
+	maybeError(t, elem.JawsRender(&sb, nil))
+	rq.InCh <- wire.WsMsg{}
+	readCall(t, rq.OutCh, "jawstreeInit=")
+
+	maybeError(t, tree.JawsInput(elem, `{"s":[1,2]}`))
+	if got := tree.selectedIndexes(); !reflect.DeepEqual(got, []int{1, 2}) {
+		t.Fatalf("sparse absolute selection = %v, want [1 2]", got)
+	}
+	maybeError(t, tree.JawsInput(elem, `{"s":[]}`))
+	if got := tree.selectedIndexes(); len(got) != 0 {
+		t.Fatalf("sparse absolute clear = %v, want empty", got)
+	}
+}
+
 func TestTreeJawsInputRejectResyncsOriginOnly(t *testing.T) {
 	jw, err := jaws.New()
 	maybeError(t, err)
@@ -527,6 +593,116 @@ func TestTreeSingleSelectServerAuthoritative(t *testing.T) {
 	}
 	if got := tree.selectedIndexes(); !reflect.DeepEqual(got, []int{2}) {
 		t.Fatalf("selected indexes = %v, want [2]", got)
+	}
+}
+
+// TestTreeCascadeOnlyServerAuthoritative verifies that a new cascade selection
+// replaces an existing disjoint subtree instead of merging into a state the browser
+// cannot represent. A remove-only delta may still prune the active subtree.
+func TestTreeCascadeOnlyServerAuthoritative(t *testing.T) {
+	root := &Node{Name: "root", Children: []*Node{
+		{Name: "a", Children: []*Node{{Name: "a1"}}},
+		{Name: "b", Children: []*Node{{Name: "b1"}}},
+	}}
+	var mu deadlock.RWMutex
+	tree := mustNew(t, &mu, root, CascadeSelectChildren)
+
+	// Two clients rendered from an empty selection choose disjoint subtrees. Each
+	// delta contains the selected anchor and its cascade-selected descendant.
+	tree.Lock()
+	_, err := tree.applyClientDelta([]int{1, 2}, nil)
+	tree.Unlock()
+	maybeError(t, err)
+	tree.Lock()
+	_, err = tree.applyClientDelta([]int{3, 4}, nil)
+	tree.Unlock()
+	maybeError(t, err)
+	if got := tree.selectedIndexes(); !reflect.DeepEqual(got, []int{3, 4}) {
+		t.Fatalf("selection after disjoint add = %v, want [3 4]", got)
+	}
+
+	// Removing a descendant prunes the active rooted selection without clearing its
+	// anchor.
+	tree.Lock()
+	_, err = tree.applyClientDelta(nil, []int{4})
+	tree.Unlock()
+	maybeError(t, err)
+	if got := tree.selectedIndexes(); !reflect.DeepEqual(got, []int{3}) {
+		t.Fatalf("selection after descendant remove = %v, want [3]", got)
+	}
+
+	// A legacy delta can overlap the prior selection: selecting ancestor a while a1
+	// is already selected reports only a as added. Merging the valid rooted result
+	// keeps the overlapping descendant.
+	maybeError(t, tree.SetSelected([][]string{{"a", "a1"}}))
+	tree.Lock()
+	_, err = tree.applyClientDelta([]int{1}, nil)
+	tree.Unlock()
+	maybeError(t, err)
+	if got := tree.selectedIndexes(); !reflect.DeepEqual(got, []int{1, 2}) {
+		t.Fatalf("selection after overlapping ancestor add = %v, want [1 2]", got)
+	}
+}
+
+func TestTreeCascadeOnlyLegacyDeltaSkipsDisabledDescendants(t *testing.T) {
+	root := &Node{Name: "root", Children: []*Node{{
+		Name: "a", Children: []*Node{{
+			Name: "disabled", Disabled: true, Children: []*Node{{Name: "leaf"}},
+		}},
+	}}}
+	var mu deadlock.RWMutex
+	tree := mustNew(t, &mu, root, CascadeSelectChildren)
+	tree.Lock()
+	_, err := tree.applyClientDelta([]int{1, 3}, nil)
+	tree.Unlock()
+	maybeError(t, err)
+	if got := tree.selectedIndexes(); !reflect.DeepEqual(got, []int{1, 3}) {
+		t.Fatalf("cascade through disabled node = %v, want [1 3]", got)
+	}
+}
+
+func TestTreeCascadeOnlyLegacyDeltaCarriesDroppedSelection(t *testing.T) {
+	root := &Node{Name: "root", Children: []*Node{{
+		Name: "p", Children: []*Node{{Name: "c1"}, {Name: "c2"}},
+	}}}
+	var mu deadlock.RWMutex
+	tree := mustNew(t, &mu, root, CascadeSelectChildren)
+
+	// With the legacy adapter, selecting p while disconnected leaves the baseline
+	// empty. Deselecting c2 after reconnect produces the cumulative add [p,c1]. It is
+	// already a valid pruned subtree and must not be expanded back to include c2.
+	tree.Lock()
+	_, err := tree.applyClientDelta([]int{1, 2}, nil)
+	tree.Unlock()
+	maybeError(t, err)
+	if got := tree.selectedIndexes(); !reflect.DeepEqual(got, []int{1, 2}) {
+		t.Fatalf("cumulative legacy delta = %v, want pruned [1 2]", got)
+	}
+}
+
+func TestTreeCascadeOnlyConcurrentRemovalsCompose(t *testing.T) {
+	root := &Node{Name: "root", Children: []*Node{{
+		Name: "p", Selected: true, Children: []*Node{
+			{Name: "a", Selected: true},
+			{Name: "b", Selected: true},
+		},
+	}}}
+	var mu deadlock.RWMutex
+	tree := mustNew(t, &mu, root, CascadeSelectChildren)
+
+	// Two clients start from [p,a,b] and independently prune a and b. Remove-only
+	// deltas compose against the current authoritative state instead of resurrecting
+	// the first removed branch from a stale absolute snapshot.
+	tree.Lock()
+	_, err := tree.applyClientDelta(nil, []int{2})
+	tree.Unlock()
+	maybeError(t, err)
+	tree.Lock()
+	_, err = tree.applyClientDelta(nil, []int{3})
+	tree.Unlock()
+	maybeError(t, err)
+	if got := tree.selectedIndexes(); !reflect.DeepEqual(got, []int{1}) {
+		t.Fatalf("concurrent prunes = %v, want shared root [1]", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- enforce a browser-representable cascade-only selection policy across construction, `SetSelected`, and client input
- make selecting gestures replace disjoint cascades exactly while remove-only edits continue to compose
- reconcile initial pruned selections and advance the browser delta baseline only after verified convergence
- document the option combination and cover it with Go, adapter, and real-Quercus regressions

## Tests

- `go generate ./...`
- `go vet ./...`
- `gofmt -l .`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec -quiet ./...`
- `JAWS_REQUIRE_NODE=1 go test -count=1 -race -coverprofile=/private/tmp/jaws-issue131-coverage.out ./...`
- `go build -v ./...`
- Linux/386 test compilation for `./lib/bind` and `./jawstree`

Closes #131