### PR TITLE
Avoid calling response writers while holding the Jaws lock

### DIFF
--- a/session.go
+++ b/session.go
@@ -377,7 +377,8 @@ func (jw *Jaws) newSession(w http.ResponseWriter, r *http.Request) (sess *Sessio
 		}
 	}()
 
-	// ResponseWriter implementations may call back into Jaws from Header.
+	// http.SetCookie calls the caller-provided ResponseWriter.Header, which may
+	// re-enter Jaws, so emit the cookie only after releasing jw.mu.
 	if w != nil {
 		http.SetCookie(w, &cookie)
 	}

--- a/session.go
+++ b/session.go
@@ -363,19 +363,25 @@ func (jw *Jaws) NewSession(w http.ResponseWriter, r *http.Request) (sess *Sessio
 
 func (jw *Jaws) newSession(w http.ResponseWriter, r *http.Request) (sess *Session) {
 	secure := secureheaders.RequestIsSecure(r, jw.TrustForwardedHeaders)
-	jw.mu.Lock()
-	defer jw.mu.Unlock()
-	for sess == nil {
-		sessionID := jw.nonZeroRandomLocked()
-		if _, ok := jw.sessions[sessionID]; !ok {
-			sess = newSession(jw, sessionID, jw.clientIP(r), secure)
-			jw.sessions[sessionID] = sess
-			if w != nil {
-				http.SetCookie(w, &sess.cookie)
+	var cookie http.Cookie
+	func() {
+		jw.mu.Lock()
+		defer jw.mu.Unlock()
+		for sess == nil {
+			sessionID := jw.nonZeroRandomLocked()
+			if _, ok := jw.sessions[sessionID]; !ok {
+				sess = newSession(jw, sessionID, jw.clientIP(r), secure)
+				jw.sessions[sessionID] = sess
+				cookie = sess.cookie
 			}
-			r.AddCookie(&sess.cookie)
 		}
+	}()
+
+	// ResponseWriter implementations may call back into Jaws from Header.
+	if w != nil {
+		http.SetCookie(w, &cookie)
 	}
+	r.AddCookie(&cookie)
 	return
 }
 

--- a/session_test.go
+++ b/session_test.go
@@ -63,6 +63,73 @@ func TestSession_Object(t *testing.T) {
 	sess.Reload()
 }
 
+type reentrantSessionResponseWriter struct {
+	*httptest.ResponseRecorder
+	jw           *Jaws
+	sessionCount int
+}
+
+func (w *reentrantSessionResponseWriter) Header() http.Header {
+	w.sessionCount = w.jw.SessionCount()
+	return w.ResponseRecorder.Header()
+}
+
+func TestSession_NewSessionCallsResponseWriterOutsideLock(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	hr := httptest.NewRequest(http.MethodGet, "http://example.test/", nil)
+	rw := &reentrantSessionResponseWriter{
+		ResponseRecorder: httptest.NewRecorder(),
+		jw:               jw,
+	}
+	type result struct {
+		sess       *Session
+		panicValue any
+	}
+	done := make(chan result, 1)
+	go func() {
+		var got result
+		defer func() {
+			got.panicValue = recover()
+			done <- got
+		}()
+		got.sess = jw.NewSession(rw, hr)
+	}()
+
+	var got result
+	select {
+	case got = <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("NewSession deadlocked while ResponseWriter.Header re-entered Jaws")
+	}
+	t.Cleanup(jw.Close)
+	if got.panicValue != nil {
+		t.Fatalf("NewSession panicked while ResponseWriter.Header re-entered Jaws: %v", got.panicValue)
+	}
+	if got.sess == nil {
+		t.Fatal("expected session")
+	}
+	if rw.sessionCount != 1 {
+		t.Fatalf("SessionCount during Header = %d, want 1", rw.sessionCount)
+	}
+	if count := jw.SessionCount(); count != 1 {
+		t.Fatalf("SessionCount after NewSession = %d, want 1", count)
+	}
+	if sess := jw.GetSession(hr); sess != got.sess {
+		t.Fatalf("GetSession after NewSession = %v, want %v", sess, got.sess)
+	}
+	cookies := rw.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("response cookies = %d, want 1", len(cookies))
+	}
+	wantCookie := got.sess.Cookie()
+	if cookie := cookies[0]; cookie.Name != wantCookie.Name || cookie.Value != wantCookie.Value {
+		t.Fatalf("response cookie = %s=%s, want %s=%s", cookie.Name, cookie.Value, wantCookie.Name, wantCookie.Value)
+	}
+}
+
 func TestSession_CookieSecureMatchesRequest(t *testing.T) {
 	jw, _ := New()
 	defer jw.Close()


### PR DESCRIPTION
## Summary

- keep session ID allocation and registration atomic under `jw.mu`
- copy the session cookie, then release the lock before calling `http.SetCookie` or updating the request
- add a regression test with a `ResponseWriter` that re-enters Jaws through `Header`, while also verifying registration and cookie propagation

Closes #172.

## Verification

- `go test -race -run '^TestSession_NewSessionCallsResponseWriterOutsideLock$' .`
- `go test -race -count=1 ./...`
- `go vet ./...`
- `staticcheck ./...`
- `gofmt`
- `git diff --check`
