### PR TITLE
Deliver broadcasts issued by ConnectFn

### DIFF
--- a/eventhandler_test.go
+++ b/eventhandler_test.go
@@ -43,7 +43,7 @@ func (t *testJawsEvent) JawsGetTag(tag.Context) (tagValue any) {
 func (t *testJawsEvent) JawsRender(elem *Element, w io.Writer, params []any) (err error) {
 	var tagValue any
 	if tagValue, _, err = elem.ApplyGetter(t); err == nil {
-		_, _ = w.Write([]byte(fmt.Sprint(params)))
+		_, _ = fmt.Fprint(w, params)
 		t.msgCh <- fmt.Sprintf("JawsRender(%d)%#v", elem.jid, tagValue)
 	}
 	return

--- a/request.go
+++ b/request.go
@@ -906,6 +906,47 @@ func (rq *Request) stopServe() {
 	rq.Jaws.recycle(rq)
 }
 
+// runWebSocket subscribes rq, runs its connect callback, and processes the
+// accepted WebSocket when the callback succeeds.
+func (rq *Request) runWebSocket(ws *websocket.Conn, pingInterval, wsTimeout time.Duration) (err error) {
+	// Subscribe before onConnect so broadcasts from the callback are buffered for
+	// this Request. Browser input and outbound writes do not start until the
+	// callback succeeds.
+	rq.mu.RLock()
+	numElems := len(rq.elems)
+	rq.mu.RUnlock()
+	// Size the broadcast buffer with headroom that scales with the page's element
+	// count. mustBroadcast (see Jaws.Serve) sends here non-blocking and, for any
+	// non-Update message, kills the subscription and cancels this request if the
+	// send would block.
+	pendingSubscription := rq.Jaws.subscribe(rq, 4+numElems*4)
+	defer func() {
+		// onConnect is user code and may return an error or panic. Release its
+		// subscription unless process took responsibility for doing so.
+		if pendingSubscription != nil {
+			rq.Jaws.unsubscribe(pendingSubscription)
+		}
+	}()
+
+	if err = rq.onConnect(); err == nil {
+		incomingMsgCh := make(chan wire.WsMsg)
+		// Snapshot ctx and cancelFn after onConnect so a context installed by the
+		// callback governs all WebSocket loops.
+		rq.mu.RLock()
+		ctx := rq.ctx
+		cancelFn := rq.cancelFn
+		rq.mu.RUnlock()
+		outboundMsgCh := make(chan wire.WsMsg, cap(pendingSubscription))
+		go wire.ReadLoop(ctx, cancelFn, rq.Jaws.Done(), incomingMsgCh, ws)  // closes incomingMsgCh
+		go wire.WriteLoop(ctx, cancelFn, rq.Jaws.Done(), outboundMsgCh, ws) // calls ws.Close()
+		go wire.PingLoop(ctx, cancelFn, rq.Jaws.Done(), pingInterval, wsTimeout, ws)
+		broadcastMsgCh := pendingSubscription
+		pendingSubscription = nil
+		rq.process(broadcastMsgCh, incomingMsgCh, outboundMsgCh) // unsubscribes broadcastMsgCh, closes outboundMsgCh
+	}
+	return
+}
+
 // ServeHTTP implements [http.Handler].
 //
 // Requires [Jaws.UseRequest] to have been successfully called for the [Request].
@@ -942,45 +983,7 @@ func (rq *Request) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ws, err = websocket.Accept(acceptWriter, acceptRequest, nil)
 		if err == nil {
 			ws.SetReadLimit(webSocketReadLimit)
-			// Subscribe before onConnect so broadcasts from the callback are
-			// buffered for this Request. Browser input and outbound writes do not
-			// start until the callback succeeds.
-			rq.mu.RLock()
-			numElems := len(rq.elems)
-			rq.mu.RUnlock()
-			// Size the broadcast buffer with headroom that scales with the page's
-			// element count. mustBroadcast (see Jaws.Serve) sends here
-			// non-blocking and, for any non-Update message, kills the subscription
-			// and cancels this request if the send would block.
-			broadcastMsgCh := rq.Jaws.subscribe(rq, 4+numElems*4)
-			ownsSubscription := broadcastMsgCh != nil
-			// onConnect is user code and may panic. Release the subscription before
-			// stopServe recycles rq unless ownership has passed to process, whose
-			// cleanup performs the unsubscribe itself.
-			defer func() {
-				if ownsSubscription {
-					rq.Jaws.unsubscribe(broadcastMsgCh)
-				}
-			}()
-			if err = rq.onConnect(); err == nil {
-				incomingMsgCh := make(chan wire.WsMsg)
-				// Snapshot ctx and cancelFn after onConnect so a context installed by
-				// the callback governs all WebSocket loops.
-				rq.mu.RLock()
-				ctx := rq.ctx
-				cancelFn := rq.cancelFn
-				rq.mu.RUnlock()
-				outboundMsgCh := make(chan wire.WsMsg, cap(broadcastMsgCh))
-				go wire.ReadLoop(ctx, cancelFn, rq.Jaws.Done(), incomingMsgCh, ws)  // closes incomingMsgCh
-				go wire.WriteLoop(ctx, cancelFn, rq.Jaws.Done(), outboundMsgCh, ws) // calls ws.Close()
-				go wire.PingLoop(ctx, cancelFn, rq.Jaws.Done(), pingInterval, wsTimeout, ws)
-				ownsSubscription = false
-				rq.process(broadcastMsgCh, incomingMsgCh, outboundMsgCh) // unsubscribes broadcastMsgCh, closes outboundMsgCh
-			} else {
-				if ownsSubscription {
-					rq.Jaws.unsubscribe(broadcastMsgCh)
-					ownsSubscription = false
-				}
+			if err = rq.runWebSocket(ws, pingInterval, wsTimeout); err != nil {
 				reason := err.Error()
 				defer func() { _ = ws.Close(websocket.StatusNormalClosure, reason) }()
 				var msg wire.WsMsg

--- a/request.go
+++ b/request.go
@@ -29,8 +29,22 @@ import (
 // own contract and cannot change silently if the library default does.
 const webSocketReadLimit = 32 * 1024
 
-// ConnectFn can be used to interact with a [Request] before message processing starts.
-// Returning an error causes the [Request] to abort, and the WebSocket connection to close.
+// ConnectFn initializes or validates a [Request] after its WebSocket is accepted.
+//
+// The function runs synchronously after the Request subscribes to broadcasts but
+// before it starts processing browser messages. It may inspect or modify
+// server-side Request, [Session], and application state. After changing state
+// that rendered Elements depend on, use [Request.Dirty] to schedule their updates
+// for when message processing starts.
+//
+// Broadcasts for the Request are buffered while the function runs and are
+// processed after it returns nil. The buffer is bounded, so the function should
+// return promptly; normal [ErrRequestOverloaded] handling applies if it fills.
+//
+// Returning an error aborts the Request, discards its buffered broadcasts, and
+// closes the WebSocket connection. Broadcasts already delivered to other active
+// Requests are unaffected. The Request pointer is borrowed for the callback; the
+// lifetime rules documented on [Request] apply.
 type ConnectFn = func(rq *Request) error
 
 // Request maintains the state for a JaWS WebSocket connection, and handles processing
@@ -295,7 +309,6 @@ func (rq *Request) HeadHTML(w io.Writer) (err error) {
 }
 
 // GetConnectFn returns the currently set [ConnectFn].
-// That function will be called before starting the WebSocket tunnel if not nil.
 func (rq *Request) GetConnectFn() (fn ConnectFn) {
 	rq.mu.RLock()
 	fn = rq.connectFn
@@ -303,8 +316,9 @@ func (rq *Request) GetConnectFn() (fn ConnectFn) {
 	return
 }
 
-// SetConnectFn sets the [ConnectFn].
-// That function will be called before starting the WebSocket tunnel if not nil.
+// SetConnectFn sets the function called after the WebSocket is accepted.
+//
+// See [ConnectFn] for the callback lifecycle and permitted operations.
 func (rq *Request) SetConnectFn(fn ConnectFn) {
 	rq.mu.Lock()
 	rq.connectFn = fn
@@ -928,29 +942,45 @@ func (rq *Request) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ws, err = websocket.Accept(acceptWriter, acceptRequest, nil)
 		if err == nil {
 			ws.SetReadLimit(webSocketReadLimit)
+			// Subscribe before onConnect so broadcasts from the callback are
+			// buffered for this Request. Browser input and outbound writes do not
+			// start until the callback succeeds.
+			rq.mu.RLock()
+			numElems := len(rq.elems)
+			rq.mu.RUnlock()
+			// Size the broadcast buffer with headroom that scales with the page's
+			// element count. mustBroadcast (see Jaws.Serve) sends here
+			// non-blocking and, for any non-Update message, kills the subscription
+			// and cancels this request if the send would block.
+			broadcastMsgCh := rq.Jaws.subscribe(rq, 4+numElems*4)
+			ownsSubscription := broadcastMsgCh != nil
+			// onConnect is user code and may panic. Release the subscription before
+			// stopServe recycles rq unless ownership has passed to process, whose
+			// cleanup performs the unsubscribe itself.
+			defer func() {
+				if ownsSubscription {
+					rq.Jaws.unsubscribe(broadcastMsgCh)
+				}
+			}()
 			if err = rq.onConnect(); err == nil {
 				incomingMsgCh := make(chan wire.WsMsg)
-				// Snapshot ctx, cancelFn and the element count together under the
-				// lock; every other access to rq.elems is also guarded by rq.mu.
+				// Snapshot ctx and cancelFn after onConnect so a context installed by
+				// the callback governs all WebSocket loops.
 				rq.mu.RLock()
 				ctx := rq.ctx
 				cancelFn := rq.cancelFn
-				numElems := len(rq.elems)
 				rq.mu.RUnlock()
-				// Size the broadcast buffer with headroom that scales with the
-				// page's element count. mustBroadcast (see Jaws.Serve) sends here
-				// non-blocking and, for any non-Update message, kills the
-				// subscription and cancels this request if the send would block.
-				// A larger page can be the target of more concurrent broadcasts
-				// between drains, so the buffer grows per element (4) over a small
-				// fixed base (4) to avoid spuriously cancelling a slow request.
-				broadcastMsgCh := rq.Jaws.subscribe(rq, 4+numElems*4)
 				outboundMsgCh := make(chan wire.WsMsg, cap(broadcastMsgCh))
 				go wire.ReadLoop(ctx, cancelFn, rq.Jaws.Done(), incomingMsgCh, ws)  // closes incomingMsgCh
 				go wire.WriteLoop(ctx, cancelFn, rq.Jaws.Done(), outboundMsgCh, ws) // calls ws.Close()
 				go wire.PingLoop(ctx, cancelFn, rq.Jaws.Done(), pingInterval, wsTimeout, ws)
+				ownsSubscription = false
 				rq.process(broadcastMsgCh, incomingMsgCh, outboundMsgCh) // unsubscribes broadcastMsgCh, closes outboundMsgCh
 			} else {
+				if ownsSubscription {
+					rq.Jaws.unsubscribe(broadcastMsgCh)
+					ownsSubscription = false
+				}
 				reason := err.Error()
 				defer func() { _ = ws.Close(websocket.StatusNormalClosure, reason) }()
 				var msg wire.WsMsg

--- a/request_test.go
+++ b/request_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
+	"log"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -3221,6 +3222,144 @@ func TestWS_ConnectFnFails(t *testing.T) {
 	}
 	if !strings.Contains(string(b), nope) {
 		t.Error(string(b))
+	}
+}
+
+func TestWS_ConnectFnBroadcastDelivered(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Close()
+	ts.rq.SetConnectFn(func(rq *Request) error {
+		rq.Redirect("/from-connect-fn")
+		return nil
+	})
+
+	conn, resp, err := ts.Dial()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.CloseNow() }()
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusSwitchingProtocols)
+	}
+
+	messageType, data, err := conn.Read(ts.ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if messageType != websocket.MessageText {
+		t.Fatalf("message type = %v, want %v", messageType, websocket.MessageText)
+	}
+	msg, ok := wire.Parse(data)
+	if !ok {
+		t.Fatalf("invalid wire message %q", data)
+	}
+	if msg.What != what.Redirect || msg.Jid != 0 || msg.Data != "/from-connect-fn" {
+		t.Fatalf("message = %+v, want request Redirect to /from-connect-fn", msg)
+	}
+}
+
+func TestWS_ConnectFnSubscriptionCleanup(t *testing.T) {
+	errRejected := errors.New("connect rejected")
+	tests := []struct {
+		name      string
+		connectFn ConnectFn
+		wantAlert string
+	}{
+		{
+			name: "error",
+			connectFn: func(*Request) error {
+				return errRejected
+			},
+			wantAlert: errRejected.Error(),
+		},
+		{
+			name: "panic",
+			connectFn: func(*Request) error {
+				panic("connect panic")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jw, err := New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer jw.Close()
+
+			ctx, cancel := context.WithTimeout(t.Context(), testTimeout)
+			defer cancel()
+			initial := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+			rq := jw.NewRequest(initial)
+			if got := jw.UseRequest(rq.JawsKey, initial); got != rq {
+				t.Fatalf("UseRequest() = %v, want %v", got, rq)
+			}
+			rq.SetConnectFn(tt.connectFn)
+
+			type subscriptionPair struct {
+				subscribed   chan wire.Message
+				unsubscribed chan wire.Message
+			}
+			cleanupCh := make(chan subscriptionPair, 1)
+			go func() {
+				select {
+				case sub := <-jw.subCh:
+					select {
+					case msgCh := <-jw.unsubCh:
+						close(sub.msgCh)
+						cleanupCh <- subscriptionPair{subscribed: sub.msgCh, unsubscribed: msgCh}
+					case <-jw.Done():
+					}
+				case <-jw.Done():
+				}
+			}()
+
+			srv := httptest.NewUnstartedServer(rq)
+			srv.Config.ErrorLog = log.New(io.Discard, "", 0)
+			srv.Start()
+			defer srv.Close()
+			u, err := url.Parse(srv.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			initial.Host = u.Host
+			initial.URL.Scheme = u.Scheme
+			initial.URL.Host = u.Host
+
+			hdr := http.Header{}
+			hdr.Set("Origin", srv.URL)
+			conn, resp, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(srv.URL, "http"), &websocket.DialOptions{HTTPHeader: hdr})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = conn.CloseNow() }()
+			if resp.StatusCode != http.StatusSwitchingProtocols {
+				t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusSwitchingProtocols)
+			}
+
+			if tt.wantAlert != "" {
+				_, data, err := conn.Read(ctx)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !strings.Contains(string(data), tt.wantAlert) {
+					t.Fatalf("error frame %q does not contain %q", data, tt.wantAlert)
+				}
+			}
+
+			select {
+			case cleanup := <-cleanupCh:
+				if cleanup.subscribed == nil {
+					t.Fatal("subscribed channel is nil")
+				}
+				if cleanup.unsubscribed != cleanup.subscribed {
+					t.Fatalf("unsubscribed channel %p, want %p", cleanup.unsubscribed, cleanup.subscribed)
+				}
+			case <-ctx.Done():
+				t.Fatal("ConnectFn subscription was not released")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- subscribe a Request before invoking ConnectFn so callback broadcasts are buffered
- defer browser message processing until ConnectFn succeeds
- release the subscription on callback errors and panics before Request recycling
- document callback state, broadcast, overload, failure, and lifetime semantics
- add WebSocket regression coverage for delivery and cleanup

## Testing

- `go test -race -coverprofile=/private/tmp/jaws-connectfn-coverage.out ./...`
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run ./...`
- `gosec ./...`
- `gofumpt -l request.go request_test.go`

Fixes #161