### PR TITLE
jawstree: cover fresh-client cascade selection regression

### DIFF
--- a/jawstree/README.md
+++ b/jawstree/README.md
@@ -167,9 +167,7 @@ the Tree's lock; read them with `Tree.GetSelected` or change them with
 rendered clients with `Tree.Dirty`:
 
 ```go
-if err := tree.SetSelected([][]string{{"Documents", "report.pdf"}}); err != nil {
-	// handle the rejected selection
-} else {
+if err := tree.SetSelected([][]string{{"Documents", "report.pdf"}}); err == nil {
 	tree.Dirty(jw)
 }
 ```

--- a/jawstree/js_test.go
+++ b/jawstree/js_test.go
@@ -238,34 +238,45 @@ process.stdout.write(JSON.stringify({
 	}
 }
 
-func TestJawstreeJS_InitReconcilesCascadeOnlySelection(t *testing.T) {
-	raw := runJawstreeJSSnippet(t, jsMock+`
+func TestJawstreeJS_InitReconcilesCascadeSelection(t *testing.T) {
+	tests := []struct {
+		name    string
+		options string
+	}{
+		{"cascade_only", `(1<<7)`},
+		{"multi_cascade", `(1<<2)|(1<<7)`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := runJawstreeJSSnippet(t, jsMock+`
 var data = { children: [{ id: "children.0", name: "P", selected: true, children: [
-	{ id: "children.0.children.0", name: "c1", selected: true },
-	{ id: "children.0.children.1", name: "c2" }
+	{ id: "children.0.children.0", name: "A" },
+	{ id: "children.0.children.1", name: "B", selected: true }
 ] }] };
-jawstreeInit({ jid: "Jid.1", options: (1<<7), data: data });
+jawstreeInit({ jid: "Jid.1", options: `+tt.options+`, data: data });
 var t = container.jawsTreeview;
 process.stdout.write(JSON.stringify({
 	selected: selectedIds(t), baseline: Array.from(t.lastServerSet).sort(), sends: sends
 }));
 `)
-	var got struct {
-		Selected []string `json:"selected"`
-		Baseline []int    `json:"baseline"`
-		Sends    []string `json:"sends"`
-	}
-	if err := json.Unmarshal([]byte(raw), &got); err != nil {
-		t.Fatalf("unexpected JSON %q: %v", raw, err)
-	}
-	if !reflect.DeepEqual(got.Selected, []string{"children.0", "children.0.children.0"}) {
-		t.Fatalf("initial selection = %v, want parent and c1 only", got.Selected)
-	}
-	if !reflect.DeepEqual(got.Baseline, []int{1, 2}) {
-		t.Fatalf("initial baseline = %v, want [1 2]", got.Baseline)
-	}
-	if len(got.Sends) != 0 {
-		t.Fatalf("initial reconcile produced outbound frames: %v", got.Sends)
+			var got struct {
+				Selected []string `json:"selected"`
+				Baseline []int    `json:"baseline"`
+				Sends    []string `json:"sends"`
+			}
+			if err := json.Unmarshal([]byte(raw), &got); err != nil {
+				t.Fatalf("unexpected JSON %q: %v", raw, err)
+			}
+			if !reflect.DeepEqual(got.Selected, []string{"children.0", "children.0.children.1"}) {
+				t.Fatalf("initial selection = %v, want parent and B only", got.Selected)
+			}
+			if !reflect.DeepEqual(got.Baseline, []int{1, 3}) {
+				t.Fatalf("initial baseline = %v, want [1 3]", got.Baseline)
+			}
+			if len(got.Sends) != 0 {
+				t.Fatalf("initial reconcile produced outbound frames: %v", got.Sends)
+			}
+		})
 	}
 }
 

--- a/jawstree/js_test.go
+++ b/jawstree/js_test.go
@@ -256,7 +256,9 @@ var data = { children: [{ id: "children.0", name: "P", selected: true, children:
 jawstreeInit({ jid: "Jid.1", options: `+tt.options+`, data: data });
 var t = container.jawsTreeview;
 process.stdout.write(JSON.stringify({
-	selected: selectedIds(t), baseline: Array.from(t.lastServerSet).sort(), sends: sends
+	selected: selectedIds(t),
+	baseline: Array.from(t.lastServerSet).sort(function (a, b) { return a - b; }),
+	sends: sends
 }));
 `)
 			var got struct {

--- a/jawstree/reconcile_production_regression_test.go
+++ b/jawstree/reconcile_production_regression_test.go
@@ -10,9 +10,9 @@ import (
 // Quercus widget (treeview.js) under jsdom, not the test mock, covering the
 // collateral-effect cases that broke the earlier one-pass reconcile: a single-select
 // switch keeping only the new node, a cascade parent-deselect keeping the still-desired
-// children, cascade select-all, empty-desired, and exact cascade-only initialization
-// and updates. The page turns its #result element green only if every assertion
-// against the real DOM passes.
+// children, cascade select-all, empty-desired, exact initialization in both cascade
+// modes, and cascade-only updates. The page turns its #result element green only if
+// every assertion against the real DOM passes.
 func TestReconcileWithRealWidget(t *testing.T) {
 	treeviewJS, err := assetsFS.ReadFile("assets/treeview.js")
 	if err != nil {
@@ -33,6 +33,7 @@ func TestReconcileWithRealWidget(t *testing.T) {
 <div id="treeS"></div>
 <div id="treeC"></div>
 <div id="treeO"></div>
+<div id="treeM"></div>
 <div id="result"></div>
 <script>
 window.addEventListener("DOMContentLoaded", function () {
@@ -66,19 +67,24 @@ window.addEventListener("DOMContentLoaded", function () {
 	jawstreeSelection({ jid: "treeC", s: [] });
 	ck(eq(ids("treeC"), []));
 
-	// Cascade-only initialization must preserve a pruned rooted selection instead
-	// of leaving every child selected by the widget's initial cascade.
-	jawstreeInit({ jid: "treeO", options: (1 << 7), data: { children: [
-		{ id: "children.0", name: "P", selected: true, children: [
-			{ id: "children.0.children.0", name: "c1", selected: true },
-			{ id: "children.0.children.1", name: "c2" }
-		] }
-	] } });
+	// Both cascade modes must preserve the same pruned rooted selection instead of
+	// leaving every child selected by the widget's initial cascade.
+	function initPrunedCascade(jid, options) {
+		jawstreeInit({ jid: jid, options: options, data: { children: [
+			{ id: "children.0", name: "P", selected: true, children: [
+				{ id: "children.0.children.0", name: "A" },
+				{ id: "children.0.children.1", name: "B", selected: true }
+			] }
+		] } });
+		ck(eq(ids(jid), ["children.0", "children.0.children.1"]));
+		ck(eq(Array.from(document.getElementById(jid).jawsTreeview.lastServerSet).sort(), [1, 3]));
+	}
+	initPrunedCascade("treeO", (1 << 7));
+	initPrunedCascade("treeM", (1 << 2) | (1 << 7));
+
+	jawstreeSelection({ jid: "treeO", s: [1, 2] });
 	ck(eq(ids("treeO"), ["children.0", "children.0.children.0"]));
 	ck(eq(Array.from(document.getElementById("treeO").jawsTreeview.lastServerSet).sort(), [1, 2]));
-	jawstreeSelection({ jid: "treeO", s: [1, 3] });
-	ck(eq(ids("treeO"), ["children.0", "children.0.children.1"]));
-	ck(eq(Array.from(document.getElementById("treeO").jawsTreeview.lastServerSet).sort(), [1, 3]));
 
 	if (ok) { document.getElementById("result").style.background = "rgb(0,255,0)"; }
 });

--- a/jawstree/reconcile_production_regression_test.go
+++ b/jawstree/reconcile_production_regression_test.go
@@ -77,14 +77,16 @@ window.addEventListener("DOMContentLoaded", function () {
 			] }
 		] } });
 		ck(eq(ids(jid), ["children.0", "children.0.children.1"]));
-		ck(eq(Array.from(document.getElementById(jid).jawsTreeview.lastServerSet).sort(), [1, 3]));
+		ck(eq(Array.from(document.getElementById(jid).jawsTreeview.lastServerSet)
+			.sort(function (a, b) { return a - b; }), [1, 3]));
 	}
 	initPrunedCascade("treeO", (1 << 7));
 	initPrunedCascade("treeM", (1 << 2) | (1 << 7));
 
 	jawstreeSelection({ jid: "treeO", s: [1, 2] });
 	ck(eq(ids("treeO"), ["children.0", "children.0.children.0"]));
-	ck(eq(Array.from(document.getElementById("treeO").jawsTreeview.lastServerSet).sort(), [1, 2]));
+	ck(eq(Array.from(document.getElementById("treeO").jawsTreeview.lastServerSet)
+		.sort(function (a, b) { return a - b; }), [1, 2]));
 
 	if (ok) { document.getElementById("result").style.background = "rgb(0,255,0)"; }
 });

--- a/jawstree/tree.go
+++ b/jawstree/tree.go
@@ -279,8 +279,14 @@ func (t *Tree) applySelection(want map[*Node]bool) (changed []*Node, err error) 
 // Quercus clears the previous selection and selects one node plus all selectable
 // descendants. The delta can omit descendants that were already selected in the
 // client's baseline, so the added nodes identify the selected root but are not an
-// absolute selection by themselves. The caller must pass at least one index after
-// resolving every index and rejecting disabled nodes.
+// absolute selection by themselves.
+//
+// Indices from the remove delta do not participate in reconstruction: the result
+// replaces the whole selection, and the authoritative update reconciles the
+// originating client.
+//
+// The caller must pass at least one index after resolving every index and rejecting
+// disabled nodes.
 func (t *Tree) cascadeClientSelection(add []int) (want map[*Node]bool, err error) {
 	added := make(map[*Node]bool, len(add))
 	for _, i := range add {


### PR DESCRIPTION
## Summary

PR #154 landed the generic post-construction reconciliation while addressing #131. This follow-up pins the remaining #134 coverage without duplicating that production logic.

- reproduce the exact authoritative `P,B` initialization from #134
- cover both `CascadeSelectChildren` and `MultiSelectEnabled | CascadeSelectChildren`
- verify exact live selection and `[1,3]` baseline with the adapter mock and vendored Quercus widget, with no outbound initialization frame
- clarify that legacy cascade reconstruction ignores remove indices and align the README example with progressive-success flow

## Tests

- `go generate ./...`
- `go vet ./...`
- `gofmt -l .`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec -quiet ./...`
- `JAWS_REQUIRE_NODE=1 go test -count=1 -race -coverprofile=/private/tmp/jaws-issue134-coverage.out ./...` (99.3%)
- `go build -v ./...`
- Linux/386 test compilation for `./lib/bind` and `./jawstree`

Closes #134