### PR TITLE
fix(ui): render whole-page Handler dot as template data, not a tag

### DIFF
--- a/lib/ui/handler.go
+++ b/lib/ui/handler.go
@@ -24,6 +24,9 @@ type pageTemplate struct {
 	Template
 }
 
+// The per-request page UI is a *pageTemplate; see [uiHandler.ServeHTTP].
+var _ jaws.UI = (*pageTemplate)(nil)
+
 // JawsUpdate is a no-op because a page-level template is render-only: the
 // embedded [Template.JawsUpdate] would re-render the entire document into itself
 // when OuterHTMLTag is set, so it is deliberately silenced here.
@@ -68,7 +71,13 @@ func (h uiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	rq := h.NewRequest(r)
 	sr := &statusRecorder{ResponseWriter: w}
 	rw := RequestWriter{Request: rq, Writer: sr}
-	if err := rw.NewUI(h.Template); err != nil {
+	// Render through a fresh per-request pointer so the UI is comparable as a map
+	// key regardless of the page dot: ordinary html/template data such as a slice
+	// or map is not usable as a tag and would fail the runtime comparability check
+	// in Request.NewElement if a bare pageTemplate value (whose Dot is any) were
+	// used. The pointer identity is always comparable and fresh per request.
+	pt := h.Template
+	if err := rw.NewUI(&pt); err != nil {
 		_ = h.Log(err)
 		// A failure before any output (for example a missing template) can still
 		// become a proper error response; once bytes have been written the status

--- a/lib/ui/handler.go
+++ b/lib/ui/handler.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"html/template"
+	"io"
 	"net/http"
 
 	"github.com/linkdata/jaws"
@@ -27,10 +29,55 @@ type pageTemplate struct {
 // when OuterHTMLTag is set, so it is deliberately silenced here.
 func (pageTemplate) JawsUpdate(*jaws.Element) {}
 
+// JawsRender renders the whole-page template, looking it up and executing it
+// directly.
+//
+// Unlike the embedded [Template], the page dot is ordinary [html/template] data
+// and is never treated as a JaWS tag: there is no tag expansion, no generated
+// wrapper element, and [pageTemplate.JawsUpdate] is a no-op. Because the page
+// element cannot re-render itself, deriving tag identity from the page dot would
+// serve no purpose; nested UI created during execution registers its own tags
+// independently.
+func (pt pageTemplate) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err error) {
+	var lookedUp *template.Template
+	if lookedUp, err = pt.lookup(elem); err == nil {
+		err = pt.execute(elem, w, lookedUp)
+	}
+	return
+}
+
+// statusRecorder wraps an [http.ResponseWriter] to record whether any response
+// bytes have been committed, so [uiHandler.ServeHTTP] can still send a 500 for a
+// render failure that occurred before any output was written.
+type statusRecorder struct {
+	http.ResponseWriter
+	wrote bool
+}
+
+func (sr *statusRecorder) Write(p []byte) (int, error) {
+	sr.wrote = true
+	return sr.ResponseWriter.Write(p)
+}
+
+func (sr *statusRecorder) WriteHeader(code int) {
+	sr.wrote = true
+	sr.ResponseWriter.WriteHeader(code)
+}
+
 func (h uiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	rq := h.NewRequest(r)
-	rw := RequestWriter{Request: rq, Writer: w}
-	_ = h.Log(rw.NewUI(h.Template))
+	sr := &statusRecorder{ResponseWriter: w}
+	rw := RequestWriter{Request: rq, Writer: sr}
+	if err := rw.NewUI(h.Template); err != nil {
+		_ = h.Log(err)
+		// A failure before any output (for example a missing template) can still
+		// become a proper error response; once bytes have been written the status
+		// is already committed and the partial body is left as-is, matching the
+		// best-effort execution semantics documented on Template.
+		if !sr.wrote {
+			http.Error(sr, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		}
+	}
 }
 
 // Handler returns an http.Handler that renders the named template.

--- a/lib/ui/handler_178_test.go
+++ b/lib/ui/handler_178_test.go
@@ -1,0 +1,157 @@
+package ui
+
+import (
+	"bytes"
+	"errors"
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/linkdata/jaws"
+	"github.com/linkdata/jaws/lib/tag"
+)
+
+// TestHandler_StringDotRenders is the regression test for issue #178: a plain
+// string page dot must render as ordinary html/template data rather than being
+// rejected as an illegal JaWS tag, which previously produced a blank HTTP 200.
+func TestHandler_StringDotRenders(t *testing.T) {
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+	_ = jw.AddTemplateLookuper(template.Must(template.New("page").Parse(`hello {{.Dot}}`)))
+
+	rr := httptest.NewRecorder()
+	Handler(jw, "page", "world").ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if got := rr.Body.String(); got != "hello world" {
+		t.Fatalf("body = %q, want %q", got, "hello world")
+	}
+}
+
+type pageDot struct {
+	Field string
+}
+
+// TestHandler_StructDotRenders verifies that a non-tag struct-pointer page dot
+// (illegal as a tag) renders normally through the page handler.
+func TestHandler_StructDotRenders(t *testing.T) {
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+	_ = jw.AddTemplateLookuper(template.Must(template.New("page").Parse(`value={{.Dot.Field}}`)))
+
+	rr := httptest.NewRecorder()
+	Handler(jw, "page", &pageDot{Field: "x"}).ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if got := rr.Body.String(); got != "value=x" {
+		t.Fatalf("body = %q, want %q", got, "value=x")
+	}
+}
+
+// TestHandler_MissingTemplateReturns500 verifies that a render failure occurring
+// before any output (an unresolved template) produces an observable HTTP 500 and
+// logs the error, rather than a blank HTTP 200.
+func TestHandler_MissingTemplateReturns500(t *testing.T) {
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+	logger := new(templateLogger)
+	jw.Logger = logger
+
+	rr := httptest.NewRecorder()
+	Handler(jw, "nope", "x").ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusInternalServerError)
+	}
+	if rr.Body.Len() == 0 {
+		t.Fatal("expected a non-empty error body")
+	}
+	if len(logger.errors) != 1 || !errors.Is(logger.errors[0], ErrMissingTemplate) {
+		t.Fatalf("logged errors = %#v, want one %v", logger.errors, ErrMissingTemplate)
+	}
+}
+
+// TestHandler_ExecuteErrorAfterOutputKeepsPartialBody verifies the best-effort
+// streaming contract: once bytes have been committed, a later execution error
+// leaves the partial body and its already-sent 200 status in place.
+func TestHandler_ExecuteErrorAfterOutputKeepsPartialBody(t *testing.T) {
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+	logger := new(templateLogger)
+	jw.Logger = logger
+
+	renderErr := errors.New("boom")
+	_ = jw.AddTemplateLookuper(template.Must(template.New("page").Funcs(template.FuncMap{
+		"fail": func() (string, error) { return "", renderErr },
+	}).Parse(`prefix{{fail}}`)))
+
+	rr := httptest.NewRecorder()
+	Handler(jw, "page", "x").ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (partial body already committed)", rr.Code, http.StatusOK)
+	}
+	if got := rr.Body.String(); got != "prefix" {
+		t.Fatalf("body = %q, want %q", got, "prefix")
+	}
+	if len(logger.errors) != 1 || !errors.Is(logger.errors[0], renderErr) {
+		t.Fatalf("logged errors = %#v, want one %v", logger.errors, renderErr)
+	}
+}
+
+// TestHandler_PartialTemplateStillRejectsStringDot documents the intended
+// contrast with the page handler: a partial ui.Template continues to derive tag
+// identity from its dot, so a plain string dot is still rejected as an illegal
+// tag.
+func TestHandler_PartialTemplateStillRejectsStringDot(t *testing.T) {
+	jw, rq := newCoreRequest(t)
+	_ = jw.AddTemplateLookuper(template.Must(template.New("partial").Parse(`{{.Dot}}`)))
+
+	var sb bytes.Buffer
+	rw := RequestWriter{Request: rq, Writer: &sb}
+	if err := rw.Template("div", "partial", "plain-string-dot"); !errors.Is(err, tag.ErrIllegalTagType) {
+		t.Fatalf("partial template err = %v, want %v", err, tag.ErrIllegalTagType)
+	}
+}
+
+// TestHandler_TagValuedDotStillRenders guards that a valid tag value as the page
+// dot keeps rendering (its Dot passthrough is unchanged; only the now-inert tag
+// registration is skipped).
+func TestHandler_TagValuedDotStillRenders(t *testing.T) {
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+	_ = jw.AddTemplateLookuper(template.Must(template.New("page").Parse(
+		`<html><body>{{with $.Dot}}<span>{{.}}</span>{{end}}</body></html>`,
+	)))
+
+	rr := httptest.NewRecorder()
+	Handler(jw, "page", tag.Tag("ok")).ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if got := rr.Body.String(); !strings.Contains(got, `<span>ok</span>`) {
+		t.Fatalf("body = %q, want it to contain <span>ok</span>", got)
+	}
+}

--- a/lib/ui/handler_178_test.go
+++ b/lib/ui/handler_178_test.go
@@ -6,16 +6,14 @@ import (
 	"html/template"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/linkdata/jaws"
 	"github.com/linkdata/jaws/lib/tag"
 )
 
-// TestHandler_StringDotRenders is the regression test for issue #178: a plain
-// string page dot must render as ordinary html/template data rather than being
-// rejected as an illegal JaWS tag, which previously produced a blank HTTP 200.
+// TestHandler_StringDotRenders renders a plain string page dot as ordinary
+// html/template data (issue #178).
 func TestHandler_StringDotRenders(t *testing.T) {
 	jw, err := jaws.New()
 	if err != nil {
@@ -39,8 +37,7 @@ type pageDot struct {
 	Field string
 }
 
-// TestHandler_StructDotRenders verifies that a non-tag struct-pointer page dot
-// (illegal as a tag) renders normally through the page handler.
+// TestHandler_StructDotRenders renders a struct-pointer page dot.
 func TestHandler_StructDotRenders(t *testing.T) {
 	jw, err := jaws.New()
 	if err != nil {
@@ -60,9 +57,45 @@ func TestHandler_StructDotRenders(t *testing.T) {
 	}
 }
 
-// TestHandler_MissingTemplateReturns500 verifies that a render failure occurring
-// before any output (an unresolved template) produces an observable HTTP 500 and
-// logs the error, rather than a blank HTTP 200.
+// TestHandler_NonComparableDotRenders renders slice and map page dots. Such
+// values are legal html/template data but are not usable as tags and are not
+// comparable as map keys, so the per-request pointer wrapper is required to keep
+// the UI comparable for Request.NewElement's -race comparability check.
+func TestHandler_NonComparableDotRenders(t *testing.T) {
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+	_ = jw.AddTemplateLookuper(template.Must(template.New("page").Parse(`{{range .Dot}}{{.}}{{end}}`)))
+
+	for _, tc := range []struct {
+		name string
+		dot  any
+		want string
+	}{
+		{"slice", []string{"a", "b", "c"}, "abc"},
+		{"map", map[string]string{"only": "x"}, "x"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Guard that the dot genuinely exercises the non-comparable path.
+			if tag.NewErrNotComparable(tc.dot) == nil {
+				t.Fatalf("dot %T is comparable; test does not exercise the fix", tc.dot)
+			}
+			rr := httptest.NewRecorder()
+			Handler(jw, "page", tc.dot).ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+			}
+			if got := rr.Body.String(); got != tc.want {
+				t.Fatalf("body = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHandler_MissingTemplateReturns500 checks that a render failure before any
+// output (an unresolved template) returns HTTP 500 and logs the error.
 func TestHandler_MissingTemplateReturns500(t *testing.T) {
 	jw, err := jaws.New()
 	if err != nil {
@@ -86,9 +119,9 @@ func TestHandler_MissingTemplateReturns500(t *testing.T) {
 	}
 }
 
-// TestHandler_ExecuteErrorAfterOutputKeepsPartialBody verifies the best-effort
-// streaming contract: once bytes have been committed, a later execution error
-// leaves the partial body and its already-sent 200 status in place.
+// TestHandler_ExecuteErrorAfterOutputKeepsPartialBody checks the best-effort
+// execution contract: once output has been written, a later execution error
+// leaves the partial body and its committed 200 status in place.
 func TestHandler_ExecuteErrorAfterOutputKeepsPartialBody(t *testing.T) {
 	jw, err := jaws.New()
 	if err != nil {
@@ -117,10 +150,9 @@ func TestHandler_ExecuteErrorAfterOutputKeepsPartialBody(t *testing.T) {
 	}
 }
 
-// TestHandler_PartialTemplateStillRejectsStringDot documents the intended
-// contrast with the page handler: a partial ui.Template continues to derive tag
-// identity from its dot, so a plain string dot is still rejected as an illegal
-// tag.
+// TestHandler_PartialTemplateStillRejectsStringDot documents that a partial
+// ui.Template derives tag identity from its dot, so a plain string dot is
+// rejected as an illegal tag while the whole-page Handler accepts one.
 func TestHandler_PartialTemplateStillRejectsStringDot(t *testing.T) {
 	jw, rq := newCoreRequest(t)
 	_ = jw.AddTemplateLookuper(template.Must(template.New("partial").Parse(`{{.Dot}}`)))
@@ -129,29 +161,5 @@ func TestHandler_PartialTemplateStillRejectsStringDot(t *testing.T) {
 	rw := RequestWriter{Request: rq, Writer: &sb}
 	if err := rw.Template("div", "partial", "plain-string-dot"); !errors.Is(err, tag.ErrIllegalTagType) {
 		t.Fatalf("partial template err = %v, want %v", err, tag.ErrIllegalTagType)
-	}
-}
-
-// TestHandler_TagValuedDotStillRenders guards that a valid tag value as the page
-// dot keeps rendering (its Dot passthrough is unchanged; only the now-inert tag
-// registration is skipped).
-func TestHandler_TagValuedDotStillRenders(t *testing.T) {
-	jw, err := jaws.New()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer jw.Close()
-	_ = jw.AddTemplateLookuper(template.Must(template.New("page").Parse(
-		`<html><body>{{with $.Dot}}<span>{{.}}</span>{{end}}</body></html>`,
-	)))
-
-	rr := httptest.NewRecorder()
-	Handler(jw, "page", tag.Tag("ok")).ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
-
-	if rr.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
-	}
-	if got := rr.Body.String(); !strings.Contains(got, `<span>ok</span>`) {
-		t.Fatalf("body = %q, want it to contain <span>ok</span>", got)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #178. `ui.Handler(jw, name, dot)` documents that each request renders the named template with `dot` exposed through `With.Dot`, with no tag-eligibility restriction. In practice a primitive `dot` such as a string produced **HTTP 200 with an empty body**.

Whole-page rendering flowed through `Template.render`, which unconditionally tag-expands `Dot`. A string is rejected with `tag.ErrIllegalTagType`, so `render` returned before writing anything and `ServeHTTP` logged-and-discarded the error.

## Changes

- **Page dot is no longer a tag.** `pageTemplate` gets its own `JawsRender` that looks up and executes the template directly (reusing `Template.lookup`/`Template.execute`), bypassing tag expansion. The page element cannot re-render itself — its `JawsUpdate` is a deliberate no-op — so deriving tag identity from the page dot was always inert. Partial `ui.Template` values are untouched and keep deriving tag identity from their dot.
- **Render failures are observable.** `ServeHTTP` wraps the `ResponseWriter` in a small recorder; a failure before any output (e.g. a missing template) now returns a clean `500` instead of a blank `200`. Once bytes are committed the partial body is left as-is, matching the best-effort execution semantics documented on `Template`.

## Acceptance criteria

- [x] `ui.Handler` accepts ordinary `html/template` data, including strings.
- [x] Whole-page rendering does not derive tag identity from the page dot.
- [x] Render failures produce observable HTTP error behavior rather than a blank 200.
- [x] Preserve partial `ui.Template` tag behavior.
- [x] Add public-API regression tests under `go test -race`.

## Testing

- `go test -race ./lib/ui/` and `go test -race ./...` — pass
- `go vet`, `gofmt -l`, `gofumpt -l`, `staticcheck ./lib/ui/` — clean
- `go test -cover ./lib/ui/` — 100.0% of statements