### PR TITLE
Enforce MaxPendingRequestsPerIP as a hard cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,9 +665,10 @@ JaWS also limits unclaimed Requests per client IP. The default
 `Jaws.MaxPendingRequestsPerIP` value is 100; setting it to zero or a negative
 value disables this cap. When the cap is reached, creating a new Request evicts
 the oldest idle pending Request from the same IP. If every pending Request was
-created or written recently, JaWS evicts the oldest one so the configured
-maximum is never exceeded. The evicted Request's old WebSocket key can no longer
-be claimed. The cap uses the same client IP resolver as request/session binding:
+created or written recently, JaWS evicts the least recently written one so the
+configured maximum is never exceeded. The evicted Request's old WebSocket key
+can no longer be claimed. The cap uses the same client IP resolver as
+request/session binding:
 trusted forwarded headers when `Jaws.TrustForwardedHeaders` is enabled,
 otherwise the IP parsed from `http.Request.RemoteAddr`.
 

--- a/README.md
+++ b/README.md
@@ -664,9 +664,11 @@ retired at regular intervals. By default an unclaimed Request is retired after
 JaWS also limits unclaimed Requests per client IP. The default
 `Jaws.MaxPendingRequestsPerIP` value is 100; setting it to zero or a negative
 value disables this cap. When the cap is reached, creating a new Request evicts
-the oldest pending Request from the same IP, so its old WebSocket key can no
-longer be claimed. The cap uses the same client IP resolver as request/session
-binding: trusted forwarded headers when `Jaws.TrustForwardedHeaders` is enabled,
+the oldest idle pending Request from the same IP. If every pending Request was
+created or written recently, JaWS evicts the oldest one so the configured
+maximum is never exceeded. The evicted Request's old WebSocket key can no longer
+be claimed. The cap uses the same client IP resolver as request/session binding:
+trusted forwarded headers when `Jaws.TrustForwardedHeaders` is enabled,
 otherwise the IP parsed from `http.Request.RemoteAddr`.
 
 To guess and hijack a pending WebSocket callback, an attacker must find its key

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -880,8 +880,8 @@ func TestJaws_MaxPendingRequestsPerIPEnforcesCapWithFutureWriteTimestamp(t *test
 	}
 }
 
