### PR TITLE
fix: render debug tags outside request lock

### DIFF
--- a/element.go
+++ b/element.go
@@ -123,12 +123,11 @@ func (elem *Element) Deleted() bool {
 	return elem.deleted.Load()
 }
 
-func (elem *Element) renderDebug(w io.Writer) {
+func (elem *Element) renderDebug(w io.Writer) (err error) {
 	var sb strings.Builder
 	_, _ = fmt.Fprintf(&sb, "<!-- id=%q %T tags=[", elem.Jid(), elem.UI())
-	if elem.mu.TryRLock() {
-		defer elem.mu.RUnlock()
-		for i, tagValue := range elem.tagsOfLocked(elem) {
+	if tags, ok := elem.tryTagsOf(elem); ok {
+		for i, tagValue := range tags {
 			if i > 0 {
 				sb.WriteString(", ")
 			}
@@ -138,7 +137,8 @@ func (elem *Element) renderDebug(w io.Writer) {
 		sb.WriteString("n/a")
 	}
 	sb.WriteByte(']')
-	_, _ = w.Write([]byte(debugCommentSanitizer.Replace(sb.String()) + " -->"))
+	_, err = w.Write([]byte(debugCommentSanitizer.Replace(sb.String()) + " -->"))
+	return
 }
 
 // debugCommentSanitizer neutralizes both the standard "-->" and the HTML5
@@ -152,7 +152,7 @@ func (elem *Element) JawsRender(w io.Writer, params []any) (err error) {
 	if !elem.deleted.Load() {
 		if err = elem.UI().JawsRender(elem, w, params); err == nil {
 			if elem.Jaws.Debug {
-				elem.renderDebug(w)
+				err = elem.renderDebug(w)
 			}
 		}
 	}

--- a/element_test.go
+++ b/element_test.go
@@ -98,6 +98,15 @@ type testNilTagGetter struct{}
 
 func (testNilTagGetter) JawsGetTag(tag.Context) any { return nil }
 
+type testReentrantDebugTag struct {
+	rq *Request
+}
+
+func (tag testReentrantDebugTag) String() string {
+	tag.rq.SetConnectFn(nil)
+	return "reentrant"
+}
+
 func TestElement_helpers(t *testing.T) {
 	is := newTestHelper(t)
 	rq := newTestRequest(t)
@@ -591,12 +600,17 @@ func TestElement_RenderDebugAndDeletedBranches(t *testing.T) {
 
 	rq.mu.Lock()
 	var sb strings.Builder
-	elem.renderDebug(&sb)
+	err = elem.renderDebug(&sb)
 	rq.mu.Unlock()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	elem.Tag(tag.Tag("a"), tag.Tag("b"))
 	sb.Reset()
-	elem.renderDebug(&sb)
+	if err = elem.renderDebug(&sb); err != nil {
+		t.Fatal(err)
+	}
 	if !strings.Contains(sb.String(), ", ") {
 		t.Fatal("expected comma-separated tags in debug output")
 	}
@@ -621,6 +635,61 @@ func TestElement_RenderDebugAndDeletedBranches(t *testing.T) {
 	elem.JawsUpdate()
 }
 
+func TestElement_JawsRenderDebugTagCanReenterRequest(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	jw.Debug = true
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+
+	tu := &testUi{renderFn: func(elem *Element, _ io.Writer, _ []any) error {
+		elem.Tag(testReentrantDebugTag{rq: rq})
+		return nil
+	}}
+	elem := rq.NewElement(tu)
+	var output strings.Builder
+	rendered := make(chan error, 1)
+	go func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				rendered <- fmt.Errorf("render panic: %v", recovered)
+			}
+		}()
+		rendered <- elem.JawsRender(&output, nil)
+	}()
+
+	select {
+	case err = <-rendered:
+		jw.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(output.String(), "reentrant") {
+			t.Fatalf("debug output = %q, want reentrant tag", output.String())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("debug tag String method deadlocked while re-entering Request")
+	}
+}
+
+func TestElement_JawsRenderReturnsDebugWriteError(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+	jw.Debug = true
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	elem := rq.NewElement(&testUi{})
+	wantErr := errors.New("debug write failed")
+
+	err = elem.JawsRender(&errResponseWriter{writeErr: wantErr}, nil)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("JawsRender error = %v, want %v", err, wantErr)
+	}
+}
+
 func TestElement_RenderDebugSanitizesHTML5CommentClose(t *testing.T) {
 	jw, err := New()
 	if err != nil {
@@ -635,7 +704,9 @@ func TestElement_RenderDebugSanitizesHTML5CommentClose(t *testing.T) {
 	elem.Tag(tag.Tag("x--!>y"))
 
 	var sb strings.Builder
-	elem.renderDebug(&sb)
+	if err = elem.renderDebug(&sb); err != nil {
+		t.Fatal(err)
+	}
 	if strings.Contains(sb.String(), "--!>") {
 		t.Fatalf("HTML5 comment close escaped the debug comment: %q", sb.String())
 	}

--- a/request.go
+++ b/request.go
@@ -539,7 +539,7 @@ func (rq *Request) tagsOfLocked(elem *Element) (tags []any) {
 
 // tryTagsOf returns a snapshot of elem's tags without waiting for rq.mu.
 func (rq *Request) tryTagsOf(elem *Element) (tags []any, ok bool) {
-	if elem != nil && rq.mu.TryRLock() {
+	if rq.mu.TryRLock() {
 		tags = rq.tagsOfLocked(elem)
 		rq.mu.RUnlock()
 		ok = true

--- a/request.go
+++ b/request.go
@@ -537,6 +537,16 @@ func (rq *Request) tagsOfLocked(elem *Element) (tags []any) {
 	return
 }
 
+// tryTagsOf returns a snapshot of elem's tags without waiting for rq.mu.
+func (rq *Request) tryTagsOf(elem *Element) (tags []any, ok bool) {
+	if elem != nil && rq.mu.TryRLock() {
+		tags = rq.tagsOfLocked(elem)
+		rq.mu.RUnlock()
+		ok = true
+	}
+	return
+}
+
 // TagsOf returns the tags currently associated with elem in this Request, or nil
 // if elem is nil. The returned slice is a newly allocated snapshot and may be
 // retained and modified by the caller.

--- a/request_test.go
+++ b/request_test.go
@@ -2056,7 +2056,9 @@ func TestRequest_renderDebugLocked(t *testing.T) {
 	e.Tag(tag.Tag("zomg"))
 
 	var sb strings.Builder
-	e.renderDebug(&sb)
+	if err := e.renderDebug(&sb); err != nil {
+		t.Fatal(err)
+	}
 
 	txt := sb.String()
 	is.Equal(strings.Contains(txt, "zomg"), true)
@@ -2065,7 +2067,9 @@ func TestRequest_renderDebugLocked(t *testing.T) {
 	rq.mu.Lock()
 	defer rq.mu.Unlock()
 	sb.Reset()
-	e.renderDebug(&sb)
+	if err := e.renderDebug(&sb); err != nil {
+		t.Fatal(err)
+	}
 
 	txt = sb.String()
 	is.Equal(strings.Contains(txt, "zomg"), false)


### PR DESCRIPTION
## Summary

- snapshot debug tags under `Request.mu`, then format and write after releasing the lock
- propagate debug-comment write failures through `Element.JawsRender`
- cover reentrant `fmt.Stringer` tags and writer failures

Fixes #162

## Verification

- `go generate ./...`
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run ./...`
- `gosec -quiet ./...`
- `go build ./...`
- `JAWS_REQUIRE_NODE=1 go test -race -coverprofile=/private/tmp/jaws-coverage.out ./...`