### PR TITLE
docs: define BoolArray removal contract

### DIFF
--- a/lib/named/namedbool.go
+++ b/lib/named/namedbool.go
@@ -26,7 +26,7 @@ type Bool struct {
 // user input it must be pre-escaped, e.g. template.HTML(template.HTMLEscapeString(s)).
 //
 // If nba is non-nil, changing the value through [Bool.JawsSet] may dirty the
-// containing [BoolArray] and deselect sibling values in single-select mode.
+// associated [BoolArray] and deselect sibling values in single-select mode.
 func NewBool(nba *BoolArray, name string, html template.HTML, checked bool) *Bool {
 	return &Bool{
 		nba:     nba,
@@ -36,7 +36,12 @@ func NewBool(nba *BoolArray, name string, html template.HTML, checked bool) *Boo
 	}
 }
 
-// Array returns the [BoolArray] that owns nb, or nil.
+// Array returns the [BoolArray] associated with nb, or nil.
+//
+// The association is fixed when nb is created and does not report current
+// membership. In particular, removing nb through [BoolArray.WriteLocked] does
+// not change this result. See [BoolArray.WriteLocked] for the restrictions on
+// using a removed Bool.
 func (nb *Bool) Array() *BoolArray {
 	return nb.nba
 }
@@ -65,6 +70,10 @@ func (nb *Bool) JawsGet(elem *jaws.Element) (yes bool) {
 }
 
 // JawsSet sets the checked state and dirties the affected element tags.
+//
+// If [Bool.Array] is non-nil, the associated array is used without checking
+// whether nb is currently one of its members. See [BoolArray.WriteLocked] for
+// the restrictions on using a removed Bool.
 //
 // It returns [jaws.ErrValueUnchanged] if checked already matched the current
 // state.

--- a/lib/named/namedboolarray.go
+++ b/lib/named/namedboolarray.go
@@ -48,6 +48,13 @@ func (nba *BoolArray) ReadLocked(fn func(nbl []*Bool)) {
 // WriteLocked calls fn with the [BoolArray] locked for writing and replaces
 // the internal []*Bool slice with the return value.
 //
+// Omitting a [Bool] from the returned slice does not detach it from nba:
+// [Bool.Array] continues to return nba, and [Bool.JawsSet] continues to apply
+// nba's single-select and dirtying behavior. Structural removal is supported
+// only after every live UI element backed by the Bool has been removed and no
+// event for it can remain in flight. Do not call Bool.JawsSet while the Bool is
+// absent; reinsert it into the same array before using it as an event setter.
+//
 // As with [BoolArray.ReadLocked], fn must not call other [BoolArray] methods or
 // [Bool.JawsSet] (they re-acquire the same non-reentrant nba mutex and deadlock);
 // operate only on the provided slice and the *[Bool] methods that take just the


### PR DESCRIPTION
## Summary

- document that WriteLocked removal does not detach Bool values
- define the live-element and in-flight-event restriction for structural removal
- clarify that Bool.Array reports fixed association and that Bool.JawsSet does not check membership

Closes #175

## Verification

- go test -race ./...
- go vet ./...
- staticcheck ./...
- golangci-lint run ./...
- gosec -quiet ./...
- go build ./...
- gofmt -l .
- go doc github.com/linkdata/jaws/lib/named BoolArray.WriteLocked
- go doc github.com/linkdata/jaws/lib/named Bool.Array