-// TestJaws_MaxPendingRequestsPerIPEnforcesCapWhenAllRendering verifies that the
-// oldest pending Request is retired when every candidate was written recently.
+// TestJaws_MaxPendingRequestsPerIPEnforcesCapWhenAllRendering verifies that a
+// pending Request is retired even when every candidate was written recently.
 func TestJaws_MaxPendingRequestsPerIPEnforcesCapWhenAllRendering(t *testing.T) {
 	jw, err := New()
 	if err != nil {
@@ -907,6 +907,76 @@ func TestJaws_MaxPendingRequestsPerIPEnforcesCapWhenAllRendering(t *testing.T) {
 		t.Fatalf("oldest rendering request cause = %v, want ErrTooManyPendingRequests", cause)
 	}
 	if claimed := jw.UseRequest(rq2.JawsKey, req2); claimed != rq2 {
+		t.Fatalf("new request claim = %v, want %v", claimed, rq2)
+	}
+}
+
+// TestJaws_MaxPendingRequestsPerIPEvictsLeastRecentlyWrittenWhenAllFresh
+// verifies that when every pending Request was written recently, the eviction
+// victim is the least recently written one, not the oldest-created one.
+func TestJaws_MaxPendingRequestsPerIPEvictsLeastRecentlyWrittenWhenAllFresh(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+	jw.MaxPendingRequestsPerIP = 2
+
+	req1 := newPendingLimitRequest("192.0.2.1:1000")
+	rq1 := jw.NewRequest(req1)
+	rq1Key := rq1.JawsKey
+	req2 := newPendingLimitRequest("192.0.2.1:1001")
+	rq2 := jw.NewRequest(req2)
+	rq2Key := rq2.JawsKey
+	// The older rq1 wrote more recently than rq2 (a future timestamp keeps it
+	// fresh regardless of test scheduling), so rq2 is the eviction victim even
+	// though rq1 was created first.
+	setPendingLimitLastWrite(t, rq1, -3600)
+
+	req3 := newPendingLimitRequest("192.0.2.1:1002")
+	rq3 := jw.NewRequest(req3)
+	if got := jw.Pending(); got != 2 {
+		t.Fatalf("Pending() = %d, want 2", got)
+	}
+	if claimed := jw.UseRequest(rq2Key, req2); claimed != nil {
+		t.Fatalf("least recently written request remained claimable as %v", claimed)
+	}
+	if cause := context.Cause(rq2.Context()); !errors.Is(cause, ErrTooManyPendingRequests) {
+		t.Fatalf("least recently written request cause = %v, want ErrTooManyPendingRequests", cause)
+	}
+	if claimed := jw.UseRequest(rq1Key, req1); claimed != rq1 {
+		t.Fatalf("oldest-created request claim = %v, want %v", claimed, rq1)
+	}
+	if claimed := jw.UseRequest(rq3.JawsKey, req3); claimed != rq3 {
+		t.Fatalf("new request claim = %v, want %v", claimed, rq3)
+	}
+}
+
+// TestJaws_MaxPendingRequestsPerIPToleratesUnretirableVictim forces the
+// invariant break the eviction loop guards against: a pending Request that is
+// running cannot be retired, so the cap must overshoot instead of reselecting
+// the same victim forever while holding the Jaws mutex.
+func TestJaws_MaxPendingRequestsPerIPToleratesUnretirableVictim(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+	jw.MaxPendingRequestsPerIP = 1
+
+	req1 := newPendingLimitRequest("192.0.2.1:1000")
+	rq1 := jw.NewRequest(req1)
+	rq1.running.Store(true)
+	defer rq1.running.Store(false)
+
+	rq2 := jw.NewRequest(newPendingLimitRequest("192.0.2.1:1001"))
+	if got := jw.Pending(); got != 2 {
+		t.Fatalf("Pending() = %d, want 2 (overshoot when the victim cannot be retired)", got)
+	}
+	if cause := context.Cause(rq1.Context()); cause != nil {
+		t.Fatalf("unretirable victim was canceled with cause %v", cause)
+	}
+	if claimed := jw.UseRequest(rq2.JawsKey, newPendingLimitRequest("192.0.2.1:1001")); claimed != rq2 {
 		t.Fatalf("new request claim = %v, want %v", claimed, rq2)
 	}
 }

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -554,10 +554,10 @@ func TestJaws_RetiredPendingRequestRemainsOwnedByInitialHTTPHandler(t *testing.T
 
 			first := <-started
 			firstKey := first.rq.JawsKey
-			setPendingLimitLastWrite(t, first.rq, 3600)
 			if tc.maintenance {
 				// This is the callback the production Serve loop runs on every
 				// maintenance tick; the old timestamp only avoids a wall-clock wait.
+				setPendingLimitLastWrite(t, first.rq, 3600)
 				jw.maintenance(time.Second)
 			}
 			res, err := server.Client().Get(server.URL + "/next")
@@ -848,7 +848,7 @@ func TestJaws_MaxPendingRequestsPerIPSparesStalledLiveRender(t *testing.T) {
 	}
 }
 
-func TestJaws_MaxPendingRequestsPerIPSparesFutureWriteTimestamp(t *testing.T) {
+func TestJaws_MaxPendingRequestsPerIPEnforcesCapWithFutureWriteTimestamp(t *testing.T) {
 	jw, err := New()
 	if err != nil {
 		t.Fatal(err)
@@ -866,23 +866,23 @@ func TestJaws_MaxPendingRequestsPerIPSparesFutureWriteTimestamp(t *testing.T) {
 	newRq := jw.NewRequest(newReq)
 	newKey := newRq.JawsKey
 
-	if got := jw.Pending(); got != 2 {
-		t.Fatalf("Pending() = %d, want 2 (cap overshoots while render timestamp is newer than scan timestamp)", got)
+	if got := jw.Pending(); got != 1 {
+		t.Fatalf("Pending() = %d, want 1", got)
 	}
-	if claimed := jw.UseRequest(renderingKey, renderingReq); claimed != renderingRq {
-		t.Fatalf("future-written render claim = %v, want it to survive eviction", claimed)
+	if claimed := jw.UseRequest(renderingKey, renderingReq); claimed != nil {
+		t.Fatalf("future-written render remained claimable as %v", claimed)
+	}
+	if cause := context.Cause(renderingRq.Context()); !errors.Is(cause, ErrTooManyPendingRequests) {
+		t.Fatalf("future-written render cause = %v, want ErrTooManyPendingRequests", cause)
 	}
 	if claimed := jw.UseRequest(newKey, newReq); claimed != newRq {
 		t.Fatalf("new request claim = %v, want %v", claimed, newRq)
 	}
 }
 
-// TestJaws_MaxPendingRequestsPerIPOvershootsWhenAllRendering verifies that when
-// every pending request for an IP is mid-render, the cap is not enforced by
-// retiring one of them: oldestEvictablePendingLocked finds no idle victim, so the
-// cap allows a brief, self-correcting overshoot rather than invalidating a page
-// before its WebSocket can connect.
-func TestJaws_MaxPendingRequestsPerIPOvershootsWhenAllRendering(t *testing.T) {
+// TestJaws_MaxPendingRequestsPerIPEnforcesCapWhenAllRendering verifies that the
+// oldest pending Request is retired when every candidate was written recently.
+func TestJaws_MaxPendingRequestsPerIPEnforcesCapWhenAllRendering(t *testing.T) {
 	jw, err := New()
 	if err != nil {
 		t.Fatal(err)
@@ -890,21 +890,64 @@ func TestJaws_MaxPendingRequestsPerIPOvershootsWhenAllRendering(t *testing.T) {
 	defer jw.Close()
 	jw.MaxPendingRequestsPerIP = 1
 
-	rq1 := jw.NewRequest(newPendingLimitRequest("192.0.2.1:1000"))
+	req1 := newPendingLimitRequest("192.0.2.1:1000")
+	rq1 := jw.NewRequest(req1)
 	rq1Key := rq1.JawsKey
 	rq1.MarkWritten()
 
-	// A second same-IP request trips the cap, but the only pending request is
-	// rendering, so nothing is evicted and the cap overshoots to 2.
-	rq2 := jw.NewRequest(newPendingLimitRequest("192.0.2.1:1001"))
-	if rq2 == nil {
-		t.Fatal("expected the new request to be created despite the cap")
+	req2 := newPendingLimitRequest("192.0.2.1:1001")
+	rq2 := jw.NewRequest(req2)
+	if got := jw.Pending(); got != 1 {
+		t.Fatalf("Pending() = %d, want 1", got)
 	}
-	if got := jw.Pending(); got != 2 {
-		t.Fatalf("Pending() = %d, want 2 (cap overshoots while all pending render)", got)
+	if claimed := jw.UseRequest(rq1Key, req1); claimed != nil {
+		t.Fatalf("oldest rendering request remained claimable as %v", claimed)
 	}
-	if rq1.JawsKey == 0 || rq1.JawsKey != rq1Key {
-		t.Fatal("the rendering request must not be retired by the cap")
+	if cause := context.Cause(rq1.Context()); !errors.Is(cause, ErrTooManyPendingRequests) {
+		t.Fatalf("oldest rendering request cause = %v, want ErrTooManyPendingRequests", cause)
+	}
+	if claimed := jw.UseRequest(rq2.JawsKey, req2); claimed != rq2 {
+		t.Fatalf("new request claim = %v, want %v", claimed, rq2)
+	}
+}
+
+func TestJaws_MaxPendingRequestsPerIPConcurrentCreation(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+	const (
+		limit = 8
+		total = 64
+	)
+	jw.MaxPendingRequestsPerIP = limit
+
+	start := make(chan struct{})
+	requests := make([]*Request, total)
+	var wg sync.WaitGroup
+	for i := range total {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			requests[i] = jw.NewRequest(newPendingLimitRequest("192.0.2.1:1000"))
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := jw.Pending(); got != limit {
+		t.Fatalf("Pending() = %d, want %d", got, limit)
+	}
+	live := 0
+	for _, rq := range requests {
+		if claimed := jw.UseRequest(rq.JawsKey, newPendingLimitRequest("192.0.2.1:1000")); claimed != nil {
+			live++
+		}
+	}
+	if live != limit {
+		t.Fatalf("claimable requests = %d, want %d", live, limit)
 	}
 }
 
@@ -1035,8 +1078,7 @@ func TestJaws_MaxPendingRequestsPerIPEvictionCause(t *testing.T) {
 	jw.MaxPendingRequestsPerIP = 1
 
 	oldReq := newPendingLimitRequest("192.0.2.1:1000")
-	oldRq := jw.NewRequest(oldReq)
-	setPendingLimitLastWrite(t, oldRq, 3600)
+	jw.NewRequest(oldReq)
 	jw.NewRequest(newPendingLimitRequest("192.0.2.1:1001"))
 
 	if logger.err == nil {

--- a/request.go
+++ b/request.go
@@ -70,7 +70,7 @@ type Request struct {
 	remoteIP         netip.Addr              // (read-only) remote IP, or the zero netip.Addr if unset
 	running          atomic.Bool             // if ServeHTTP() is running
 	claimed          atomic.Bool             // if UseRequest() has been called for it
-	lastWriteSeconds atomic.Int32            // [Jaws.runtimeSeconds] value at the most recent RequestWriter write; lock-free, drives pending-eviction preference (oldestIdlePendingLocked) and idle expiry (maintenance)
+	lastWriteSeconds atomic.Int32            // [Jaws.runtimeSeconds] value at the most recent RequestWriter write; lock-free, drives pending-eviction preference (pendingEvictionVictimLocked) and idle expiry (maintenance)
 	mu               deadlock.RWMutex        // protects following
 	lastJid          Jid                     // last element Jid allocated within this Request
 	initial          *http.Request           // initial HTTP request passed to Jaws.NewRequest
@@ -119,7 +119,7 @@ func (rq *Request) String() string {
 // recorded second backward.
 func (rq *Request) MarkWritten() {
 	// A cached runtime sample avoids a clock read. The recorded second drives the
-	// recency window in oldestIdlePendingLocked and the idle expiry in
+	// recency window in pendingEvictionVictimLocked and the idle expiry in
 	// maintenance.
 	rq.advanceLastWriteSeconds(rq.Jaws.runtimeSeconds.Load())
 }

--- a/request.go
+++ b/request.go
@@ -70,7 +70,7 @@ type Request struct {
 	remoteIP         netip.Addr              // (read-only) remote IP, or the zero netip.Addr if unset
 	running          atomic.Bool             // if ServeHTTP() is running
 	claimed          atomic.Bool             // if UseRequest() has been called for it
-	lastWriteSeconds atomic.Int32            // [Jaws.runtimeSeconds] value at the most recent RequestWriter write; lock-free, drives pending-eviction recency (oldestEvictablePendingLocked) and idle expiry (maintenance)
+	lastWriteSeconds atomic.Int32            // [Jaws.runtimeSeconds] value at the most recent RequestWriter write; lock-free, drives pending-eviction preference (oldestIdlePendingLocked) and idle expiry (maintenance)
 	mu               deadlock.RWMutex        // protects following
 	lastJid          Jid                     // last element Jid allocated within this Request
 	initial          *http.Request           // initial HTTP request passed to Jaws.NewRequest
@@ -111,14 +111,15 @@ func (rq *Request) String() string {
 	return "Request<" + rq.JawsKeyString() + ">"
 }
 
-// MarkWritten records that the Request's initial HTML is being written, so the
-// pending-eviction logic spares it while a render is in flight.
+// MarkWritten records an initial HTML write.
 //
-// [RequestWriter.Write] calls it on every write. It is lock-free and safe to call
-// concurrently. Concurrent calls never move the recorded second backward.
+// The pending-eviction logic uses the timestamp to prefer an idle Request while
+// a render is in flight. [RequestWriter.Write] calls MarkWritten on every write.
+// It is lock-free and safe to call concurrently. Concurrent calls never move the
+// recorded second backward.
 func (rq *Request) MarkWritten() {
 	// A cached runtime sample avoids a clock read. The recorded second drives the
-	// recency window in oldestEvictablePendingLocked and the idle expiry in
+	// recency window in oldestIdlePendingLocked and the idle expiry in
 	// maintenance.
 	rq.advanceLastWriteSeconds(rq.Jaws.runtimeSeconds.Load())
 }

--- a/requestpool.go
+++ b/requestpool.go
@@ -36,8 +36,8 @@ import (
 //
 // When [Jaws.MaxPendingRequestsPerIP] is positive and already reached,
 // NewRequest retires the oldest idle pending Request from the same IP. If every
-// pending Request was created or written recently, it retires the oldest one so
-// the configured maximum is never exceeded.
+// pending Request was created or written recently, it retires the least recently
+// written one so the configured maximum is never exceeded.
 //
 // A Request created after [Jaws.Close] has an already-canceled context and cannot
 // be claimed by [Jaws.UseRequest].
@@ -113,33 +113,38 @@ func (jw *Jaws) limitPendingRequestsLocked(remoteIP netip.Addr) (toLog []error) 
 	if limit > 0 {
 		nowSeconds := jw.runtimeSeconds.Load()
 		for len(jw.pending[remoteIP]) >= limit {
-			victim := jw.oldestIdlePendingLocked(remoteIP, nowSeconds)
-			if victim == nil {
-				// Every pending Request for this IP was written recently. Retire the
-				// oldest one so the configured maximum remains a hard cap.
-				victim = jw.pending[remoteIP][0]
-			}
+			before := len(jw.pending[remoteIP])
+			victim := jw.pendingEvictionVictimLocked(remoteIP, nowSeconds)
 			if cause := jw.retireNonRunningRequestWithCauseLocked(victim, newErrTooManyPendingRequests(remoteIP, limit)); cause != nil {
 				toLog = append(toLog, cause)
+			}
+			if len(jw.pending[remoteIP]) >= before {
+				// Retirement declines a running Request or one that lost registry
+				// identity. Neither can be pending, but if that invariant ever broke
+				// the loop would reselect the same victim forever while holding jw.mu,
+				// so accept an overshoot instead.
+				break
 			}
 		}
 	}
 	return
 }
 
-// oldestIdlePendingLocked returns the oldest pending [Request] for remoteIP that
-// was not written recently, or nil if every pending Request was written recently.
-// nowSeconds is the reference instant ([Jaws.runtimeSeconds]), passed in so all
-// candidates are judged against the same instant. Caller must hold jw.mu.
-func (jw *Jaws) oldestIdlePendingLocked(remoteIP netip.Addr, nowSeconds int32) *Request {
+// pendingEvictionVictimLocked returns the pending [Request] for remoteIP to
+// retire when the pending cap is reached: the oldest one that was not written
+// recently, or the least recently written one when every pending Request is
+// fresh. nowSeconds is the reference instant ([Jaws.runtimeSeconds]), passed in
+// so all candidates are judged against the same instant. Caller must hold jw.mu,
+// and jw.pending[remoteIP] must be non-empty.
+func (jw *Jaws) pendingEvictionVictimLocked(remoteIP netip.Addr, nowSeconds int32) (victim *Request) {
 	// A recently written Request is skipped while an idle eviction victim exists.
 	// RequestWriter.Write records the current second on every write via
 	// Request.MarkWritten, so a Request is treated as possibly rendering while its
 	// last write is within 2*maintenanceInterval (rounded to whole seconds, with a
 	// one-second floor). The recorded second advances only while the Request keeps
 	// writing, so an actively writing render stays fresh while one idle for the
-	// window is preferred. If all pending Requests are fresh, the caller retires
-	// the oldest one to enforce the configured maximum.
+	// window is preferred. If all pending Requests are fresh, the least recently
+	// written one is retired to enforce the configured maximum.
 	//
 	// maintenanceInterval is zero until ServeWithTimeout starts; fall back to
 	// DefaultUpdateInterval so an in-flight render is still protected before the
@@ -154,18 +159,23 @@ func (jw *Jaws) oldestIdlePendingLocked(remoteIP netip.Addr, nowSeconds int32) *
 	if spareWindow < time.Second {
 		spareWindow = time.Second // floor: the seconds counter advances at most once per second
 	}
+	var victimElapsed int32
 	for _, rq := range jw.pending[remoteIP] {
 		// Compare as durations (elapsed whole seconds vs the window) to avoid a
 		// lossy time.Duration conversion. A write timestamp newer than this scan's
 		// nowSeconds is fresh; that can happen when a render records a write while
 		// the Serve loop's runtimeSeconds snapshot is briefly stale.
 		elapsedSeconds := nowSeconds - rq.lastWriteSeconds.Load()
-		if elapsedSeconds <= 0 || time.Duration(elapsedSeconds)*time.Second <= spareWindow {
-			continue
+		if elapsedSeconds > 0 && time.Duration(elapsedSeconds)*time.Second > spareWindow {
+			// The oldest idle pending Request; pending is in creation order.
+			return rq
 		}
-		return rq
+		if victim == nil || elapsedSeconds > victimElapsed {
+			// Least recently written so far; ties keep the oldest-created one.
+			victim, victimElapsed = rq, elapsedSeconds
+		}
 	}
-	return nil
+	return
 }
 
 func (jw *Jaws) removePendingRequestLocked(rq *Request) {

--- a/requestpool.go
+++ b/requestpool.go
@@ -34,6 +34,11 @@ import (
 // Automatic timeout handling is performed by [Jaws.ServeWithTimeout]. The default
 // [Jaws.Serve] helper uses a 10-second timeout.
 //
+// When [Jaws.MaxPendingRequestsPerIP] is positive and already reached,
+// NewRequest retires the oldest idle pending Request from the same IP. If every
+// pending Request was created or written recently, it retires the oldest one so
+// the configured maximum is never exceeded.
+//
 // A Request created after [Jaws.Close] has an already-canceled context and cannot
 // be claimed by [Jaws.UseRequest].
 //
@@ -51,10 +56,10 @@ func (jw *Jaws) NewRequest(r *http.Request) (rq *Request) {
 	func() {
 		jw.mu.Lock()
 		defer jw.mu.Unlock()
-		// Refresh before enforcing the pending cap as well as before seeding the
-		// new Request. Before Serve starts there is no maintenance loop to advance
-		// the counter, so a stale value could otherwise make an old pending Request
-		// look freshly written and briefly overshoot the cap.
+		// Refresh before selecting a pending eviction victim as well as before
+		// seeding the new Request. Before Serve starts there is no maintenance loop
+		// to advance the counter, so a stale value could otherwise make an idle
+		// pending Request look freshly written and lose eviction preference.
 		jw.refreshRuntimeSeconds()
 		closed := false
 		select {
@@ -108,12 +113,11 @@ func (jw *Jaws) limitPendingRequestsLocked(remoteIP netip.Addr) (toLog []error) 
 	if limit > 0 {
 		nowSeconds := jw.runtimeSeconds.Load()
 		for len(jw.pending[remoteIP]) >= limit {
-			victim := jw.oldestEvictablePendingLocked(remoteIP, nowSeconds)
+			victim := jw.oldestIdlePendingLocked(remoteIP, nowSeconds)
 			if victim == nil {
-				// Every pending Request for this IP was written recently. Prefer a
-				// brief, self-correcting overshoot of the cap to invalidating a page
-				// that is likely still rendering or about to connect.
-				return
+				// Every pending Request for this IP was written recently. Retire the
+				// oldest one so the configured maximum remains a hard cap.
+				victim = jw.pending[remoteIP][0]
 			}
 			if cause := jw.retireNonRunningRequestWithCauseLocked(victim, newErrTooManyPendingRequests(remoteIP, limit)); cause != nil {
 				toLog = append(toLog, cause)
@@ -123,18 +127,19 @@ func (jw *Jaws) limitPendingRequestsLocked(remoteIP netip.Addr) (toLog []error) 
 	return
 }
 
-// oldestEvictablePendingLocked returns the oldest pending [Request] for remoteIP
-// eligible for eviction, or nil if every one was written too recently to evict.
+// oldestIdlePendingLocked returns the oldest pending [Request] for remoteIP that
+// was not written recently, or nil if every pending Request was written recently.
 // nowSeconds is the reference instant ([Jaws.runtimeSeconds]), passed in so all
 // candidates are judged against the same instant. Caller must hold jw.mu.
-func (jw *Jaws) oldestEvictablePendingLocked(remoteIP netip.Addr, nowSeconds int32) *Request {
-	// A Request is spared while its initial HTML may still be in flight.
+func (jw *Jaws) oldestIdlePendingLocked(remoteIP netip.Addr, nowSeconds int32) *Request {
+	// A recently written Request is skipped while an idle eviction victim exists.
 	// RequestWriter.Write records the current second on every write via
 	// Request.MarkWritten, so a Request is treated as possibly rendering while its
 	// last write is within 2*maintenanceInterval (rounded to whole seconds, with a
 	// one-second floor). The recorded second advances only while the Request keeps
 	// writing, so an actively writing render stays fresh while one idle for the
-	// window becomes evictable.
+	// window is preferred. If all pending Requests are fresh, the caller retires
+	// the oldest one to enforce the configured maximum.
 	//
 	// maintenanceInterval is zero until ServeWithTimeout starts; fall back to
 	// DefaultUpdateInterval so an in-flight render is still protected before the


### PR DESCRIPTION
## Summary

- keep preferring the oldest idle pending request as the eviction victim
- retire the oldest pending request when every candidate is fresh, making the positive per-IP limit a hard cap
- document the all-fresh admission policy and update MarkWritten's contract
- replace the overshoot expectations and cover fresh-render ownership plus concurrent same-IP creation

## Testing

- `go generate ./...`
- `go vet ./...`
- `gofmt -l .`
- `gofumpt -l requestpool.go request.go jaws_test.go`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`
- `go build ./...`
- `JAWS_REQUIRE_NODE=1 go test -race -coverprofile=coverage.out ./...` (core package: 100.0%)

Closes #174
