### PR TITLE
click: build Click.Name in linear time when parsing

### DIFF
--- a/click.go
+++ b/click.go
@@ -62,6 +62,7 @@ func parseClickData(value string) (clk Click, after string, ok bool) {
 	clickPart, after, _ = strings.Cut(value, "\t")
 	var n int
 	var kstate int
+	var name strings.Builder
 	ok = true
 	for field := range strings.FieldsSeq(clickPart) {
 		if ok {
@@ -79,12 +80,27 @@ func parseClickData(value string) (clk Click, after string, ok bool) {
 					clk.setKeyState(kstate)
 				}
 			case 3:
+				// First name token: assign directly so the common single-token click
+				// stays allocation-free.
 				clk.Name = field
 			default:
-				clk.Name += " " + field
+				// Second or later name token: accumulate with a strings.Builder, seeded
+				// once with the first token and joined by single spaces, so the name stays
+				// O(total length) rather than the O(n^2) of naive per-token string
+				// concatenation. The click frame is untrusted browser input sized up to the
+				// WebSocket read limit.
+				if name.Len() == 0 {
+					name.Grow(len(clk.Name) + 1 + len(field))
+					name.WriteString(clk.Name)
+				}
+				name.WriteByte(' ')
+				name.WriteString(field)
 			}
 			n++
 		}
+	}
+	if name.Len() > 0 {
+		clk.Name = name.String()
 	}
 	ok = ok && n >= 3
 	return

--- a/click_test.go
+++ b/click_test.go
@@ -53,6 +53,12 @@ func TestParseClickData(t *testing.T) {
 			wantOK: true,
 		},
 		{
+			name:   "name with many tokens collapses whitespace",
+			in:     "1 2 0    a   b     c d",
+			want:   Click{Name: "a b c d", X: 1, Y: 2},
+			wantOK: true,
+		},
+		{
 			name:   "invalid x",
 			in:     "bad 20 0 save",
 			wantOK: false,
@@ -158,6 +164,31 @@ func Fuzz_parseClickData(f *testing.F) {
 			t.Fatalf("roundtrip mismatch: click=%+v/%+v after=%q/%q", clk, clk3, after, after3)
 		}
 	})
+}
+
+func BenchmarkParseClickData(b *testing.B) {
+	// Name accumulation must remain linear in the frame size, and the single-token
+	// click (by far the most common) must stay allocation-free. Cover one, two, and
+	// many name tokens; the long name is bounded in production by the WebSocket read
+	// limit.
+	cases := []struct {
+		name  string
+		value string
+	}{
+		{"OneToken", "10 20 0 save"},
+		{"TwoTokens", "10 20 0 save button"},
+		{"LongName", "0 0 0 " + strings.Repeat("a ", 8000)},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, _, ok := parseClickData(tc.value); !ok {
+					b.Fatal("expected ok")
+				}
+			}
+		})
+	}
 }
 
 func Fuzz_clickStringRoundTrip(f *testing.F) {


### PR DESCRIPTION
## Problem

`parseClickData` accumulated the click name with `clk.Name += " " + field` once per whitespace-separated token past the fourth (`click.go`). Go strings are immutable, so each `+=` reallocates and copies the whole accumulated name — making the parse **O(n²)** in the token count.

The click frame is untrusted browser input, validated for Origin/IP/size but bounded only by the 32 KiB WebSocket read limit. A single crafted frame (`"0 0 0 " + "a ".repeat(16000)`) is a well-formed Click that returns `ok=true`, yet internally forces hundreds of MB of copying and thousands of allocations. Events dispatch serially on the request's event goroutine, so a sustained paced stream from one connected client pins a CPU core and adds process-wide GC pressure.

## Fix

Keep the first name token assigned directly (`case 3: clk.Name = field`), so the common single-token click stays **allocation-free**, and switch to a `strings.Builder` only from the second token on — seeded once with the first token and joined by single spaces, preserving the documented whitespace-collapse behavior. Name accumulation is then O(total length).

## Benchmark (regression guard)

`BenchmarkParseClickData` (`b.Loop`, Apple M5 Max), covering one/two/many name tokens:

```
BenchmarkParseClickData/OneToken-18     ~37 ns/op       0 B/op     0 allocs/op   (fast path preserved)
BenchmarkParseClickData/TwoTokens-18    ~56 ns/op      16 B/op     1 allocs/op   (unchanged)
BenchmarkParseClickData/LongName-18    ~43 µs/op   62968 B/op    17 allocs/op
```

The `LongName` case (8000 tokens) was **O(n²)** before this change: ~5380 µs/op, ~66 MB/op, 8003 allocs/op on the same input (benchstat count=6: −99.23% time, −99.91% B/op, −99.79% allocs). The single- and two-token fast paths are unchanged from before the PR.

## Testing

- `TestParseClickData` includes a multi-token whitespace-collapse case; `Fuzz_parseClickData` and `Fuzz_clickStringRoundTrip` seeds pass.
- `go test -race -count=1 .` passes; `go build ./...`, `go vet ./...`, `gofmt` clean.

Found during a defect audit; robustness/DoS-hardening (bounded per frame, transient), low severity but real work amplification.