### PR TITLE
fix: WsMsg.FillAlert panics on nil error (#180)

### DIFF
--- a/lib/wire/wsmsg.go
+++ b/lib/wire/wsmsg.go
@@ -185,8 +185,14 @@ func jsonUnquoteString(s string) (out string, ok bool) {
 }
 
 // FillAlert replaces m with an escaped danger alert for err.
+//
+// A nil err yields a danger alert with an empty message rather than panicking.
 func (m *WsMsg) FillAlert(err error) {
+	var s string
+	if err != nil {
+		s = err.Error()
+	}
 	m.Jid = 0
 	m.What = what.Alert
-	m.Data = "danger\n" + html.EscapeString(err.Error())
+	m.Data = "danger\n" + html.EscapeString(s)
 }

--- a/lib/wire/wsmsg_test.go
+++ b/lib/wire/wsmsg_test.go
@@ -412,6 +412,7 @@ func Test_wsMsg_FillAlert(t *testing.T) {
 		err  error
 		want string
 	}{
+		{"nil error", nil, "Alert\t\t\"danger\\n\"\n"},
 		{"event unhandled", errors.New("event unhandled"), "Alert\t\t\"danger\\nevent unhandled\"\n"},
 		{"escape error text", fooError, "Alert\t\t\"danger\\n&lt;&#34;\"\n"},
 	}


### PR DESCRIPTION
## Summary

`wire.WsMsg.FillAlert(nil)` panicked because it called `err.Error()` unconditionally. Optional-error paths could therefore crash while attempting to construct an alert.

This treats a nil `err` as an empty message, producing a deterministic `danger` alert (`"danger\n"`) instead of panicking, and documents the behavior in the doc comment.

## Changes

- `lib/wire/wsmsg.go`: guard the nil error in `FillAlert`; document that a nil `err` yields a danger alert with an empty message.
- `lib/wire/wsmsg_test.go`: add a `nil error` case to the table-driven test alongside the existing escaping cases.

## Acceptance criteria

- [x] `FillAlert(nil)` does not panic.
- [x] Nil behavior is deterministic and documented.
- [x] A regression test covers nil and preserves escaping for non-nil errors.

## Verification

- `gofmt`/`gofumpt`/`staticcheck` clean on touched files
- `go vet ./lib/wire/` clean
- `go test -race ./...` passes

Fixes #180