### PR TITLE
fix: truncate inbound Set/Call data at first tab in wire.Parse

### DIFF
--- a/lib/wire/wsmsg.go
+++ b/lib/wire/wsmsg.go
@@ -142,7 +142,16 @@ func Parse(txt []byte) (WsMsg, bool) {
 				// txt[0:nl1] ... txt[nl1+1 : nl2] ... txt[nl2+1:len(txt)-1] ... \n
 				if wht := what.Parse(string(txt[0:nl1])); wht.IsValid() {
 					if id := jid.ParseString(string(txt[nl1+1 : nl2])); id.IsValid() {
-						data := string(txt[nl2+1 : len(txt)-1])
+						raw := txt[nl2+1 : len(txt)-1]
+						if wht == what.Set || wht == what.Call {
+							// Set and Call data is taken verbatim and is best-effort:
+							// the field ends at the first tab, so drop any tab-separated
+							// suffix an untrusted frame appended past that boundary.
+							if i := bytes.IndexByte(raw, '\t'); i >= 0 {
+								raw = raw[:i]
+							}
+						}
+						data := string(raw)
 						if txt[nl2+1] == '"' && wht != what.Set && wht != what.Call {
 							// The browser encodes this data with JSON.stringify.
 							// strconv.Unquote decodes the common case cheaply and

--- a/lib/wire/wsmsg_test.go
+++ b/lib/wire/wsmsg_test.go
@@ -145,6 +145,33 @@ func Test_wsParse_CompletePasses(t *testing.T) {
 	}
 }
 
+// Test_wsParse_SetCallTruncateAtTab covers the parser contract that inbound Set
+// and Call data ends at the first tab: a tab-separated suffix an untrusted frame
+// appended past the documented boundary must be dropped, leaving only the
+// recoverable prefix. Frames without such a suffix must round-trip unchanged.
+func Test_wsParse_SetCallTruncateAtTab(t *testing.T) {
+	tests := []struct {
+		name string
+		txt  string
+		want WsMsg
+	}{
+		{"set suffix dropped", "Set\tJid.1\tpath=1\textra\n", WsMsg{Jid: jid.Jid(1), What: what.Set, Data: "path=1"}},
+		{"call suffix dropped", "Call\tJid.1\tfn=1\textra\n", WsMsg{Jid: jid.Jid(1), What: what.Call, Data: "fn=1"}},
+		{"set multiple tabs keep prefix", "Set\tJid.2\ta\tb\tc\n", WsMsg{Jid: jid.Jid(2), What: what.Set, Data: "a"}},
+		{"set empty before tab", "Set\tJid.3\t\textra\n", WsMsg{Jid: jid.Jid(3), What: what.Set, Data: ""}},
+		{"set no tab unchanged", "Set\tJid.4\tpath=1\n", WsMsg{Jid: jid.Jid(4), What: what.Set, Data: "path=1"}},
+		{"call no tab unchanged", "Call\tJid.5\tfn=1\n", WsMsg{Jid: jid.Jid(5), What: what.Call, Data: "fn=1"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := Parse([]byte(tt.txt))
+			if !ok || tt.want != got {
+				t.Errorf("Parse(%q): got %+v, %v want %+v", tt.txt, got, ok, tt.want)
+			}
+		})
+	}
+}
+
 func Test_wsParse_IncompleteFails(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary

Fixes #181.

`wire.Parse` documents that inbound `what.Set` and `what.Call` data is best-effort and *ends at the first tab*, but it assigned the entire remainder after the Jid field to `Data`. A tab-separated suffix from an untrusted frame therefore leaked past the documented boundary into Set/Call handling:

```go
got, _ := wire.Parse([]byte("Set\tJid.1\tpath=1\textra\n"))
// before: got.Data == "path=1\textra"
// after:  got.Data == "path=1"
```

## Change

In `Parse`, cut the verbatim Set/Call data field at the first tab before converting it to a string, so only the recoverable prefix survives — matching the parser contract already stated in the doc comment. The cut is done on the byte slice so the discarded suffix is never allocated.

Non-Set/Call frames (JSON-quoted or verbatim) and tab-free Set/Call frames are untouched, so existing `Append`/`Parse` round trips are unchanged.

## Acceptance criteria

- [x] Set and Call data stop at the first tab.
- [x] Regression tests cover both commands with a tab-separated suffix (`Test_wsParse_SetCallTruncateAtTab`).
- [x] Existing valid append/parse round trips remain unchanged.

## Verification

- `go test -race ./...` (full module) passes.
- `go vet ./lib/wire/...` clean; `gofmt` clean.
- `Fuzz_wsParse` run for 8s with no new failures.