### PR TITLE
ui: skip out-of-band-deleted leftovers in container reconcile

### DIFF
--- a/lib/ui/containerhelper.go
+++ b/lib/ui/containerhelper.go
@@ -175,11 +175,8 @@ func (u *ContainerHelper) reconcile(elem *jaws.Element, wantContents []jaws.UI) 
 		newOrder = append(newOrder, childElem.Jid())
 	}
 
-	// Everything left in the pool is a leftover no longer wanted. Skip any deleted
-	// out-of-band (the same what.Delete/what.Remove case the reuse loop guards above):
-	// a deleted Element is already unregistered and inert, so passing it to
-	// Element.Remove would trip validChildElement's deleted-child guard and report a
-	// spurious misuse via Jaws.reportMisuse (which panics when no Logger is configured).
+	// A deleted leftover is already unregistered, while Element.Remove requires a
+	// live, registered child.
 	for _, elems := range pool {
 		for _, e := range elems {
 			if !e.Deleted() {

--- a/lib/ui/containerhelper.go
+++ b/lib/ui/containerhelper.go
@@ -175,8 +175,17 @@ func (u *ContainerHelper) reconcile(elem *jaws.Element, wantContents []jaws.UI) 
 		newOrder = append(newOrder, childElem.Jid())
 	}
 
+	// Everything left in the pool is a leftover no longer wanted. Skip any deleted
+	// out-of-band (the same what.Delete/what.Remove case the reuse loop guards above):
+	// a deleted Element is already unregistered and inert, so passing it to
+	// Element.Remove would trip validChildElement's deleted-child guard and report a
+	// spurious misuse via Jaws.reportMisuse (which panics when no Logger is configured).
 	for _, elems := range pool {
-		toRemove = append(toRemove, elems...)
+		for _, e := range elems {
+			if !e.Deleted() {
+				toRemove = append(toRemove, e)
+			}
+		}
 	}
 	return
 }

--- a/lib/ui/containerhelper_test.go
+++ b/lib/ui/containerhelper_test.go
@@ -229,6 +229,41 @@ func TestContainerHelper_ReconcileDiscardsOutOfBandDeletedChild(t *testing.T) {
 	}
 }
 
+func TestContainerHelper_RemovesOutOfBandDeletedLeftover(t *testing.T) {
+	_, rq := newCoreRequest(t) // jaws.New(): nil Logger, so a spurious reportMisuse panics
+	span1 := NewSpan(testHTMLGetter("span1"))
+	span2 := NewSpan(testHTMLGetter("span2"))
+	tc := &testContainer{contents: []jaws.UI{span1, span2}}
+	container := NewContainer("div", tc)
+	elem, _ := renderUI(t, rq, container)
+
+	if len(container.contents) != 2 {
+		t.Fatalf("want 2 contents got %d", len(container.contents))
+	}
+	deletedChild := container.contents[1]
+
+	// Delete span2's Element out-of-band (as a what.Delete broadcast would via
+	// rq.DeleteElement) AND drop span2 from what the container wants. That routes the
+	// deleted Element to the removal path rather than the self-healing reuse path
+	// exercised by TestContainerHelper_ReconcileDiscardsOutOfBandDeletedChild. Before
+	// the fix, UpdateContainer called elem.Remove on the deleted leftover and
+	// validChildElement reported it via reportMisuse, panicking with the nil Logger.
+	rq.DeleteElement(deletedChild)
+	if !deletedChild.Deleted() {
+		t.Fatal("expected child to be marked deleted")
+	}
+	tc.contents = []jaws.UI{span1}
+
+	container.JawsUpdate(elem)
+
+	if len(container.contents) != 1 {
+		t.Fatalf("want 1 content after update got %d", len(container.contents))
+	}
+	if remaining := container.contents[0]; remaining.Deleted() || rq.GetElementByJid(remaining.Jid()) == nil {
+		t.Fatal("remaining child must be live and registered")
+	}
+}
+
 func TestContainerHelperRenderErrorPaths(t *testing.T) {
 	_, rq := newCoreRequest(t)
 	renderErr := errors.New("render error")

--- a/lib/ui/containerhelper_test.go
+++ b/lib/ui/containerhelper_test.go
@@ -229,8 +229,8 @@ func TestContainerHelper_ReconcileDiscardsOutOfBandDeletedChild(t *testing.T) {
 	}
 }
 
