### PR TITLE
Fix numeric input adapter reconciliation

### DIFF
--- a/lib/bind/setterfloat64.go
+++ b/lib/bind/setterfloat64.go
@@ -174,9 +174,9 @@ func makeSetterFloat64for[T numeric](s *Setter[float64], value any) bool {
 // representable as float64.
 //
 // If conversion changes value but the converted value already matches the
-// underlying setter, the adapter reports a successful set instead of
-// [jaws.ErrValueUnchanged]. This lets consumers reconcile their float64 view with
-// the canonical converted value returned by [Getter.JawsGet].
+// underlying setter's current value, the adapter reports a successful set
+// instead of [jaws.ErrValueUnchanged]. This lets consumers reconcile their
+// float64 view with the canonical converted value returned by [Getter.JawsGet].
 //
 // Only the predeclared numeric types are matched, by their exact type. Named
 // (defined) numeric types such as "type Celsius float64" are NOT matched:

--- a/lib/bind/setterfloat64.go
+++ b/lib/bind/setterfloat64.go
@@ -100,7 +100,15 @@ func (s setterFloat64[T]) JawsGet(elem *jaws.Element) float64 {
 
 func (s setterFloat64[T]) JawsSet(elem *jaws.Element, value float64) (err error) {
 	if err = sanitizeFloatForT[T](value); err == nil {
-		err = s.Setter.JawsSet(elem, T(value))
+		converted := T(value)
+		err = s.Setter.JawsSet(elem, converted)
+		// ErrValueUnchanged is accurate for the underlying T setter, but not for
+		// this float64 view when conversion changed the requested value. Report a
+		// successful change so input widgets dirty themselves and reconcile the
+		// browser with the canonical value returned by JawsGet.
+		if err != nil && errors.Is(err, jaws.ErrValueUnchanged) && float64(converted) != value {
+			err = nil
+		}
 	}
 	return
 }
@@ -164,6 +172,11 @@ func makeSetterFloat64for[T numeric](s *Setter[float64], value any) bool {
 // types and float32), which is bridged to float64 by ordinary Go conversion. That
 // bridge can lose precision: int64/uint64 magnitudes beyond 2^53 are not exactly
 // representable as float64.
+//
+// If conversion changes value but the converted value already matches the
+// underlying setter, the adapter reports a successful set instead of
+// [jaws.ErrValueUnchanged]. This lets consumers reconcile their float64 view with
+// the canonical converted value returned by [Getter.JawsGet].
 //
 // Only the predeclared numeric types are matched, by their exact type. Named
 // (defined) numeric types such as "type Celsius float64" are NOT matched:

--- a/lib/bind/setterfloat64_test.go
+++ b/lib/bind/setterfloat64_test.go
@@ -83,6 +83,37 @@ func Test_makeSetterFloat64_int(t *testing.T) {
 	}
 }
 
+func Test_setterFloat64_conversionSignalsCanonicalChange(t *testing.T) {
+	t.Run("int truncation", func(t *testing.T) {
+		ts := newTestSetter(1)
+		s := MakeSetterFloat64(ts)
+		if err := s.JawsSet(nil, 1.9); err != nil {
+			t.Fatalf("JawsSet(1.9): %v", err)
+		}
+		if ts.Get() != 1 {
+			t.Fatalf("stored value = %d, want 1", ts.Get())
+		}
+		if err := s.JawsSet(nil, 1); !errors.Is(err, jaws.ErrValueUnchanged) {
+			t.Fatalf("JawsSet(1) = %v, want ErrValueUnchanged", err)
+		}
+	})
+
+	t.Run("float32 rounding", func(t *testing.T) {
+		value := float32(0.1)
+		ts := newTestSetter(value)
+		s := MakeSetterFloat64(ts)
+		if err := s.JawsSet(nil, 0.1); err != nil {
+			t.Fatalf("JawsSet(0.1): %v", err)
+		}
+		if ts.Get() != value {
+			t.Fatalf("stored value = %v, want %v", ts.Get(), value)
+		}
+		if err := s.JawsSet(nil, float64(value)); !errors.Is(err, jaws.ErrValueUnchanged) {
+			t.Fatalf("JawsSet(canonical value) = %v, want ErrValueUnchanged", err)
+		}
+	})
+}
+
 // Test_setterFloat64_sanitizesUntrustedInput covers the float-from-client guard:
 // non-finite values are rejected for every numeric type and out-of-range values
 // are rejected before the (otherwise wrapping) float->int conversion. The bound

--- a/lib/bind/setterfloat64_test.go
+++ b/lib/bind/setterfloat64_test.go
@@ -112,6 +112,34 @@ func Test_setterFloat64_conversionSignalsCanonicalChange(t *testing.T) {
 			t.Fatalf("JawsSet(canonical value) = %v, want ErrValueUnchanged", err)
 		}
 	})
