### PR TITLE
fix: require "type/" prefix when matching MIME families in PreloadHTML

### DIFF
--- a/lib/assets/js.go
+++ b/lib/assets/js.go
@@ -58,14 +58,18 @@ func PreloadHTML(urls ...*url.URL) (htmlCode, faviconURL string) {
 			cssurls = append(cssurls, urlstr)
 			continue
 		default:
-			if strings.HasPrefix(mimetype, "image") {
+			// Match MIME families on the "type/" prefix (case-insensitively) so
+			// unrelated types such as "imagery/*" or "fontastic/*" are not mistaken
+			// for "image/*" or "font/*".
+			lowmime := strings.ToLower(mimetype)
+			if strings.HasPrefix(lowmime, "image/") {
 				asattr = "image"
 				if strings.HasPrefix(strings.ToLower(path.Base(u.Path)), "favicon") {
 					favicontype = mimetype
 					faviconURL = urlstr
 					continue
 				}
-			} else if strings.HasPrefix(mimetype, "font") {
+			} else if strings.HasPrefix(lowmime, "font/") {
 				asattr = "font"
 			}
 		}

--- a/lib/assets/js_test.go
+++ b/lib/assets/js_test.go
@@ -165,6 +165,70 @@ func Test_PreloadHTML_MultipleFaviconsLastWins(t *testing.T) {
 	}
 }
 
+// Test_PreloadHTML_MIMEFamilyMatching pins that MIME families are matched on the
+// "type/" prefix case-insensitively. False prefixes such as "imagery/*" and
+// "fontastic/*" must not be mistaken for "image/*" or "font/*", while differently
+// cased valid families such as "IMAGE/*" and "FONT/*" must still be recognized.
+func Test_PreloadHTML_MIMEFamilyMatching(t *testing.T) {
+	// Distinct ".jaws*" extensions keep these process-global registrations from
+	// colliding with real MIME mappings or with other tests in this package.
+	reg := map[string]string{
+		".jawsimagery":   "imagery/not-an-image",
+		".jawsfontastic": "fontastic/not-a-font",
+		".jawsupperimg":  "IMAGE/x-icon",
+		".jawsupperfont": "FONT/woff2",
+	}
+	for ext, typ := range reg {
+		if err := mime.AddExtensionType(ext, typ); err != nil {
+			t.Fatalf("AddExtensionType(%q, %q): %v", ext, typ, err)
+		}
+	}
+
+	mustParseURL := func(urlstr string) *url.URL {
+		u, err := url.Parse(urlstr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return u
+	}
+
+	txt, fav := PreloadHTML(
+		mustParseURL("favicon.jawsimagery"),  // imagery/* is not image/*
+		mustParseURL("brand.jawsfontastic"),  // fontastic/* is not font/*
+		mustParseURL("favicon.jawsupperimg"), // IMAGE/* is image/* (case-insensitive)
+		mustParseURL("brand.jawsupperfont"),  // FONT/* is font/* (case-insensitive)
+	)
+
+	// imagery/* is not an image: it never becomes a favicon and falls through to a
+	// bare preload link carrying only its (non-image) type, with no as="image".
+	wantImagery := `<link rel="preload" href="favicon.jawsimagery" type="imagery/not-an-image">`
+	if !strings.Contains(txt, wantImagery) {
+		t.Errorf("imagery/* preload = missing %q in %q", wantImagery, txt)
+	}
+
+	// fontastic/* is not a font: no as="font" is attached.
+	wantFontastic := `<link rel="preload" href="brand.jawsfontastic" type="fontastic/not-a-font">`
+	if !strings.Contains(txt, wantFontastic) {
+		t.Errorf("fontastic/* preload = missing %q in %q", wantFontastic, txt)
+	}
+
+	// IMAGE/* qualifies as an image, so the favicon-named resource wins the favicon
+	// slot and is emitted as the rel="icon" link.
+	if fav != "favicon.jawsupperimg" {
+		t.Errorf("favicon = %q, want %q", fav, "favicon.jawsupperimg")
+	}
+	wantFaviconLink := `<link rel="icon" type="IMAGE/x-icon" href="favicon.jawsupperimg">`
+	if !strings.Contains(txt, wantFaviconLink) {
+		t.Errorf("case-insensitive favicon = missing %q in %q", wantFaviconLink, txt)
+	}
+
+	// FONT/* qualifies as a font, so it receives as="font".
+	wantUpperFont := `<link rel="preload" href="brand.jawsupperfont" as="font" type="FONT/woff2">`
+	if !strings.Contains(txt, wantUpperFont) {
+		t.Errorf("case-insensitive font preload = missing %q in %q", wantUpperFont, txt)
+	}
+}
+
 func runJawsJSSnippet(t *testing.T, snippet string) string {
 	t.Helper()
 

--- a/lib/assets/js_test.go
+++ b/lib/assets/js_test.go
@@ -103,7 +103,9 @@ func Test_PreloadHTML(t *testing.T) {
 	// regardless of the platform's MIME table.
 	fontMime, _, _ := strings.Cut(mime.TypeByExtension(".woff2"), ";")
 	var wantFontLink string
-	if strings.HasPrefix(fontMime, "font") {
+	// Classify the family exactly as PreloadHTML does (case-insensitive "font/"
+	// prefix) so the expectation matches the code on any platform MIME table.
+	if strings.HasPrefix(strings.ToLower(fontMime), "font/") {
 		wantFontLink = `<link rel="preload" href="someExtraFont.woff2" as="font" type="` + fontMime + `">`
 	} else {
 		// No font/* MIME on this platform: still a preload link, but no as/type.


### PR DESCRIPTION
Fixes #182.

## Problem

`assets.PreloadHTML` classified MIME families with `strings.HasPrefix(mimetype, "image")` and `"font"` rather than the `"image/"` and `"font/"` prefixes, so unrelated types such as `imagery/*` and `fontastic/*` were mistaken for images or fonts. This let non-image resources be emitted as favicons and non-font resources receive font preload metadata. Matching was also case-sensitive, so validly-typed-but-differently-cased resources (`IMAGE/*`, `FONT/*`) were missed.

## Fix

Match on the `"image/"` and `"font/"` prefixes, lowercasing the resolved MIME type first so family matching is case-insensitive. Only genuine `image/*` types now qualify as favicons, and only genuine `font/*` types receive `as="font"` preload handling.

## Tests

Added `Test_PreloadHTML_MIMEFamilyMatching`, which registers `imagery/*`, `fontastic/*`, `IMAGE/*` and `FONT/*` extensions and asserts:

- `imagery/*` is not treated as an image (no favicon, no `as="image"`).
- `fontastic/*` is not treated as a font (no `as="font"`).
- `IMAGE/*` is recognized as an image and its `favicon`-named resource wins the favicon slot.
- `FONT/*` is recognized as a font and receives `as="font"`.

The test fails against the unfixed source and passes with the fix. `go vet` and `go test -race ./lib/assets/` are clean.

Acceptance criteria from the issue:

- [x] Only `image/*` types qualify as favicons.
- [x] Only `font/*` types receive font preload handling.
- [x] Family matching is case-insensitive.
- [x] Add regressions for false prefixes and existing image/font cases.