-func TestContainerHelper_RemovesOutOfBandDeletedLeftover(t *testing.T) {
-	_, rq := newCoreRequest(t) // jaws.New(): nil Logger, so a spurious reportMisuse panics
+func TestContainerHelper_SkipsOutOfBandDeletedLeftover(t *testing.T) {
+	_, rq := newCoreRequest(t) // jaws.New(): nil Logger, so an invalid removal panics
 	span1 := NewSpan(testHTMLGetter("span1"))
 	span2 := NewSpan(testHTMLGetter("span2"))
 	tc := &testContainer{contents: []jaws.UI{span1, span2}}
@@ -240,14 +240,14 @@ func TestContainerHelper_RemovesOutOfBandDeletedLeftover(t *testing.T) {
 	if len(container.contents) != 2 {
 		t.Fatalf("want 2 contents got %d", len(container.contents))
 	}
+	remainingChild := container.contents[0]
 	deletedChild := container.contents[1]
 
 	// Delete span2's Element out-of-band (as a what.Delete broadcast would via
-	// rq.DeleteElement) AND drop span2 from what the container wants. That routes the
-	// deleted Element to the removal path rather than the self-healing reuse path
-	// exercised by TestContainerHelper_ReconcileDiscardsOutOfBandDeletedChild. Before
-	// the fix, UpdateContainer called elem.Remove on the deleted leftover and
-	// validChildElement reported it via reportMisuse, panicking with the nil Logger.
+	// rq.DeleteElement) and drop span2 from what the container wants. That routes the
+	// deleted Element to the leftover path rather than the self-healing reuse path
+	// exercised by TestContainerHelper_ReconcileDiscardsOutOfBandDeletedChild.
+	// UpdateContainer must discard it without trying to remove it a second time.
 	rq.DeleteElement(deletedChild)
 	if !deletedChild.Deleted() {
 		t.Fatal("expected child to be marked deleted")
@@ -259,7 +259,11 @@ func TestContainerHelper_RemovesOutOfBandDeletedLeftover(t *testing.T) {
 	if len(container.contents) != 1 {
 		t.Fatalf("want 1 content after update got %d", len(container.contents))
 	}
-	if remaining := container.contents[0]; remaining.Deleted() || rq.GetElementByJid(remaining.Jid()) == nil {
+	remaining := container.contents[0]
+	if remaining != remainingChild {
+		t.Fatal("remaining child must be reused")
+	}
+	if remaining.Deleted() || rq.GetElementByJid(remaining.Jid()) != remaining {
 		t.Fatal("remaining child must be live and registered")
 	}
 }


### PR DESCRIPTION
## Problem

`ContainerHelper.reconcile`'s reuse loop already discards Elements deleted out-of-band — a `what.Delete` broadcast targeting a tag the child registered, or a browser `what.Remove` — so a still-wanted child self-heals (`containerhelper.go:158-169`). But the leftover sweep that builds `toRemove` appended **every** remaining pooled Element unconditionally (`containerhelper.go:178-180`), so a child that was **both** deleted out-of-band **and** no longer wanted was fed to `Element.Remove`.

`Element.validChildElement` rejects a deleted child (`element.go:398`) via `Jaws.reportMisuse`, which:

- **panics** on the request's update goroutine under the default `jaws.New()` (nil `Logger`) configuration and in `deadlock.Debug` builds, tearing down that one connection during a routine container update; or
- with a `Logger` configured, logs a misleading phantom `jaws: Element.Remove: invalid child element: child is deleted` for behavior that is actually correct (the DOM node was already removed by the `what.Delete`).

The trigger is ordinary public-API use — `jw.Delete(tag)` on a container child (which `requestloop.go` resolves to `DeleteElement`, leaving the pointer in the private `contents` slice), then dropping that child from `JawsContains`. `reconcile`'s own doc comment names this out-of-band deletion as anticipated.

## Fix

Mirror the reuse loop's `!Deleted()` filter into the leftover sweep, so a deleted (already-unregistered, inert) Element never reaches `Element.Remove`.

## Testing

- New `TestContainerHelper_SkipsOutOfBandDeletedLeftover` deletes a child out-of-band **and** drops it from the wanted set (the removal path), complementing the existing `...ReconcileDiscardsOutOfBandDeletedChild` which keeps it wanted (the reuse path). Confirmed the new test panics via `reportMisuse` against the unpatched code and passes with the fix.
- `go test -race -count=1 ./lib/ui/` passes; `go build ./...`, `go vet ./...`, `gofmt` clean.

Found during a defect audit. Config-dependent worst case (panic/torn-down connection under the nil-Logger default or debug builds; misleading log otherwise) on a natural trigger — the most impactful of the three audit findings.