+
+	t.Run("negative int truncation", func(t *testing.T) {
+		ts := newTestSetter(-1)
+		s := MakeSetterFloat64(ts)
+		if err := s.JawsSet(nil, -1.9); err != nil {
+			t.Fatalf("JawsSet(-1.9): %v", err)
+		}
+		if ts.Get() != -1 {
+			t.Fatalf("stored value = %d, want -1", ts.Get())
+		}
+		if err := s.JawsSet(nil, -1); !errors.Is(err, jaws.ErrValueUnchanged) {
+			t.Fatalf("JawsSet(-1) = %v, want ErrValueUnchanged", err)
+		}
+	})
+
+	t.Run("uint truncation", func(t *testing.T) {
+		ts := newTestSetter(uint(2))
+		s := MakeSetterFloat64(ts)
+		if err := s.JawsSet(nil, 2.9); err != nil {
+			t.Fatalf("JawsSet(2.9): %v", err)
+		}
+		if ts.Get() != 2 {
+			t.Fatalf("stored value = %d, want 2", ts.Get())
+		}
+		if err := s.JawsSet(nil, 2); !errors.Is(err, jaws.ErrValueUnchanged) {
+			t.Fatalf("JawsSet(2) = %v, want ErrValueUnchanged", err)
+		}
+	})
 }
 
 // Test_setterFloat64_sanitizesUntrustedInput covers the float-from-client guard:

--- a/lib/ui/input_widgets_test.go
+++ b/lib/ui/input_widgets_test.go
@@ -178,6 +178,84 @@ func TestInputFloatWidgets(t *testing.T) {
 	mustMatch(t, `^<input id="Jid\.[0-9]+" type="range" value="3.4">$`, got)
 }
 
