### PR TITLE
docs: define UI element multiplicity

### DIFF
--- a/.agents/skills/jaws/SKILL.md
+++ b/.agents/skills/jaws/SKILL.md
@@ -40,8 +40,17 @@ JaWS is an immediate-mode, server-driven UI framework, not an MVC framework.
   that value with another Request; construct fresh widgets per request. The
   widgets may still refer to shared, synchronized application state, binders,
   handlers, and tags.
-- `Container.JawsContains` must return hashable `UI` items, and the returned slice must not be mutated after return.
-- Treat `*ui.Container` / `*ui.Tbody` / `ContainerHelper` widgets as request-scoped; construct fresh per request, do not cache across requests.
+- Within its Request, a `UI` value normally backs one live `Element`. Reuse one
+  value for multiple live Elements only when its concrete type documents that
+  support and retains no state that can differ between those Elements.
+- `Container.JawsContains` must return hashable `UI` items, and the returned
+  slice must not be mutated after return. A UI value may occur more than once in
+  one returned slice only when its type supports multiple live Elements.
+- HTML-inner widgets, `ui.Img`, `ui.Option`, and `ui.Template` support multiple
+  live Elements when their shared getters, handlers, and template data are safe
+  for those calls. Input widgets, `*ui.Container`, `*ui.Tbody`, `*ui.Select`,
+  `ContainerHelper`, and `ui.JsVar` require a distinct widget per live Element.
+  `ui.Register` supports multiple live Elements only when its updater does.
 
 ## Constructing UI values: `ui.New` and `bind.New`
 

--- a/.agents/skills/jaws/SKILL.md
+++ b/.agents/skills/jaws/SKILL.md
@@ -46,11 +46,9 @@ JaWS is an immediate-mode, server-driven UI framework, not an MVC framework.
 - `Container.JawsContains` must return hashable `UI` items, and the returned
   slice must not be mutated after return. A UI value may occur more than once in
   one returned slice only when its type supports multiple live Elements.
-- HTML-inner widgets, `ui.Img`, `ui.Option`, and `ui.Template` support multiple
-  live Elements when their shared getters, handlers, and template data are safe
-  for those calls. Input widgets, `*ui.Container`, `*ui.Tbody`, `*ui.Select`,
-  `ContainerHelper`, and `ui.JsVar` require a distinct widget per live Element.
-  `ui.Register` supports multiple live Elements only when its updater does.
+- Treat the package documentation shown by
+  `go doc github.com/linkdata/jaws/lib/ui` as the canonical standard-widget
+  multiplicity summary, and consult each concrete type's docs for its conditions.
 
 ## Constructing UI values: `ui.New` and `bind.New`
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Next steps when building a real application typically include:
 
 1. Adding more templates and wiring them with `AddTemplateLookuper`.
 2. Creating types that implement `JawsRender` and `JawsUpdate` so they
-   can be reused as widgets.
+   can be used as widgets.
 3. Introducing sessions (see below) to keep track of user state.
 
 ### Creating HTML entities
@@ -129,6 +129,11 @@ UI objects are request-scoped: construct fresh UI values for each Request and
 never reuse one UI value across Requests. The application state, binders,
 handlers and tags referenced by UI values may be shared when synchronized as
 required. The `ui.RequestWriter` helpers construct fresh widgets while rendering.
+
+Within a Request, a UI value normally backs one live Element. It may back
+multiple live Elements only when its concrete type documents that support. To
+show the same application state in several places, construct distinct widgets
+that share the synchronized binder, getter, handler or tag.
 
 If an HTML entity is not registered in a Request, JaWS will not
 forward events from it, nor perform DOM manipulations for it.

--- a/contracts.go
+++ b/contracts.go
@@ -13,8 +13,11 @@ type Container interface {
 	//
 	// The returned [UI] values must be comparable, since they are used as map keys
 	// (see [UI] for the comparability requirement), and the slice contents must not
-	// be modified after returning it. A child UI may be returned repeatedly for
-	// the same Request, but must not be shared with a different Request.
+	// be modified after returning it. Returning a child UI again from a later call
+	// lets the container reuse its existing live [Element]. The same UI may occur
+	// more than once in one returned slice only when its type documents support for
+	// backing multiple live Elements. A child UI must not be shared with a different
+	// [Request].
 	JawsContains(elem *Element) (contents []UI)
 }
 
