### PR TITLE
request: tolerate a nil *Element in DeleteElement

### DIFF
--- a/request_test.go
+++ b/request_test.go
@@ -94,6 +94,17 @@ func TestRequest_MiscBranches(t *testing.T) {
 	}
 }
 
+func TestRequest_DeleteElementNil(t *testing.T) {
+	rq := newTestRequest(t)
+	defer rq.Close()
+
+	// GetElementByJid returns nil for an unknown Jid, so forwarding that result to
+	// DeleteElement must be a no-op rather than a nil dereference, matching the rest of
+	// the nil-tolerant *Element-accepting Request methods (Tag, TagExpanded, TagsOf).
+	rq.DeleteElement(rq.GetElementByJid(Jid(999)))
+	rq.DeleteElement(nil)
+}
+
 func TestRequest_Registrations(t *testing.T) {
 	is := newTestHelper(t)
 	rq := newTestRequest(t)

--- a/requestloop.go
+++ b/requestloop.go
@@ -385,10 +385,10 @@ func (rq *Request) removeElementsLocked(pred func(*Element) bool) {
 }
 
 // deleteElementLocked removes elem from the request's element list and from every
-// tag entry, marking it deleted; it is a no-op if elem belongs to another request.
-// Caller must hold rq.mu.
+// tag entry, marking it deleted; it is a no-op if elem is nil or belongs to another
+// request. Caller must hold rq.mu.
 func (rq *Request) deleteElementLocked(elem *Element) {
-	if elem.Request == rq {
+	if elem != nil && elem.Request == rq {
 		elem.deleted.Store(true)
 		rq.removeElementsLocked(func(e *Element) bool { return e == elem })
 	}
@@ -400,6 +400,10 @@ func (rq *Request) deleteElementLocked(elem *Element) {
 // Use [Element.Remove] to remove a managed DOM child and unregister it together.
 // DeleteElement is intended for elements that were never successfully rendered,
 // or whose DOM lifecycle is managed separately.
+//
+// A nil elem is a no-op, matching [Request.Tag], [Request.TagExpanded] and
+// [Request.TagsOf]; passing the nil that [Request.GetElementByJid] returns for an
+// unknown Jid is therefore safe.
 func (rq *Request) DeleteElement(elem *Element) {
 	rq.mu.Lock()
 	defer rq.mu.Unlock()


### PR DESCRIPTION
## Problem

`Request.DeleteElement(nil)` panics with a nil-pointer dereference. `deleteElementLocked` reads `elem.Request` before any nil check, and `Element` embeds `*Request` as its first field, so the field read faults on a nil `*Element`.

This is inconsistent with the rest of the API family: every sibling `*Element`-accepting method already tolerates nil — `Tag` and `TagExpanded` guard `elem != nil`, `TagsOf` is documented "or nil if elem is nil". And `GetElementByJid` is documented to return nil for an unknown Jid, so the natural one-liner

```go
rq.DeleteElement(rq.GetElementByJid(id)) // id not present -> panic
```

composes two documented public behaviors into a crash. No doc forbids nil.

## Fix

Guard `elem != nil` in `deleteElementLocked` (one line), matching the nil-tolerant siblings, and document the nil no-op on `DeleteElement`.

## Testing

- New `TestRequest_DeleteElementNil` exercises both `DeleteElement(nil)` and `DeleteElement(GetElementByJid(<unknown>))`. Confirmed it panics against the unpatched code and passes with the fix.
- `go test -race -count=1 .` passes; `go build ./...`, `go vet ./...`, `gofmt` clean.

Found during a defect audit of the public API surface. Contained-panic robustness gap (recovered on the render/event paths), hence low severity, but an avoidable crash on input the API family otherwise accepts.