+// TestInputFloat_ReconcilesConvertedValues verifies that number inputs receive
+// the canonical server value when a numeric adapter truncates or rounds an input
+// to the value that was already stored.
+func TestInputFloat_ReconcilesConvertedValues(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		want       string
+		makeSetter func() bind.Setter[float64]
+	}{
+		{
+			name:  "int truncation",
+			input: "1.9",
+			want:  "1",
+			makeSetter: func() bind.Setter[float64] {
+				var mu deadlock.Mutex
+				value := 1
+				return bind.MakeSetterFloat64(bind.New(&mu, &value))
+			},
+		},
+		{
+			name:  "float32 rounding",
+			input: "0.1",
+			want:  "0.10000000149011612",
+			makeSetter: func() bind.Setter[float64] {
+				var mu deadlock.Mutex
+				value := float32(0.1)
+				return bind.MakeSetterFloat64(bind.New(&mu, &value))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jw, err := jaws.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(jw.Close)
+			go jw.Serve()
+
+			tr := jawstest.NewTestRequest(jw, nil)
+			defer func() {
+				tr.Close()
+				<-tr.DoneCh
+			}()
+			<-tr.ReadyCh
+
+			number := NewNumber(tt.makeSetter())
+			elem := tr.NewElement(number)
+			var buf strings.Builder
+			if err = elem.JawsRender(&buf, []any{`step="any"`}); err != nil {
+				t.Fatal(err)
+			}
+			if err = jaws.CallEventHandlers(elem.UI(), elem, what.Input, tt.input); err != nil {
+				t.Fatalf("input %q: %v", tt.input, err)
+			}
+
+			select {
+			case msg := <-tr.OutCh:
+				if msg.What != what.Value || msg.Jid != elem.Jid() || msg.Data != tt.want {
+					t.Fatalf("update = {%v %v %q}, want {%v %v %q}", msg.What, msg.Jid, msg.Data, what.Value, elem.Jid(), tt.want)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("no corrective value update received")
+			}
+
+			if err = jaws.CallEventHandlers(elem.UI(), elem, what.Input, tt.want); err != nil {
+				t.Fatalf("unchanged input %q: %v", tt.want, err)
+			}
+			select {
+			case msg := <-tr.OutCh:
+				t.Fatalf("unchanged input produced update {%v %v %q}", msg.What, msg.Jid, msg.Data)
+			case <-time.After(300 * time.Millisecond):
+			}
+		})
+	}
+}
+
 // TestInputFloat_RejectsNonFinite verifies that NaN/Inf from the untrusted browser
 // (which strconv.ParseFloat accepts) is rejected and never reaches the bound value.
 func TestInputFloat_RejectsNonFinite(t *testing.T) {

--- a/lib/ui/input_widgets_test.go
+++ b/lib/ui/input_widgets_test.go
@@ -178,9 +178,9 @@ func TestInputFloatWidgets(t *testing.T) {
 	mustMatch(t, `^<input id="Jid\.[0-9]+" type="range" value="3.4">$`, got)
 }
 
-// TestInputFloat_ReconcilesConvertedValues verifies that number inputs receive
-// the canonical server value when a numeric adapter truncates or rounds an input
-// to the value that was already stored.
+// TestInputFloat_ReconcilesConvertedValues verifies that number and range inputs
+// receive the canonical server value when a numeric adapter truncates or rounds
+// an input to the value that was already stored.
 func TestInputFloat_ReconcilesConvertedValues(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -209,50 +209,60 @@ func TestInputFloat_ReconcilesConvertedValues(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			jw, err := jaws.New()
-			if err != nil {
-				t.Fatal(err)
-			}
-			t.Cleanup(jw.Close)
-			go jw.Serve()
-
-			tr := jawstest.NewTestRequest(jw, nil)
-			defer func() {
-				tr.Close()
-				<-tr.DoneCh
-			}()
-			<-tr.ReadyCh
-
-			number := NewNumber(tt.makeSetter())
-			elem := tr.NewElement(number)
-			var buf strings.Builder
-			if err = elem.JawsRender(&buf, []any{`step="any"`}); err != nil {
-				t.Fatal(err)
-			}
-			if err = jaws.CallEventHandlers(elem.UI(), elem, what.Input, tt.input); err != nil {
-				t.Fatalf("input %q: %v", tt.input, err)
-			}
-
-			select {
-			case msg := <-tr.OutCh:
-				if msg.What != what.Value || msg.Jid != elem.Jid() || msg.Data != tt.want {
-					t.Fatalf("update = {%v %v %q}, want {%v %v %q}", msg.What, msg.Jid, msg.Data, what.Value, elem.Jid(), tt.want)
+	// Number and Range embed the same InputFloat, so both must reconcile.
+	widgets := []struct {
+		kind string
+		make func(bind.Setter[float64]) jaws.UI
+	}{
+		{"number", func(s bind.Setter[float64]) jaws.UI { return NewNumber(s) }},
+		{"range", func(s bind.Setter[float64]) jaws.UI { return NewRange(s) }},
+	}
+	for _, w := range widgets {
+		for _, tt := range tests {
+			t.Run(w.kind+"/"+tt.name, func(t *testing.T) {
+				jw, err := jaws.New()
+				if err != nil {
+					t.Fatal(err)
 				}
-			case <-time.After(time.Second):
-				t.Fatal("no corrective value update received")
-			}
+				t.Cleanup(jw.Close)
+				go jw.Serve()
 
-			if err = jaws.CallEventHandlers(elem.UI(), elem, what.Input, tt.want); err != nil {
-				t.Fatalf("unchanged input %q: %v", tt.want, err)
-			}
-			select {
-			case msg := <-tr.OutCh:
-				t.Fatalf("unchanged input produced update {%v %v %q}", msg.What, msg.Jid, msg.Data)
-			case <-time.After(300 * time.Millisecond):
-			}
-		})
+				tr := jawstest.NewTestRequest(jw, nil)
+				defer func() {
+					tr.Close()
+					<-tr.DoneCh
+				}()
+				<-tr.ReadyCh
+
+				widget := w.make(tt.makeSetter())
+				elem := tr.NewElement(widget)
+				var buf strings.Builder
+				if err = elem.JawsRender(&buf, []any{`step="any"`}); err != nil {
+					t.Fatal(err)
+				}
+				if err = jaws.CallEventHandlers(elem.UI(), elem, what.Input, tt.input); err != nil {
+					t.Fatalf("input %q: %v", tt.input, err)
+				}
+
+				select {
+				case msg := <-tr.OutCh:
+					if msg.What != what.Value || msg.Jid != elem.Jid() || msg.Data != tt.want {
+						t.Fatalf("update = {%v %v %q}, want {%v %v %q}", msg.What, msg.Jid, msg.Data, what.Value, elem.Jid(), tt.want)
+					}
+				case <-time.After(time.Second):
+					t.Fatal("no corrective value update received")
+				}
+
+				if err = jaws.CallEventHandlers(elem.UI(), elem, what.Input, tt.want); err != nil {
+					t.Fatalf("unchanged input %q: %v", tt.want, err)
+				}
+				select {
+				case msg := <-tr.OutCh:
+					t.Fatalf("unchanged input produced update {%v %v %q}", msg.What, msg.Jid, msg.Data)
+				case <-time.After(300 * time.Millisecond):
+				}
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- treat conversion-adjusted numeric adapter no-ops as successful changes
- reconcile number inputs after integer truncation and float32 rounding
- preserve redundant-update suppression for canonical unchanged values
- document the adapter behavior

Fixes #176

## Testing

- go generate ./...
- go vet ./...
- gofmt / gofumpt checks
- staticcheck ./...
- golangci-lint run ./...
- gosec ./...
- JAWS_REQUIRE_NODE=1 go test -race -coverprofile=/private/tmp/jaws-176-coverage.out ./...
- go build ./...
- GOOS=linux GOARCH=386 CGO_ENABLED=0 go test -c ./lib/bind (cross-compile; Linux CI executes the 386 tests)