@@ -51,9 +54,18 @@ type TemplateLookuper interface {
 //
 // A UI value is request-scoped. Once it has been used to create an [Element]
 // for one [Request], it must not be used to create an Element for another
-// Request. Construct a fresh UI value for each Request. The application state,
-// getters, setters, handlers and tags referenced by those UI values may be
-// shared across Requests when synchronized as required.
+// Request. Construct a fresh UI value for each Request.
+//
+// Within its owning Request, a UI value must back at most one live Element
+// unless its concrete type documents support for multiple live Elements. Such
+// a type must not retain state on the shared UI value that can differ between
+// those Elements. To render the same application state more than once, construct
+// distinct UI values that share getters, setters, handlers or tags.
+// An Element stops being live when it is deleted or its owning Request lifecycle
+// ends.
+//
+// Application state referenced by UI values may be shared across Requests when
+// synchronized as required.
 //
 // In addition, all UI objects must be comparable so they can be used as map keys.
 // The compile-time type must be comparable; debug builds additionally perform a

--- a/lib/named/namedbooloption.go
+++ b/lib/named/namedbooloption.go
@@ -32,6 +32,7 @@ func UpdateBoolOption(elem *jaws.Element, nb *Bool) {
 
 // namedBoolOption is an internal UI wrapper used by BoolArray.JawsContains.
 // It intentionally stays unexported; public option widgets live in package ui.
+// It retains no Element-specific state and may back multiple live Elements.
 type namedBoolOption struct {
 	*Bool
 }

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -112,10 +112,8 @@ reuse it across requests, even if that widget currently appears stateless.
 Within a request, a widget normally backs at most one live `jaws.Element`. A
 widget may back multiple live Elements only when its type documents that
 support; such a widget retains no state that can differ between those Elements.
-The HTML-inner widgets, `Img`, `Option`, and `Template` support this use when
-their shared getters, handlers, and template data are safe for those calls.
-Input widgets, `ContainerHelper`-based widgets, and `JsVar` do not. `Register`
-supports it only when its updater does.
+The [package documentation](doc.go) is the canonical standard-widget
+classification; each concrete type's Go documentation states its conditions.
 
 The application data referenced by widgets has a separate lifetime. Distinct
 request-scoped widgets may share synchronized backing state, binders, handlers
@@ -130,6 +128,10 @@ binder := bind.New(&mu, &value)
 left := ui.NewText(binder)
 right := ui.NewText(binder)
 ```
+
+Direct construction is not required: calling `rw.Text(binder)` twice constructs
+the two distinct widgets automatically. In a template, render
+`{{$.Text .Binder}}` twice for the same result.
 
 ## Adding a simple static widget
 

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -109,10 +109,27 @@ request, typically through `RequestWriter` helpers such as `$.Span(...)`,
 `$.Text(...)`, `$.Container(...)`, and `$.JsVar(...)`. Do not cache a widget and
 reuse it across requests, even if that widget currently appears stateless.
 
+Within a request, a widget normally backs at most one live `jaws.Element`. A
+widget may back multiple live Elements only when its type documents that
+support; such a widget retains no state that can differ between those Elements.
+The HTML-inner widgets, `Img`, `Option`, and `Template` support this use when
+their shared getters, handlers, and template data are safe for those calls.
+Input widgets, `ContainerHelper`-based widgets, and `JsVar` do not. `Register`
+supports it only when its updater does.
+
 The application data referenced by widgets has a separate lifetime. Distinct
 request-scoped widgets may share synchronized backing state, binders, handlers
 and tags. For `JsVar`, use a `JsVarMaker` when a shared handler or template value
 needs to create the binding for the current request.
+
+For example, render one bound value in two text inputs by constructing two
+widgets over the same binder:
+
+```go
+binder := bind.New(&mu, &value)
+left := ui.NewText(binder)
+right := ui.NewText(binder)
+```
 
 ## Adding a simple static widget
 

--- a/lib/ui/a.go
+++ b/lib/ui/a.go
@@ -8,6 +8,10 @@ import (
 )
 
 // An A renders an HTML anchor element with dynamic inner HTML.
+//
+// One A value may back multiple live [jaws.Element] values. Its HTML getter is
+// shared by those Elements and must be safe for their render, update and event
+// calls.
 type A struct{ HTMLInner }
 
 // NewA returns an anchor widget whose inner HTML is rendered from innerHTML.

--- a/lib/ui/button.go
+++ b/lib/ui/button.go
@@ -8,6 +8,10 @@ import (
 )
 
 // Button renders an HTML button element with dynamic inner HTML.
+//
+// One Button value may back multiple live [jaws.Element] values. Its HTML getter
+// is shared by those Elements and must be safe for their render, update and event
+// calls.
 type Button struct{ HTMLInner }
 
 // NewButton returns a button widget whose inner HTML is rendered from innerHTML.

--- a/lib/ui/checkbox.go
+++ b/lib/ui/checkbox.go
@@ -8,6 +8,9 @@ import (
 )
 
 // Checkbox renders an HTML checkbox input bound to a bool setter.
+//
+// A Checkbox value must back at most one live [jaws.Element]. Construct distinct
+// Checkbox values over the same setter to render one bound value more than once.
 type Checkbox struct{ InputBool }
 
 // NewCheckbox returns a checkbox input widget bound to g.

--- a/lib/ui/container.go
+++ b/lib/ui/container.go
@@ -7,6 +7,9 @@ import (
 )
 
 // Container renders an HTML element around a dynamic child collection.
+//
+// A Container value must back at most one live [jaws.Element]. Construct a
+// distinct Container for each place the collection is rendered.
 type Container struct {
 	OuterHTMLTag string
 	ContainerHelper

--- a/lib/ui/containerhelper.go
+++ b/lib/ui/containerhelper.go
@@ -16,6 +16,10 @@ import (
 // It tracks already-rendered child elements and performs append/remove/order
 // updates during [ContainerHelper.UpdateContainer].
 //
+// A ContainerHelper retains child-element reconciliation state for one live
+// [jaws.Element]. A widget embedding one must therefore back at most one live
+// Element.
+//
 // A ContainerHelper belongs to a request-scoped widget instance (for example a
 // widget created via a RequestWriter helper method).
 //
@@ -42,7 +46,9 @@ type ContainerHelper struct {
 }
 
 // NewContainerHelper returns a ContainerHelper for rendering and updating c.
-// ContainerHelper values are request-scoped and must not be reused across requests.
+//
+// The returned value is request-scoped and retains state for one live
+// [jaws.Element].
 func NewContainerHelper(c jaws.Container) ContainerHelper {
 	return ContainerHelper{Container: c}
 }

--- a/lib/ui/date.go
+++ b/lib/ui/date.go
@@ -10,6 +10,9 @@ import (
 
 // Date renders an HTML date input bound to a time value setter.
 //
+// A Date value must back at most one live [jaws.Element]. Construct distinct Date
+// values over the same setter to render one bound value more than once.
+//
 // The control is date-only: a browser edit normalizes the bound [time.Time] to
 // midnight UTC of the picked date, discarding time-of-day and location. See
 // [InputDate.JawsInput].

--- a/lib/ui/div.go
+++ b/lib/ui/div.go
@@ -8,6 +8,10 @@ import (
 )
 
 // Div renders an HTML div element with dynamic inner HTML.
+//
+// One Div value may back multiple live [jaws.Element] values. Its HTML getter is
+// shared by those Elements and must be safe for their render, update and event
+// calls.
 type Div struct{ HTMLInner }
 
 // NewDiv returns a div widget whose inner HTML is rendered from innerHTML.

--- a/lib/ui/doc.go
+++ b/lib/ui/doc.go
@@ -24,7 +24,8 @@
 // calls. Input widgets, [ContainerHelper]-based widgets and [JsVar] require a
 // distinct widget value for each live Element. [Register] supports multiple live
 // Elements only when its Updater does. Distinct widgets may still share
-// synchronized application state.
+// synchronized application state. This is the canonical package-wide
+// classification; each concrete type's documentation states its conditions.
 //
 // HTML-inner widgets route content through [bind.MakeHTMLGetter]. Plain strings
 // are treated as trusted HTML, while [bind.Getter][string], [bind.Binder][string]

--- a/lib/ui/doc.go
+++ b/lib/ui/doc.go
@@ -17,6 +17,15 @@
 // application state, binders, handlers or tags when that shared state is
 // synchronized as required.
 //
+// Within one request, a widget normally backs at most one live [jaws.Element].
+// The HTML-inner widgets, [Img], [Option] and [Template] document support for
+// backing multiple live Elements because they retain no Element-specific state;
+// their shared getters, handlers and template data must also be safe for those
+// calls. Input widgets, [ContainerHelper]-based widgets and [JsVar] require a
+// distinct widget value for each live Element. [Register] supports multiple live
+// Elements only when its Updater does. Distinct widgets may still share
+// synchronized application state.
+//
 // HTML-inner widgets route content through [bind.MakeHTMLGetter]. Plain strings
 // are treated as trusted HTML, while [bind.Getter][string], [bind.Binder][string]
 // and [fmt.Stringer] values are escaped. Raw [template.HTMLAttr] params are also

--- a/lib/ui/html_widgets.go
+++ b/lib/ui/html_widgets.go
@@ -10,6 +10,10 @@ import (
 )
 
 // HTMLInner is a reusable base for widgets that render as `<tag>inner</tag>`.
+//
+// HTMLInner retains no Element-specific state. A widget embedding it may back
+// multiple live [jaws.Element] values when its HTMLGetter is also safe for those
+// Elements' render, update and event calls.
 type HTMLInner struct {
 	// HTMLGetter returns the trusted inner HTML to render and update.
 	HTMLGetter bind.HTMLGetter

--- a/lib/ui/img.go
+++ b/lib/ui/img.go
@@ -10,6 +10,10 @@ import (
 )
 
 // Img renders an HTML img element whose src is read from a string getter.
+//
+// One Img value may back multiple live [jaws.Element] values. Its getter is
+// shared by those Elements and must be safe for their render, update and event
+// calls.
 type Img struct{ bind.Getter[string] }
 
 // NewImg returns an img widget whose src attribute is read from g.

--- a/lib/ui/input_widgets.go
+++ b/lib/ui/input_widgets.go
@@ -15,14 +15,18 @@ import (
 )
 
 // Input stores common state for interactive input widgets.
-// There is one of these per request and input widget.
+//
+// An Input value retains the last browser value and dirty tag for one live
+// [jaws.Element]. A widget embedding Input must therefore back at most one live
+// Element. To render the same bound state more than once, construct distinct
+// widgets that share the setter.
 type Input struct {
 	// tag is the dirty tag, written once during render and read on the event
 	// goroutine (JawsInput). The render-completes-before-events lifecycle makes
 	// the unsynchronized access safe; it is unexported so external code cannot
 	// mutate it.
 	tag  any
-	Last atomic.Value // the last value received from the request
+	Last atomic.Value // last rendered or accepted browser value for the Element
 }
 
 func (u *Input) applyGetterAttrs(elem *jaws.Element, getter any) (attrs []template.HTMLAttr, err error) {
@@ -38,6 +42,8 @@ func (u *Input) maybeDirty(elem *jaws.Element, inErr error) (err error) {
 }
 
 // InputText is the reusable base for string input widgets.
+//
+// A widget embedding InputText must back at most one live [jaws.Element].
 type InputText struct {
 	Input
 	bind.Setter[string]
@@ -72,6 +78,8 @@ func (u *InputText) JawsInput(elem *jaws.Element, value string) (err error) {
 }
 
 // InputBool is the reusable base for boolean input widgets.
+//
+// A widget embedding InputBool must back at most one live [jaws.Element].
 type InputBool struct {
 	Input
 	bind.Setter[bool]
@@ -121,6 +129,8 @@ func (u *InputBool) JawsInput(elem *jaws.Element, value string) (err error) {
 }
 
 // InputFloat is the reusable base for float64 input widgets.
+//
+// A widget embedding InputFloat must back at most one live [jaws.Element].
 type InputFloat struct {
 	Input
 	bind.Setter[float64]
@@ -207,6 +217,8 @@ func (u *InputFloat) JawsInput(elem *jaws.Element, value string) (err error) {
 }
 
 // InputDate is the reusable base for date input widgets.
+//
+// A widget embedding InputDate must back at most one live [jaws.Element].
 //
 // The control is date-only. Rendering shows the calendar date in the bound
 // value's own location, but a browser edit normalizes the bound [time.Time] to

--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -90,9 +90,9 @@ type IsJsVar interface {
 
 // JsVarMaker creates a request-scoped JavaScript variable binding.
 //
-// JawsMakeJsVar must return a fresh [IsJsVar] for each request. The returned
-// bindings may share synchronized backing state, but the bindings themselves
-// must not be shared between requests.
+// JawsMakeJsVar must return a fresh [IsJsVar] for each call. The returned value
+// is scoped to rq and one live [jaws.Element]. Bindings may share synchronized
+// backing state, but the binding values themselves must remain distinct.
 type JsVarMaker interface {
 	JawsMakeJsVar(rq *jaws.Request) (value IsJsVar, err error)
 }
@@ -161,10 +161,11 @@ func JSONSizeCheck[T any](maxBytes int) (check JsVarCheck[T]) {
 // JsVar binds a Go value to a named JavaScript variable in the browser.
 //
 // A JsVar is request-scoped and must not be rendered by more than one
-// [jaws.Request]. Construct a fresh JsVar for each request, either directly
+// [jaws.Request]. Within that request, it must back at most one live
+// [jaws.Element]. Construct a fresh JsVar for each binding, either directly
 // while rendering or through [JsVarMaker]. Distinct JsVar values may use the
 // same locker and Ptr to expose synchronized application state to multiple
-// requests.
+// Elements or requests.
 //
 // JsVar is intended for JSON-marshalable state shared with application
 // JavaScript. The browser binding reads and writes the window property named
@@ -503,9 +504,9 @@ func (jsvar *JsVar[T]) JawsInput(elem *jaws.Element, value string) (err error) {
 // The locker l must be non-nil and must remain valid for the lifetime of the JsVar.
 // The pointer v may be nil; reads then return the zero value, rendering omits the
 // initial data, and writes return [github.com/linkdata/jq.ErrInvalidReceiver].
-// Create a fresh JsVar for each request; l and v may be shared by distinct
-// request-scoped JsVar values. Use [JsVarMaker] when construction depends on the
-// current request or the maker is stored in shared handler data.
+// Create a fresh JsVar for each live [jaws.Element]; l and v may be shared by
+// distinct request-scoped JsVar values. Use [JsVarMaker] when construction
+// depends on the current request or the maker is stored in shared handler data.
 func NewJsVar[T any](l sync.Locker, v *T) *JsVar[T] {
 	return &JsVar[T]{RWLocker: bind.AsRWLocker(l), Ptr: v}
 }

--- a/lib/ui/label.go
+++ b/lib/ui/label.go
@@ -8,6 +8,10 @@ import (
 )
 
 // Label renders an HTML label element with dynamic inner HTML.
+//
+// One Label value may back multiple live [jaws.Element] values. Its HTML getter
+// is shared by those Elements and must be safe for their render, update and event
+// calls.
 type Label struct{ HTMLInner }
 
 // NewLabel returns a label widget whose inner HTML is rendered from innerHTML.

--- a/lib/ui/li.go
+++ b/lib/ui/li.go
@@ -8,6 +8,10 @@ import (
 )
 
 // Li renders an HTML list item with dynamic inner HTML.
+//
+// One Li value may back multiple live [jaws.Element] values. Its HTML getter is
+// shared by those Elements and must be safe for their render, update and event
+// calls.
 type Li struct{ HTMLInner }
 
 // NewLi returns a list item widget whose inner HTML is rendered from innerHTML.

--- a/lib/ui/number.go
+++ b/lib/ui/number.go
@@ -8,6 +8,9 @@ import (
 )
 
 // Number renders an HTML number input bound to a float64 setter.
+//
+// A Number value must back at most one live [jaws.Element]. Construct distinct
+// Number values over the same setter to render one bound value more than once.
 type Number struct{ InputFloat }
 
 // NewNumber returns a number input widget bound to g.

--- a/lib/ui/option.go
+++ b/lib/ui/option.go
@@ -8,6 +8,9 @@ import (
 )
 
 // Option renders an HTML option element backed by a [named.Bool].
+//
+// One Option value may back multiple live [jaws.Element] values. All of those
+// Elements reflect the shared Bool.
 type Option struct{ *named.Bool }
 
 // NewOption returns an option widget backed by nb.

--- a/lib/ui/password.go
+++ b/lib/ui/password.go
@@ -8,6 +8,9 @@ import (
 )
 
 // Password renders an HTML password input bound to a string setter.
+//
+// A Password value must back at most one live [jaws.Element]. Construct distinct
+// Password values over the same setter to render one bound value more than once.
 type Password struct{ InputText }
 
 // NewPassword returns a password input widget bound to g.

--- a/lib/ui/radio.go
+++ b/lib/ui/radio.go
@@ -8,6 +8,9 @@ import (
 )
 
 // Radio renders an HTML radio input bound to a bool setter.
+//
+// A Radio value must back at most one live [jaws.Element]. Construct distinct
+// Radio values over the same setter to render one bound value more than once.
 type Radio struct{ InputBool }
 
 // NewRadio returns a radio input widget bound to g.

--- a/lib/ui/range.go
+++ b/lib/ui/range.go
@@ -8,6 +8,9 @@ import (
 )
 
 // Range renders an HTML range input bound to a float64 setter.
+//
+// A Range value must back at most one live [jaws.Element]. Construct distinct
+// Range values over the same setter to render one bound value more than once.
 type Range struct{ InputFloat }
 
 // NewRange returns a range input widget bound to g.

--- a/lib/ui/register.go
+++ b/lib/ui/register.go
@@ -9,6 +9,10 @@ import (
 
 // Register is an update-only widget that renders no HTML; it exists so its
 // embedded [jaws.Updater] receives dynamic updates.
+//
+// One Register value may back multiple live [jaws.Element] values only when its
+// Updater supports those calls without retaining Element-specific state on a
+// shared value.
 type Register struct{ jaws.Updater }
 
 // NewRegister returns an update-only widget that invokes updater during updates.

--- a/lib/ui/requestwriter.go
+++ b/lib/ui/requestwriter.go
@@ -14,6 +14,9 @@ type RequestWriter struct {
 }
 
 // NewUI creates an element for ui and renders it to the underlying writer.
+//
+// The ui value must satisfy the ownership and live-Element multiplicity
+// requirements documented by [jaws.UI].
 func (rw RequestWriter) NewUI(ui jaws.UI, params ...any) (err error) {
 	elem := rw.NewElement(ui)
 	if err = elem.JawsRender(rw, params); err != nil {

--- a/lib/ui/select.go
+++ b/lib/ui/select.go
@@ -10,6 +10,10 @@ import (
 
 // Select renders a single-selection HTML select element.
 //
+// A Select value must back at most one live [jaws.Element]. Construct distinct
+// Select values over the same [named.SelectHandler] to render one selection more
+// than once.
+//
 // The widget stores one selected option name through a [named.SelectHandler].
 // Render params are written as supplied, but a multiple select is not
 // supported by the JaWS select value contract.

--- a/lib/ui/span.go
+++ b/lib/ui/span.go
@@ -8,6 +8,10 @@ import (
 )
 
 // Span renders an HTML span element with dynamic inner HTML.
+//
+// One Span value may back multiple live [jaws.Element] values. Its HTML getter
+// is shared by those Elements and must be safe for their render, update and event
+// calls.
 type Span struct{ HTMLInner }
 
 // NewSpan returns a span widget whose inner HTML is rendered from innerHTML.

--- a/lib/ui/tbody.go
+++ b/lib/ui/tbody.go
@@ -7,6 +7,9 @@ import (
 )
 
 // Tbody renders an HTML tbody containing dynamic child rows.
+//
+// A Tbody value must back at most one live [jaws.Element]. Construct a distinct
+// Tbody for each place the rows are rendered.
 type Tbody struct {
 	ContainerHelper
 }

--- a/lib/ui/td.go
+++ b/lib/ui/td.go
@@ -8,6 +8,10 @@ import (
 )
 
 // Td renders an HTML table cell with dynamic inner HTML.
+//
+// One Td value may back multiple live [jaws.Element] values. Its HTML getter is
+// shared by those Elements and must be safe for their render, update and event
+// calls.
 type Td struct{ HTMLInner }
 
 // NewTd returns a table cell widget whose inner HTML is rendered from innerHTML.

--- a/lib/ui/template.go
+++ b/lib/ui/template.go
@@ -12,6 +12,11 @@ import (
 
 // Template references a Go [html/template] template to be rendered through JaWS.
 //
+// A Template retains no Element-specific state and may back multiple live
+// [jaws.Element] values. Its Dot and any callbacks reached during execution are
+// shared by those Elements and must be safe for their render, update and event
+// calls.
+//
 // The OuterHTMLTag field identifies the generated wrapper element used for
 // partial templates. If OuterHTMLTag is empty, the template is rendered without
 // a generated wrapper. Name identifies the template to execute and Dot contains

--- a/lib/ui/text.go
+++ b/lib/ui/text.go
@@ -8,6 +8,9 @@ import (
 )
 
 // Text renders an HTML text input bound to a string setter.
+//
+// A Text value must back at most one live [jaws.Element]. Construct distinct
+// Text values over the same setter to render one bound value more than once.
 type Text struct{ InputText }
 
 // NewText returns a text input widget bound to g.

--- a/lib/ui/textarea.go
+++ b/lib/ui/textarea.go
@@ -10,6 +10,9 @@ import (
 )
 
 // Textarea renders an HTML textarea bound to a string setter.
+//
+// A Textarea value must back at most one live [jaws.Element]. Construct distinct
+// Textarea values over the same setter to render one bound value more than once.
 type Textarea struct{ InputText }
 
 // NewTextarea returns a textarea widget bound to g.

--- a/lib/ui/tr.go
+++ b/lib/ui/tr.go
@@ -8,6 +8,10 @@ import (
 )
 
 // Tr renders an HTML table row with dynamic inner HTML.
+//
+// One Tr value may back multiple live [jaws.Element] values. Its HTML getter is
+// shared by those Elements and must be safe for their render, update and event
+// calls.
 type Tr struct{ HTMLInner }
 
 // NewTr returns a table row widget whose inner HTML is rendered from innerHTML.

--- a/request.go
+++ b/request.go
@@ -593,7 +593,10 @@ func (rq *Request) newElementLocked(ui UI) (elem *Element) {
 // NewElement creates a new [Element] using the given [UI] object.
 //
 // The UI value becomes scoped to rq and must not be used with another
-// [Request]. See [UI] for the ownership contract.
+// [Request]. Unless its concrete type documents support for multiple live
+// Elements, it must not already back a live Element in rq. These ownership and
+// multiplicity requirements are caller obligations; NewElement does not enforce
+// them. See [UI] for the complete contract.
 //
 // Panics if the build tag "debug" is set and the [UI] object doesn't satisfy all requirements.
 func (rq *Request) NewElement(ui UI) *Element {

--- a/request.go
+++ b/request.go
@@ -598,7 +598,7 @@ func (rq *Request) newElementLocked(ui UI) (elem *Element) {
 // multiplicity requirements are caller obligations; NewElement does not enforce
 // them. See [UI] for the complete contract.
 //
-// Panics if the build tag "debug" is set and the [UI] object doesn't satisfy all requirements.
+// Panics in debug builds when ui does not satisfy [UI]'s comparability requirement.
 func (rq *Request) NewElement(ui UI) *Element {
 	if deadlock.Debug {
 		if err := tag.NewErrNotComparable(ui); err != nil {


### PR DESCRIPTION
## Summary

- define one live Element per UI value as the default within a Request
- allow duplicate container children only for types that document multi-Element support
- classify standard widgets and show how distinct inputs can share one binder
- align the README, Go docs, and Jaws skill guidance

## Verification

- go vet ./...
- go test -race ./...
- go doc for the updated core and UI contracts

Closes #160