### PR TITLE
fix(ui): apply initial select getter

### DIFF
--- a/lib/ui/containerhelper_test.go
+++ b/lib/ui/containerhelper_test.go
@@ -128,6 +128,64 @@ collect:
 	}
 }
 
+func TestContainerHelper_AppendsSelectBeforeSettingInitialValue(t *testing.T) {
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+	go jw.Serve()
+
+	tr := jawstest.NewTestRequest(jw, nil)
+	t.Cleanup(func() {
+		tr.Close()
+		<-tr.DoneCh
+	})
+	<-tr.ReadyCh
+
+	outerHandler := &testContainer{}
+	outer := NewContainer("div", outerHandler)
+	outerElem := tr.NewElement(outer)
+	var sb strings.Builder
+	if err := outerElem.JawsRender(&sb, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	selectHandler := &testSelectHandler{
+		testContainer: &testContainer{contents: []jaws.UI{
+			plainSelectOption{value: "1", label: "one"},
+			plainSelectOption{value: "2", label: "two"},
+		}},
+		testSetter: newTestSetter("2"),
+	}
+	outerHandler.contents = []jaws.UI{NewSelect(selectHandler)}
+	tr.BcastCh <- wire.Message{Dest: outerHandler, What: what.Update}
+
+	sawAppend := false
+	for {
+		select {
+		case msg := <-tr.OutCh:
+			switch msg.What {
+			case what.Append:
+				sawAppend = true
+				if !strings.Contains(msg.Data, "<select") {
+					t.Fatalf("Append data %q does not contain the select", msg.Data)
+				}
+			case what.Value:
+				if !sawAppend {
+					t.Fatalf("select Value %q was sent before its containing Append", msg.Data)
+				}
+				if msg.Data != "2" {
+					t.Fatalf("select Value = %q, want %q", msg.Data, "2")
+				}
+				return
+			}
+		case <-time.After(time.Second):
+			t.Fatal("no appended select value update received")
+		}
+	}
+}
+
 func TestContainerHelperUpdateContainerDuplicates(t *testing.T) {
 	_, rq := newCoreRequest(t)
 	span1 := NewSpan(testHTMLGetter("span1"))

--- a/lib/ui/containerhelper_test.go
+++ b/lib/ui/containerhelper_test.go
@@ -537,6 +537,16 @@ type testSelectHandler struct {
 	*testSetter[string]
 }
 
+type countingSelectHandler struct {
+	*testSelectHandler
+	getCount int
+}
+
+func (sh *countingSelectHandler) JawsGet(elem *jaws.Element) string {
+	sh.getCount++
+	return sh.testSetter.JawsGet(elem)
+}
+
 type plainSelectOption struct {
 	value string
 	label string
@@ -576,6 +586,86 @@ func TestSelectWidget(t *testing.T) {
 	}
 }
 
+func TestSelectWidget_AppliesGetterAfterInitialRender(t *testing.T) {
+	tests := []struct {
+		name string
+		sh   named.SelectHandler
+		want string
+	}{
+		{
+			name: "empty BoolArray selection",
+			sh: named.NewBoolArray(false).
+				Add("1", "one").
+				Add("2", "two"),
+		},
+		{
+			name: "custom getter differs from option markup",
+			sh: &testSelectHandler{
+				testContainer: &testContainer{contents: []jaws.UI{
+					plainSelectOption{value: "1", label: "one"},
+					plainSelectOption{value: "2", label: "two"},
+				}},
+				testSetter: newTestSetter("2"),
+			},
+			want: "2",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			jw, err := jaws.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(jw.Close)
+			go jw.Serve()
+
+			tr := jawstest.NewTestRequest(jw, nil)
+			t.Cleanup(func() {
+				tr.Close()
+				<-tr.DoneCh
+			})
+			<-tr.ReadyCh
+
+			rw := RequestWriter{Request: tr.Request, Writer: tr.Recorder}
+			if err := rw.NewUI(NewSelect(tc.sh)); err != nil {
+				t.Fatal(err)
+			}
+			if got := tr.BodyString(); strings.Contains(got, " selected") {
+				t.Fatalf("initial option markup unexpectedly selected an option: %s", got)
+			}
+
+			tr.InCh <- wire.WsMsg{}
+			select {
+			case msg := <-tr.OutCh:
+				if msg.What != what.Value || msg.Data != tc.want {
+					t.Fatalf("initial select update = %+v, want Value %q", msg, tc.want)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("no initial select value update received")
+			}
+		})
+	}
+}
+
+func TestSelectWidget_RenderErrorDoesNotApplyGetter(t *testing.T) {
+	_, rq := newCoreRequest(t)
+	renderErr := errors.New("render error")
+	sh := &countingSelectHandler{testSelectHandler: &testSelectHandler{
+		testContainer: &testContainer{contents: []jaws.UI{testRenderErrorUI{err: renderErr}}},
+		testSetter:    newTestSetter("1"),
+	}}
+	var sb strings.Builder
+	rw := RequestWriter{Request: rq, Writer: &sb}
+
+	if err := rw.NewUI(NewSelect(sh)); !errors.Is(err, renderErr) {
+		t.Fatalf("want %v got %v", renderErr, err)
+	}
+	if sh.getCount != 0 {
+		t.Fatalf("getter called %d times after failed render", sh.getCount)
+	}
+}
+
 func TestSelectWidget_AppendsOptionBeforeSettingNewValue(t *testing.T) {
 	jw, err := jaws.New()
 	if err != nil {
@@ -602,6 +692,15 @@ func TestSelectWidget_AppendsOptionBeforeSettingNewValue(t *testing.T) {
 	var sb strings.Builder
 	if err := elem.JawsRender(&sb, nil); err != nil {
 		t.Fatal(err)
+	}
+	tr.InCh <- wire.WsMsg{}
+	select {
+	case msg := <-tr.OutCh:
+		if msg.What != what.Value || msg.Data != "1" {
+			t.Fatalf("initial select update = %+v, want Value %q", msg, "1")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no initial select value update received")
 	}
 
 	sh.Set("2")

--- a/lib/ui/select.go
+++ b/lib/ui/select.go
@@ -29,6 +29,10 @@ func NewSelect(sh named.SelectHandler) *Select {
 }
 
 // JawsRender renders ui as an HTML select element and applies its selected value.
+//
+// The value is queued even when the option markup may already represent it:
+// [named.SelectHandler] permits custom option renderers, so Select cannot know
+// whether that markup agrees with the handler's getter.
 func (u *Select) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err error) {
 	if err = u.RenderContainer(elem, w, "select", params); err == nil {
 		u.applyValue(elem)

--- a/lib/ui/select.go
+++ b/lib/ui/select.go
@@ -28,9 +28,12 @@ func NewSelect(sh named.SelectHandler) *Select {
 	return &Select{ContainerHelper: NewContainerHelper(sh)}
 }
 
-// JawsRender renders ui as an HTML select element.
-func (u *Select) JawsRender(elem *jaws.Element, w io.Writer, params []any) error {
-	return u.RenderContainer(elem, w, "select", params)
+// JawsRender renders ui as an HTML select element and applies its selected value.
+func (u *Select) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err error) {
+	if err = u.RenderContainer(elem, w, "select", params); err == nil {
+		u.applyValue(elem)
+	}
+	return
 }
 
 // JawsUpdate updates the selected value and child options.
@@ -40,14 +43,16 @@ func (u *Select) JawsRender(elem *jaws.Element, w io.Writer, params []any) error
 // options actually changed.
 func (u *Select) JawsUpdate(elem *jaws.Element) {
 	u.UpdateContainer(elem)
-	// The selected value is only set when the Container is a bind.Setter of string;
-	// the child options are always updated. NewSelect always supplies a
-	// named.SelectHandler (a bind.Setter of string), so this guard (and the one in
-	// JawsInput) only takes effect if Container is later reassigned to a plain
-	// jaws.Container.
+	u.applyValue(elem)
+}
+
+func (u *Select) applyValue(elem *jaws.Element) {
+	// NewSelect always supplies a named.SelectHandler (a bind.Setter of string),
+	// so this guard (and the one in JawsInput) only takes effect if Container is
+	// later reassigned to a plain jaws.Container.
 	if setter, ok := u.ContainerHelper.Container.(bind.Setter[string]); ok {
-		// Set the live value after reconciling options, so a newly selected
-		// option exists in the browser before the select value is assigned.
+		// JawsRender and JawsUpdate call this only after rendering or reconciling
+		// options, so the options exist before the select value is assigned.
 		elem.SetValue(setter.JawsGet(elem))
 	}
 }


### PR DESCRIPTION
## Summary

- apply the select handler getter after successful initial option rendering
- share the post-options value application between render and update paths
- cover empty selections, custom handlers, render failures, and update ordering

Fixes #177

## Testing

- `go test -race ./...`
- `go test -race -run '^TestSelectWidget' -count=10 ./lib/ui`
- `git diff --check`