### PR TITLE
fix: never reuse Request identities, pool only buffers (#195)

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,8 @@ these invariants before relying on a green build alone:
   initial HTTP handler that still holds it.
 * Dirty dispatch expands tags once, targets only elements registered for those
   tags, and does not let one request's queued update reach a finished, unregistered
-  request (whose key is never reassigned to another Request).
+  request (whose key stays reserved, never reassigned to another Request, while it
+  remains reachable).
 * Session grace windows remain deliberate for unclaimed, claimed, failed-upgrade,
   and closed-WebSocket requests.
 * Subsecond `ServeWithTimeout` values are not useful in production. AI-assisted

--- a/README.md
+++ b/README.md
@@ -365,8 +365,11 @@ instead retire a
 non-running Request: its context is canceled, its key becomes unclaimable, and it is
 excluded from `Pending` and `RequestCount`. Retirement preserves the Request's
 identity, Elements and buffers so an initial HTTP handler still holding it can keep
-rendering. In every case a finished key cannot be assigned to another Request while
-the old one remains reachable; no deadline is guaranteed for later reuse.
+rendering. For registered Requests, a finished key is not assigned to another Request
+while the old one remains reachable; no deadline is guaranteed for later reuse. (A
+Request created by `NewRequest` after `Jaws.Close` is never registered and installs no
+tombstone, so two such post-close calls could receive the same key — harmless, since
+neither is claimable.)
 
 `*Request` values are borrowed lifecycle objects. Do not store them in
 application state or pass them to background goroutines; copy the required

--- a/README.md
+++ b/README.md
@@ -358,8 +358,8 @@ to the pool, and its key is reserved until the Request is collected rather than
 reassigned. Completion does not mutate render-visible Element state, so if an
 early `/jaws/<key>` callback claims and tears down a Request whose initial render
 is still in flight, the render is not corrupted (it continues on a now finished,
-unregistered Request). Maintenance or the per-IP limit can instead retire an
-unclaimed Request: its context is canceled, its key becomes unclaimable, and it is
+unregistered Request). Maintenance or the per-IP limit can instead retire a
+non-running Request: its context is canceled, its key becomes unclaimable, and it is
 excluded from `Pending` and `RequestCount`. Retirement preserves the Request's
 identity, Elements and buffers so an initial HTTP handler still holding it can keep
 rendering. In every case a finished key cannot be assigned to another Request while

--- a/README.md
+++ b/README.md
@@ -357,8 +357,10 @@ its WebSocket processing exits: its context is canceled, its buffers are release
 to the pool, and its key is reserved until the Request is collected rather than
 reassigned. Completion does not mutate render-visible Element state, so if an
 early `/jaws/<key>` callback claims and tears down a Request whose initial render
-is still in flight, the render is not corrupted (it continues on a now finished,
-unregistered Request). Maintenance or the per-IP limit can instead retire a
+is still in flight, that render may degrade — its element and tag collections are
+cleared, so later lookups find nothing — but it stays race-safe: no data race, no
+reused identity, and no duplicated element id. Maintenance or the per-IP limit can
+instead retire a
 non-running Request: its context is canceled, its key becomes unclaimable, and it is
 excluded from `Pending` and `RequestCount`. Retirement preserves the Request's
 identity, Elements and buffers so an initial HTTP handler still holding it can keep

--- a/README.md
+++ b/README.md
@@ -373,8 +373,9 @@ An `*Element` belongs to its owning Request and embeds a pointer to it.
 Render-scoped widgets may retain child Elements they create between render and
 update calls within that Request lifecycle, as container helpers do, but should
 access them only from those calls. Do not let an Element escape the Request
-lifecycle or pass it to background work: when the owning Request finishes it is
-unregistered and detached from its Elements, so a retained Element becomes inert.
+lifecycle or pass it to background work: once the owning Request finishes it is
+unregistered, so the Element receives no further broadcasts or updates, though its
+fields are left intact and its methods still operate on the finished Request.
 Request identities are never reused, so a stale Element can never come to
 represent an unrelated connection.
 
@@ -406,11 +407,14 @@ these invariants before relying on a green build alone:
 
 * Lock order stays `Jaws.mu -> Request.mu -> Session.mu`, with `Request.muQueue`
   and element/widget/value locks remaining leaf locks.
-* Request pooling clears keys, elements, tags, sessions, queues, cancellation
-  state, and pending/request maps before a pointer can be reused.
+* Request identities are never reused; only the internal buffers are pooled.
+  Completion releases queued dirt, elements, tags, and messages (clearing through
+  capacity), detaches the session, unregisters the identity, and reserves the key
+  with a tombstone until the Request is collected. It must not mutate render-visible
+  Element state, which a still-running initial renderer may read lock-free.
 * Dirty dispatch expands tags once, targets only elements registered for those
-  tags, and does not let one request's queued update reach a recycled request
-  with a different key.
+  tags, and does not let one request's queued update reach a finished, unregistered
+  request (whose key is never reassigned to another Request).
 * Session grace windows remain deliberate for unclaimed, claimed, failed-upgrade,
   and closed-WebSocket requests.
 * Subsecond `ServeWithTimeout` values are not useful in production. AI-assisted

--- a/README.md
+++ b/README.md
@@ -352,18 +352,18 @@ Every `NewRequest` returns a distinct `*Request` identity that is never reused
 for another connection; only its internal buffers are pooled. While the `Jaws`
 instance is open, `NewRequest` creates a pending request owned by it. `UseRequest`
 is the only operation that claims that pending request for a WebSocket, and it
-also removes the request from the pending set. A Request is not claimable until
-its initial render completes (its initial HTTP request context is canceled when
-the rendering handler returns), so an early `/jaws/<key>` callback that arrives
-mid-render gets a 404 without consuming the key. A claimed Request finishes after
-its WebSocket processing exits: its context is canceled, its buffers are released,
-and its key is reserved until the Request is collected rather than reassigned.
-Maintenance or the per-IP limit can instead retire an unclaimed Request: its
-context is canceled, its key becomes unclaimable, and it is excluded from
-`Pending` and `RequestCount`. Retiring an unclaimed Request does not change its
-identity or Elements while an initial HTTP handler still holds them. In every
-case a finished key cannot be assigned to another Request while the old one
-remains reachable; no deadline is guaranteed for later reuse.
+also removes the request from the pending set. A claimed Request finishes after
+its WebSocket processing exits: its context is canceled, its buffers are released
+to the pool, and its key is reserved until the Request is collected rather than
+reassigned. Completion does not mutate render-visible Element state, so if an
+early `/jaws/<key>` callback claims and tears down a Request whose initial render
+is still in flight, the render is not corrupted (it continues on a now finished,
+unregistered Request). Maintenance or the per-IP limit can instead retire an
+unclaimed Request: its context is canceled, its key becomes unclaimable, and it is
+excluded from `Pending` and `RequestCount`. Retirement preserves the Request's
+identity, Elements and buffers so an initial HTTP handler still holding it can keep
+rendering. In every case a finished key cannot be assigned to another Request while
+the old one remains reachable; no deadline is guaranteed for later reuse.
 
 `*Request` values are borrowed lifecycle objects. Do not store them in
 application state or pass them to background goroutines; copy the required
@@ -408,10 +408,13 @@ these invariants before relying on a green build alone:
 * Lock order stays `Jaws.mu -> Request.mu -> Session.mu`, with `Request.muQueue`
   and element/widget/value locks remaining leaf locks.
 * Request identities are never reused; only the internal buffers are pooled.
-  Completion releases queued dirt, elements, tags, and messages (clearing through
-  capacity), detaches the session, unregisters the identity, and reserves the key
-  with a tombstone until the Request is collected. It must not mutate render-visible
-  Element state, which a still-running initial renderer may read lock-free.
+  Completion (after WebSocket serving) releases queued dirt, elements, tags, and
+  messages, detaches the session, unregisters the identity, and reserves the key
+  with a tombstone until the Request is collected. It clears only live length,
+  relying on the shrink paths to zero vacated entries, and must not mutate
+  render-visible Element state a still-running initial renderer may read lock-free.
+  Non-running retirement instead preserves the Request's Elements and buffers for an
+  initial HTTP handler that still holds it.
 * Dirty dispatch expands tags once, targets only elements registered for those
   tags, and does not let one request's queued update reach a finished, unregistered
   request (whose key is never reassigned to another Request).

--- a/README.md
+++ b/README.md
@@ -348,16 +348,22 @@ updates.
 
 ### Request lifecycle invariants
 
-While the `Jaws` instance is open, `NewRequest` creates a pending request owned
-by it. `UseRequest` is the only operation that claims that pending request for a
-WebSocket, and it also removes the request from the pending set. A claimed
-Request is removed after its WebSocket processing exits. Maintenance or the
-per-IP limit can instead retire an unclaimed Request: its context is canceled,
-its key becomes unclaimable, and it is excluded from `Pending` and
-`RequestCount`. Retiring an unclaimed Request does not change its identity or
-Elements while an initial HTTP handler still holds them. Its key cannot be
-assigned to another Request while the retired Request remains reachable; no
-deadline is guaranteed for later reuse.
+Every `NewRequest` returns a distinct `*Request` identity that is never reused
+for another connection; only its internal buffers are pooled. While the `Jaws`
+instance is open, `NewRequest` creates a pending request owned by it. `UseRequest`
+is the only operation that claims that pending request for a WebSocket, and it
+also removes the request from the pending set. A Request is not claimable until
+its initial render completes (its initial HTTP request context is canceled when
+the rendering handler returns), so an early `/jaws/<key>` callback that arrives
+mid-render gets a 404 without consuming the key. A claimed Request finishes after
+its WebSocket processing exits: its context is canceled, its buffers are released,
+and its key is reserved until the Request is collected rather than reassigned.
+Maintenance or the per-IP limit can instead retire an unclaimed Request: its
+context is canceled, its key becomes unclaimable, and it is excluded from
+`Pending` and `RequestCount`. Retiring an unclaimed Request does not change its
+identity or Elements while an initial HTTP handler still holds them. In every
+case a finished key cannot be assigned to another Request while the old one
+remains reachable; no deadline is guaranteed for later reuse.
 
 `*Request` values are borrowed lifecycle objects. Do not store them in
 application state or pass them to background goroutines; copy the required
@@ -367,9 +373,10 @@ An `*Element` belongs to its owning Request and embeds a pointer to it.
 Render-scoped widgets may retain child Elements they create between render and
 update calls within that Request lifecycle, as container helpers do, but should
 access them only from those calls. Do not let an Element escape the Request
-lifecycle or pass it to background work: when a Request that entered
-`ServeHTTP` returns, it may be placed in an internal pool, and the Element's
-embedded Request pointer may later represent an unrelated connection.
+lifecycle or pass it to background work: when the owning Request finishes it is
+unregistered and detached from its Elements, so a retained Element becomes inert.
+Request identities are never reused, so a stale Element can never come to
+represent an unrelated connection.
 
 Dirtying is two-stage: `Request.Dirty` and `Jaws.Dirty` expand tags and record
 them on the `Jaws` instance, then the serving loop distributes those tags to

--- a/README.md
+++ b/README.md
@@ -355,11 +355,12 @@ is the only operation that claims that pending request for a WebSocket, and it
 also removes the request from the pending set. A claimed Request finishes after
 its WebSocket processing exits: its context is canceled, its buffers are released
 to the pool, and its key is reserved until the Request is collected rather than
-reassigned. Completion does not mutate render-visible Element state, so if an
+reassigned. Completion leaves the lock-free Element fields and the id counter intact, so if an
 early `/jaws/<key>` callback claims and tears down a Request whose initial render
-is still in flight, that render may degrade — its element and tag collections are
-cleared, so later lookups find nothing — but it stays race-safe: no data race, no
-reused identity, and no duplicated element id. Maintenance or the per-IP limit can
+is still in flight, that render may degrade — the elements and tags rendered so far
+are forgotten (a later lookup finds nothing, though newly created elements are
+tracked again) — but it stays race-safe: no data race, no reused identity, and no
+duplicated element id. Maintenance or the per-IP limit can
 instead retire a
 non-running Request: its context is canceled, its key becomes unclaimable, and it is
 excluded from `Pending` and `RequestCount`. Retirement preserves the Request's

--- a/broadcast.go
+++ b/broadcast.go
@@ -39,9 +39,10 @@ func (jw *Jaws) Broadcast(msg wire.Message) {
 	case nil: // send to all active requests
 	case key.Key: // send to the active request with this identity key
 		if dest == 0 {
-			// A recycled producer captured a zeroed key; no live request can match
-			// (keys are always non-zero), so drop it rather than fall through to
-			// tag expansion.
+			// No live Request can have a zero key (a finished Request keeps its
+			// non-zero key but is unregistered, and destKey returns zero for it), so a
+			// zero destination matches nothing; drop it rather than fall through to tag
+			// expansion.
 			return
 		}
 	default:
@@ -163,15 +164,13 @@ func (jw *Jaws) distributeDirt() int {
 
 	// Appending outside jw.mu is deliberately safe:
 	//   - The snapshot includes pending (not-yet-running) Requests; their todoDirt
-	//     buffers until they connect or are recycled (bounded by the request timeout),
+	//     buffers until they connect or finish (bounded by the request timeout),
 	//     so a value mutated in the render-to-connect window is reflected on the first
 	//     update pass.
-	//   - A Request can be recycled between snapshot and append. appendDirtyTags and
-	//     clearLocked both take rq.mu, so there is no data race, and stale tags in a
-	//     reborn Request resolve to nothing in Request.makeUpdateList against its
-	//     freshly emptied tagMap (at worst a redundant re-render). Applying dirt is
-	//     idempotent, so unlike destKey/cancelIfCurrent this path needs no
-	//     key-identity guard.
+	//   - A Request can finish between snapshot and append. appendDirtyTags checks
+	//     rq.registered under rq.mu (which releaseBuffersLocked also holds while
+	//     clearing it), so a finished Request discards the stale tags instead of
+	//     re-materializing storage on a dead identity.
 	for _, rq := range reqs {
 		rq.appendDirtyTags(dirt)
 	}

--- a/element.go
+++ b/element.go
@@ -21,8 +21,10 @@ import (
 // between its render and update calls within the same Request lifecycle, but
 // should access them only from those calls. Do not retain an Element in
 // longer-lived application state or pass it to background work: once the embedded
-// Request finishes it is unregistered and detached from its elements, so a retained
-// Element becomes inert.
+// Request finishes it is unregistered, so the Element receives no further broadcasts
+// or updates, though its fields are left intact and its methods still operate on the
+// now finished Request. Request identities are never reused, so a retained Element
+// can never come to represent an unrelated connection.
 type Element struct {
 	*Request // (read-only) the Request the Element belongs to
 	// internals

--- a/element.go
+++ b/element.go
@@ -20,8 +20,9 @@ import (
 // for that call. A request-scoped widget may retain child Elements it creates
 // between its render and update calls within the same Request lifecycle, but
 // should access them only from those calls. Do not retain an Element in
-// longer-lived application state or pass it to background work: the embedded
-// Request may later be pooled and reused for another connection.
+// longer-lived application state or pass it to background work: once the embedded
+// Request finishes it is unregistered and detached from its elements, so a retained
+// Element becomes inert.
 type Element struct {
 	*Request // (read-only) the Request the Element belongs to
 	// internals

--- a/jaws.go
+++ b/jaws.go
@@ -163,7 +163,7 @@ type Jaws struct {
 	serving                 atomic.Bool
 	defaultAuthOnce         sync.Once    // guards lazy creation of defaultAuthVal
 	defaultAuthVal          *DefaultAuth // shared fail-open Auth; see [Jaws.DefaultAuth]
-	reqPool                 sync.Pool
+	requestBufferPool       sync.Pool    // reusable *requestBuffers; Requests themselves are never pooled or reused
 	serveJS                 *staticserve.StaticServe
 	serveCSS                *staticserve.StaticServe
 	mu                      deadlock.RWMutex // protects following
@@ -184,9 +184,9 @@ type Jaws struct {
 // New allocates a JaWS instance with the default configuration.
 //
 // The returned [Jaws] value is ready for use: static assets are embedded, the
-// broadcast channels and update ticker are allocated and the request pool is
-// primed. You must still start the processing loop with [Jaws.Serve] or
-// [Jaws.ServeWithTimeout] on its own goroutine before broadcasting. Call
+// broadcast channels and update ticker are allocated and the reusable request
+// buffer pool is primed. You must still start the processing loop with [Jaws.Serve]
+// or [Jaws.ServeWithTimeout] on its own goroutine before broadcasting. Call
 // [Jaws.Close] when finished with the instance to free associated resources.
 func New() (jw *Jaws, err error) {
 	var serveJS, serveCSS *staticserve.StaticServe
@@ -214,11 +214,8 @@ func New() (jw *Jaws, err error) {
 			}
 			if err = tmp.GenerateHeadHTML(); err == nil {
 				jw = tmp
-				jw.reqPool.New = func() any {
-					return (&Request{
-						Jaws:   jw,
-						tagMap: make(map[any][]*Element),
-					}).clearLocked()
+				jw.requestBufferPool.New = func() any {
+					return &requestBuffers{tagMap: make(map[any][]*Element)}
 				}
 			}
 		}

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -1826,7 +1826,7 @@ func TestJaws_distributeDirt_AscendingOrder(t *testing.T) {
 	}
 	defer jw.Close()
 
-	rq := &Request{}
+	rq := &Request{registered: true}
 	jw.mu.Lock()
 	jw.requests[1] = rq
 	jw.requestCount++
@@ -2917,6 +2917,7 @@ func newUnpooledBenchRequest(jw *Jaws) (rq *Request) {
 			}
 			rq.mu.Lock()
 			rq.JawsKey = jawsKey
+			rq.registered = true
 			rq.lastWriteSeconds.Store(jw.runtimeSeconds.Load())
 			rq.remoteIP = remoteIP
 			rq.ctx, rq.cancelFn = context.WithCancelCause(jw.BaseContext)
@@ -2934,11 +2935,18 @@ func recycleUnpooledBenchRequest(jw *Jaws, rq *Request) {
 	defer jw.mu.Unlock()
 	rq.mu.Lock()
 	defer rq.mu.Unlock()
-	if rq.JawsKey != 0 {
+	if rq.JawsKey != 0 && jw.requests[rq.JawsKey] == rq {
+		// Model a fully-unpooled design: cancel and unregister, then drop the
+		// Request (and its buffers) for the garbage collector. Nothing is returned
+		// to a pool, so this is the allocation-heavy reference the pooled impl is
+		// compared against.
+		if rq.cancelFn != nil {
+			rq.cancelFn(nil)
+		}
 		jw.removePendingRequestLocked(rq)
 		delete(jw.requests, rq.JawsKey)
 		jw.requestCount--
-		rq.clearLocked()
+		rq.registered = false
 	}
 }
 
@@ -2948,16 +2956,20 @@ func populateBenchRequest(rq *Request, tags []any) {
 	}
 }
 
-// BenchmarkRequestLifecyclePooling compares the current pooled Request lifecycle
-// with a benchmark-only fresh-allocation lifecycle. It isolates the create,
-// optional render-state population and recycle path; it does not measure HTTP or
-// WebSocket serving.
+// BenchmarkRequestLifecyclePooling compares the production Request lifecycle with a
+// benchmark-only fully-unpooled lifecycle. It isolates the create, optional
+// render-state population and recycle path; it does not measure HTTP or WebSocket
+// serving.
 //
-// The impl axis selects pooled (jw.reqPool via NewRequest/recycle) versus a fresh
-// &Request each iteration. The mode axis runs the cycle single-goroutine (serial)
-// or under [testing.B.RunParallel], since a [sync.Pool]'s payoff is a GC-pressure
-// and high-churn effect that a single-goroutine run under-measures. Sub-benchmarks
-// use key=value names so "benchstat -col /impl" pivots pooled against unpooled.
+// The impl axis selects pooled (jw.NewRequest/recycle, which allocates a fresh
+// Request but reuses its buffers from jw.requestBufferPool) versus unpooled (a
+// fresh &Request with freshly allocated buffers each iteration, nothing reused).
+// The mode axis runs the cycle single-goroutine (serial) or under
+// [testing.B.RunParallel], since a [sync.Pool]'s payoff is a GC-pressure and
+// high-churn effect that a single-goroutine run under-measures. Sub-benchmarks use
+// key=value names so "benchstat -col /impl" pivots pooled against unpooled, and
+// running it on this branch versus main pivots the buffer-pool design against the
+// former whole-Request pool.
 func BenchmarkRequestLifecyclePooling(b *testing.B) {
 	for _, c := range []struct {
 		name  string

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -3047,6 +3047,33 @@ func cycleBenchRequest(jw *Jaws, newRq func(*Jaws) *Request, recycle func(*Jaws,
 	runtime.KeepAlive(rq)
 }
 
+// BenchmarkRequestRecycleAfterHighWater measures recycling empty Requests that reuse
+// a pooled buffer previously grown to a high-water element count. Because every
+// buffer-shrink path zeroes vacated entries, completion clears only the live length,
+// so empty recycling must stay flat across the high-water axis rather than rescanning
+// the retained capacity on every cycle.
+func BenchmarkRequestRecycleAfterHighWater(b *testing.B) {
+	for _, hw := range []int{0, 1000, 100000} {
+		b.Run("highwater="+strconv.Itoa(hw), func(b *testing.B) {
+			jw := newBenchPoolJaws(b)
+			// Grow a buffer to the high-water mark, then return it to the pool so the
+			// empty cycles below borrow (and must not rescan) its retained capacity.
+			big := jw.NewRequest(nil)
+			for i := 0; i < hw; i++ {
+				big.NewElement(benchUI{n: i})
+			}
+			jw.recycle(big)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				rq := jw.NewRequest(nil)
+				jw.recycle(rq)
+				runtime.KeepAlive(rq)
+			}
+		})
+	}
+}
+
 func benchmarkSyncSubscription(b *testing.B, jw *Jaws) {
 	b.Helper()
 	for i := 0; i <= cap(jw.subCh); i++ {

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -2693,13 +2693,13 @@ func TestServeHTTP_TailScript_EndpointIsPerRequest(t *testing.T) {
 	is.Equal(w.Code, http.StatusNoContent)
 }
 
-// TestServeHTTP_TailScript_RejectsRecycledKey covers the recycled-request behavior
-// of the /jaws/.tail endpoint: recycling deletes the key from jw.requests, so a tail
-// fetch for the old key misses the map and returns 404, while the reused pooled
-// object drains only its own freshly queued content (its queue was reset by
-// clearLocked), never the recycled request's. This exercises the map-deletion 404
-// and content isolation; the concurrent drain-under-lock guarantee (holding jw.mu
-// across drainTailScript) is exercised separately, under the race detector, by
+// TestServeHTTP_TailScript_RejectsRecycledKey covers the finished-request behavior
+// of the /jaws/.tail endpoint: completion reserves the key with a nil tombstone in
+// jw.requests, so a tail fetch for the old key finds no live Request and returns
+// 404, while a later, distinct request drains only its own freshly queued content,
+// never the finished request's. This exercises the tombstone 404 and content
+// isolation; the concurrent drain-under-lock guarantee (holding jw.mu across
+// drainTailScript) is exercised separately, under the race detector, by
 // TestRequest_TailScriptConcurrentWithRecycle.
 func TestServeHTTP_TailScript_RejectsRecycledKey(t *testing.T) {
 	is := newTestHelper(t)
@@ -2712,23 +2712,22 @@ func TestServeHTTP_TailScript_RejectsRecycledKey(t *testing.T) {
 	stale.NewElement(&testUi{}).SetClass("stale")
 	staleKey := stale.JawsKeyString()
 
-	// Recycle the request and create a new one under a fresh key. The pool typically
-	// hands back the same struct, so the content check below also guards that a
-	// reused object carries none of the recycled request's queued content; it holds
-	// whether or not the pool reused the struct.
+	// Finish the request and create a new one under a fresh key. Identities are never
+	// reused, so rq is a distinct Request; the content check below guards that it
+	// carries none of the finished request's queued content.
 	jw.recycle(stale)
 	rq := jw.NewRequest(hr)
 	rq.NewElement(&testUi{}).SetClass("fresh")
 
-	// Old key was deleted from jw.requests on recycle, so the lookup misses and
-	// nothing is drained.
+	// The old key was tombstoned on completion, so the lookup finds no live Request
+	// and nothing is drained.
 	req := httptest.NewRequest(http.MethodGet, "/jaws/.tail/"+staleKey, nil)
 	req.RemoteAddr = hr.RemoteAddr
 	w := httptest.NewRecorder()
 	jw.ServeHTTP(w, req)
 	is.Equal(w.Code, http.StatusNotFound)
 
-	// The reused request's own tail fetch still returns its own content.
+	// The new request's own tail fetch still returns its own content.
 	req = httptest.NewRequest(http.MethodGet, "/jaws/.tail/"+rq.JawsKeyString(), nil)
 	req.RemoteAddr = hr.RemoteAddr
 	w = httptest.NewRecorder()
@@ -2803,17 +2802,17 @@ func TestJaws_cancelIfCurrent_IgnoresStaleRequest(t *testing.T) {
 	stale := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
 	jawsKey := stale.JawsKey
 
-	// The /jaws/.tail handler snapshots the Request before writing the response;
-	// recycle the snapshot and create a new request so the pool can hand the
-	// stale pointer to a different connection, as can happen before a write
-	// error triggers a cancel.
+	// The /jaws/.tail handler snapshots the Request before writing the response; the
+	// snapshotted Request can finish before a write error triggers a cancel. Finish it
+	// and create another request: cancelIfCurrent must cancel nothing, because the
+	// finished Request is no longer the registered entry for its key.
 	jw.recycle(stale)
 	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
 
 	jw.cancelIfCurrent(jawsKey, stale, errors.New("write failed"))
 
-	// Whether or not the pool reused the object for rq (it normally does here,
-	// which is exactly the stale-cancel scenario), rq must stay live.
+	// rq is a distinct Request (identities are never reused); a stale cancel aimed at
+	// the finished snapshot must not touch it.
 	is.NoErr(rq.Context().Err())
 }
 

--- a/request.go
+++ b/request.go
@@ -177,8 +177,13 @@ func (rq *Request) advanceLastWriteSeconds(now int32) {
 // finished Request stays reachable, since its key is held reserved by a tombstone.
 // After the Request is collected the tombstone is removed and the CSPRNG may
 // eventually reissue that key value to a new Request, which such a stale value could
-// then match. The *Request pointer itself is never reused, so pointer-derived
-// operations never reach a different connection.
+// then match. Two narrower guarantees always hold: the *Request pointer is never
+// reused, so it never aliases another connection, and destKey returns zero once the
+// Request has finished, so it cannot hand back the finished Request's destination.
+// (This is not a blanket "pointer-derived operations are safe" claim: [Request.Dirty]
+// dirties matching Elements on other live Requests by design, and an Alert or
+// Redirect message queued before completion carries a key.Key destination that can
+// itself outlive the Request.)
 func (rq *Request) destKey() (k key.Key) {
 	rq.mu.RLock()
 	if rq.registered {

--- a/request.go
+++ b/request.go
@@ -71,13 +71,16 @@ type requestBuffers struct {
 //
 // A Request pointer is borrowed for the HTTP or WebSocket lifecycle that supplied
 // it. Do not retain it in application state or use it from a background goroutine:
-// when that lifecycle ends the Request finishes — its context is canceled, it is
-// unregistered from the [Jaws] instance, and its reusable buffers are released. Its
-// methods still run on a retained pointer, but the Request no longer receives
-// broadcasts or updates and its collections are empty, so the calls have no useful
-// effect. Background work should instead retain [Request.Context] and, when it must
-// terminate the connection, the cancel function returned while deriving a
-// replacement context through [Request.SetContext].
+// once that lifecycle ends the Request finishes — its context is canceled and it is
+// unregistered from the [Jaws] instance — and its identity is never reused for
+// another connection. Its methods still run on a retained pointer, but the Request
+// receives no further broadcasts or updates, so the calls have no effect on any live
+// connection. (Completion after WebSocket serving additionally releases the reusable
+// buffers to the pool; retirement of an unclaimed Request preserves them so an
+// initial HTTP handler that still holds the pointer can finish rendering.) Background
+// work should instead retain [Request.Context] and, when it must terminate the
+// connection, the cancel function returned while deriving a replacement context
+// through [Request.SetContext].
 //
 // Unlike [Session], whose methods are nil-safe, Request methods are not safe to call on a
 // nil *Request: a Request is always obtained from [Jaws.NewRequest] or [Jaws.UseRequest]
@@ -275,8 +278,12 @@ func (rq *Request) ensureAutoSession(w http.ResponseWriter, r *http.Request) {
 // Elements, Jid counter and render-input fields untouched. The Request keeps its
 // identity key and canceled context, so a pointer retained by the initial renderer
 // or by background work stays permanently bound to this finished lifecycle and is
-// never reused for another connection. The caller must hold rq.mu and ensure no
-// other goroutine is still processing rq.
+// never reused for another connection.
+//
+// The caller must hold rq.mu. The WebSocket processing loop must have exited, but an
+// initial HTTP renderer may still be running concurrently (an early callback can
+// claim and tear down a Request mid-render); that is precisely why this leaves
+// render-visible Element and Jid state untouched and transfers wsQueue under muQueue.
 func (rq *Request) releaseBuffersLocked() (buffers *requestBuffers) {
 	// Cancel first so a retained context observes cancellation, then detach the
 	// Request from its session and unregister its identity.

--- a/request.go
+++ b/request.go
@@ -66,10 +66,10 @@ type requestBuffers struct {
 // Request maintains the state for a JaWS WebSocket connection, and handles processing
 // of events and broadcasts.
 //
-// Each Request has a stable identity that is never reused for another connection:
-// once it finishes, its context stays canceled and identity-targeted operations
-// are never retargeted to a different Request. A pointer retained past its
-// documented lifetime therefore can never alias an unrelated connection.
+// Each Request has a stable identity — the *Request pointer — that is never reused
+// for another connection: once it finishes, its context stays canceled and the
+// pointer is never handed out again, so a pointer retained past its documented
+// lifetime can never alias an unrelated connection.
 //
 // A Request pointer is borrowed for the lifecycle that supplied it — the initial
 // HTTP render (from [Jaws.NewRequest]) or the WebSocket handling (from
@@ -81,12 +81,14 @@ type requestBuffers struct {
 // retired; it is then unregistered, and its identity is never reused for another
 // connection.
 //
-// Because the identity is never reused, a retained pointer can never come to
-// represent a different connection, so identity-targeted operations (updates and
-// broadcasts aimed at this Request) reach nothing once it has finished. This is not
-// a general no-op guarantee: instance-wide calls such as [Request.Dirty] delegate to
-// [Jaws]-wide dirtying and can still update matching Elements on other live Requests.
-// Background work should instead retain [Request.Context] and, when it must terminate
+// Because the pointer is never reused it can never come to represent a different
+// connection, and a broadcast destination resolved from the Request after it has
+// finished (as [Request.Alert] and [Request.Redirect] do) is empty, so such a call
+// reaches nothing. This is not a general no-op guarantee: [Request.Dirty] delegates
+// to [Jaws]-wide dirtying and can still update matching Elements on other live
+// Requests, and an Alert or Redirect queued before completion carries a key value
+// that can outlive the Request and, after that key is later reused, match a different
+// Request. Background work should instead retain [Request.Context] and, when it must terminate
 // the connection, the cancel function returned while deriving a replacement context
 // through [Request.SetContext].
 //

--- a/request.go
+++ b/request.go
@@ -50,10 +50,12 @@ type ConnectFn = func(rq *Request) error
 // requestBuffers holds the reusable per-Request storage: the pending-dirt list,
 // the element list, the tag-to-elements map and the outbound message queue.
 //
-// A [Request] borrows one from [Jaws.requestBufferPool] for its lifetime and
-// returns it when it finishes (see [Request.releaseBuffersLocked]). Pooling the
-// buffers rather than the whole Request keeps allocation low while giving every
-// Request a distinct, never-reused identity.
+// A [Request] borrows one from [Jaws.requestBufferPool] for its lifetime and returns
+// it on completion after WebSocket serving (see [Request.releaseBuffersLocked]); a
+// Request retired while non-running keeps its buffers instead, so an initial HTTP
+// handler that may still be rendering can keep using them. Pooling the buffers rather
+// than the whole Request keeps allocation low while giving every Request a distinct,
+// never-reused identity.
 type requestBuffers struct {
 	todoDirt []any
 	elems    []*Element
@@ -69,17 +71,23 @@ type requestBuffers struct {
 // are never retargeted to a different Request. A pointer retained past its
 // documented lifetime therefore can never alias an unrelated connection.
 //
-// A Request pointer is borrowed for the HTTP or WebSocket lifecycle that supplied
-// it. Do not retain it in application state or use it from a background goroutine:
-// once that lifecycle ends the Request finishes — its context is canceled and it is
-// unregistered from the [Jaws] instance — and its identity is never reused for
-// another connection. Its methods still run on a retained pointer, but the Request
-// receives no further broadcasts or updates, so the calls have no effect on any live
-// connection. (Completion after WebSocket serving additionally releases the reusable
-// buffers to the pool; retirement of an unclaimed Request preserves them so an
-// initial HTTP handler that still holds the pointer can finish rendering.) Background
-// work should instead retain [Request.Context] and, when it must terminate the
-// connection, the cancel function returned while deriving a replacement context
+// A Request pointer is borrowed for the lifecycle that supplied it — the initial
+// HTTP render (from [Jaws.NewRequest]) or the WebSocket handling (from
+// [Jaws.UseRequest]). Do not retain it in application state or use it from a
+// background goroutine; using it past that borrowed lifecycle is unsupported. The
+// end of the initial HTTP render does not by itself finish the Request: it normally
+// stays pending until [Jaws.UseRequest] claims it for the WebSocket. The Request
+// finishes when its WebSocket handling ends, or when a non-running Request is
+// retired; it is then unregistered, and its identity is never reused for another
+// connection.
+//
+// Because the identity is never reused, a retained pointer can never come to
+// represent a different connection, so identity-targeted operations (updates and
+// broadcasts aimed at this Request) reach nothing once it has finished. This is not
+// a general no-op guarantee: instance-wide calls such as [Request.Dirty] delegate to
+// [Jaws]-wide dirtying and can still update matching Elements on other live Requests.
+// Background work should instead retain [Request.Context] and, when it must terminate
+// the connection, the cancel function returned while deriving a replacement context
 // through [Request.SetContext].
 //
 // Unlike [Session], whose methods are nil-safe, Request methods are not safe to call on a
@@ -105,7 +113,7 @@ type Request struct {
 	httpDoneCh       <-chan struct{}         // once claimed, set to http.Request.Context().Done()
 	cancelFn         context.CancelCauseFunc // cancel function
 	connectFn        ConnectFn               // a ConnectFn to call before starting message processing for the Request
-	buffers          *requestBuffers         // reusable storage borrowed from Jaws.requestBufferPool; detached and returned when the Request finishes
+	buffers          *requestBuffers         // reusable storage borrowed from Jaws.requestBufferPool; returned to the pool on completion, kept on retirement
 	elems            []*Element              // our Elements
 	tagMap           map[any][]*Element      // maps tags to Elements
 	muQueue          deadlock.Mutex          // protects wsQueue and tailsent
@@ -741,8 +749,8 @@ func (rq *Request) HasTag(elem *Element, tagValue any) (yes bool) {
 // and re-renders the affected elements. Takes rq.mu.
 //
 // It may run after the caller's dirt snapshot was taken but before rq finished
-// (see distributeDirt). A finished Request has released its buffers, so the tags
-// are discarded rather than re-materializing storage on a dead identity.
+// (see distributeDirt). A finished Request is unregistered (registered is false), so
+// the tags are discarded rather than accumulating on a dead identity.
 func (rq *Request) appendDirtyTags(tags []any) {
 	rq.mu.Lock()
 	if rq.registered {

--- a/request.go
+++ b/request.go
@@ -281,17 +281,21 @@ func (rq *Request) ensureAutoSession(w http.ResponseWriter, r *http.Request) {
 // releaseBuffersLocked detaches the reusable storage from a finished Request and
 // returns it for the caller to return to [Jaws.requestBufferPool].
 //
-// It cancels any live context, detaches the reusable collections, kills any attached
-// session and clears the registered flag. It deliberately leaves the Request's
-// Elements, Jid counter and render-input fields untouched. The Request keeps its
-// identity key and canceled context, so a pointer retained by the initial renderer
-// or by background work stays permanently bound to this finished lifecycle and is
-// never reused for another connection.
+// It cancels any live context, detaches and clears the reusable collections (the
+// element list, tag map, dirt list and message queue), kills any attached session
+// and clears the registered flag. It does NOT mutate the individual Element objects'
+// fields or the Jid counter. The Request keeps its identity key and canceled context,
+// so a pointer retained by the initial renderer or by background work stays
+// permanently bound to this finished lifecycle and is never reused for another
+// connection.
 //
 // The caller must hold rq.mu. The WebSocket processing loop must have exited, but an
 // initial HTTP renderer may still be running concurrently (an early callback can
-// claim and tear down a Request mid-render); that is precisely why this leaves
-// render-visible Element and Jid state untouched and transfers wsQueue under muQueue.
+// claim and tear down a Request mid-render). This is race-safe rather than fully
+// non-destructive: clearing the collections can degrade that render (later
+// GetElements and getElementByJid find nothing), but the Element fields and Jid
+// counter it reads lock-free are left intact and wsQueue is transferred under
+// muQueue, so there is no data race, no reused identity, and no duplicated Jid.
 func (rq *Request) releaseBuffersLocked() (buffers *requestBuffers) {
 	// Cancel first so a retained context observes cancellation, then detach the
 	// Request from its session and unregister its identity.

--- a/request.go
+++ b/request.go
@@ -67,16 +67,17 @@ type requestBuffers struct {
 // Each Request has a stable identity that is never reused for another connection:
 // once it finishes, its context stays canceled and identity-targeted operations
 // are never retargeted to a different Request. A pointer retained past its
-// documented lifetime therefore stays inert rather than aliasing an unrelated
-// connection.
+// documented lifetime therefore can never alias an unrelated connection.
 //
 // A Request pointer is borrowed for the HTTP or WebSocket lifecycle that supplied
 // it. Do not retain it in application state or use it from a background goroutine:
-// when that lifecycle ends the Request finishes — its context is canceled and its
-// reusable buffers are released — so a retained pointer becomes inert (it keeps its
-// identity but is unregistered and empty). Background work should instead retain
-// [Request.Context] and, when it must terminate the connection, the cancel function
-// returned while deriving a replacement context through [Request.SetContext].
+// when that lifecycle ends the Request finishes — its context is canceled, it is
+// unregistered from the [Jaws] instance, and its reusable buffers are released. Its
+// methods still run on a retained pointer, but the Request no longer receives
+// broadcasts or updates and its collections are empty, so the calls have no useful
+// effect. Background work should instead retain [Request.Context] and, when it must
+// terminate the connection, the cancel function returned while deriving a
+// replacement context through [Request.SetContext].
 //
 // Unlike [Session], whose methods are nil-safe, Request methods are not safe to call on a
 // nil *Request: a Request is always obtained from [Jaws.NewRequest] or [Jaws.UseRequest]
@@ -269,12 +270,13 @@ func (rq *Request) ensureAutoSession(w http.ResponseWriter, r *http.Request) {
 // releaseBuffersLocked detaches the reusable storage from a finished Request and
 // returns it for the caller to return to [Jaws.requestBufferPool].
 //
-// It cancels any live context, drops queued dirt and messages, marks every element
-// inert, kills any attached session and clears the registered flag. The Request
-// keeps its identity key and canceled context, so a pointer retained by the
-// initial renderer or by background work stays permanently bound to this finished
-// lifecycle and is never reused for another connection. The caller must hold rq.mu
-// and ensure no other goroutine is still processing rq.
+// It cancels any live context, detaches the reusable collections, kills any attached
+// session and clears the registered flag. It deliberately leaves the Request's
+// Elements, Jid counter and render-input fields untouched. The Request keeps its
+// identity key and canceled context, so a pointer retained by the initial renderer
+// or by background work stays permanently bound to this finished lifecycle and is
+// never reused for another connection. The caller must hold rq.mu and ensure no
+// other goroutine is still processing rq.
 func (rq *Request) releaseBuffersLocked() (buffers *requestBuffers) {
 	// Cancel first so a retained context observes cancellation, then detach the
 	// Request from its session and unregister its identity.
@@ -294,14 +296,16 @@ func (rq *Request) releaseBuffersLocked() (buffers *requestBuffers) {
 	rq.claimed.Store(false)
 	rq.registered = false
 
-	// Detach the reusable collections and hand them to the pool. Clear through
-	// capacity, not just length: a drain may have resliced a buffer to len 0 while
-	// leaving payloads in the unused capacity (see getSendMsgs), and those references
-	// must not be pinned in the pooled backing storage. todoDirt, elems and tagMap are
-	// guarded by rq.mu (held here).
+	// Detach the reusable collections and hand them to the pool. Clear only the live
+	// length: every production path that shrinks a buffer already zeroes the vacated
+	// entries (getSendMsgs and drainTailScript for wsQueue, makeUpdateList for
+	// todoDirt, slices.DeleteFunc for elems), so the unused capacity holds no live
+	// references. Clearing through capacity instead would rescan a pooled buffer's
+	// high-water mark on every recycle — including later empty requests — under
+	// rq.mu/muQueue.
 	buffers = rq.buffers
-	clear(rq.todoDirt[:cap(rq.todoDirt)]) // release tag references before pooling
-	clear(rq.elems[:cap(rq.elems)])       // release *Element references so the pooled array pins nothing
+	clear(rq.todoDirt) // release tag references before pooling
+	clear(rq.elems)    // release *Element references so the pooled array pins nothing
 	clear(rq.tagMap)
 	if buffers != nil {
 		buffers.todoDirt = rq.todoDirt[:0]
@@ -320,7 +324,7 @@ func (rq *Request) releaseBuffersLocked() (buffers *requestBuffers) {
 	// surfacing that message in the next Request that borrows the buffer.
 	rq.muQueue.Lock()
 	rq.tailsent = false
-	clear(rq.wsQueue[:cap(rq.wsQueue)]) // release queued message payloads (incl. drained tail) before pooling
+	clear(rq.wsQueue) // release queued message payloads before pooling
 	if buffers != nil {
 		buffers.wsQueue = rq.wsQueue[:0]
 	}

--- a/request.go
+++ b/request.go
@@ -72,11 +72,11 @@ type requestBuffers struct {
 //
 // A Request pointer is borrowed for the HTTP or WebSocket lifecycle that supplied
 // it. Do not retain it in application state or use it from a background goroutine:
-// a Request that enters [Request.ServeHTTP] may be returned to an internal pool
-// when ServeHTTP returns, and the same pointer may later represent another
-// connection. Background work should retain [Request.Context] and, when it must
-// terminate the connection, the cancel function returned while deriving a
-// replacement context through [Request.SetContext].
+// when that lifecycle ends the Request finishes — its context is canceled and its
+// reusable buffers are released — so a retained pointer becomes inert (it keeps its
+// identity but is unregistered and empty). Background work should instead retain
+// [Request.Context] and, when it must terminate the connection, the cancel function
+// returned while deriving a replacement context through [Request.SetContext].
 //
 // Unlike [Session], whose methods are nil-safe, Request methods are not safe to call on a
 // nil *Request: a Request is always obtained from [Jaws.NewRequest] or [Jaws.UseRequest]
@@ -169,6 +169,25 @@ func (rq *Request) destKey() (k key.Key) {
 	}
 	rq.mu.RUnlock()
 	return
+}
+
+// initialRenderMayBeActiveLocked reports whether the initial HTTP render might
+// still own the Request, meaning it is not yet claimable by its WebSocket.
+//
+// It is true only while the initial request carries a cancelable context that has
+// not been canceled; net/http cancels that context when the rendering handler
+// returns (or the client connection closes), so consulting it at claim time is a
+// deterministic, synchronous "render complete" signal with no watcher goroutine to
+// race. A nil initial request, or one whose context cannot be canceled
+// ([context.Background], as httptest requests use), is treated as having no active
+// render so the Request is immediately claimable. Caller must hold jw.mu; rq.initial
+// is assigned once under jw.mu in getRequestLocked and is not reassigned.
+func (rq *Request) initialRenderMayBeActiveLocked() bool {
+	if rq.initial == nil {
+		return false
+	}
+	ctx := rq.initial.Context()
+	return ctx.Done() != nil && ctx.Err() == nil
 }
 
 // claim binds this request to the HTTP request making the WebSocket call. It
@@ -276,63 +295,54 @@ func (rq *Request) ensureAutoSession(w http.ResponseWriter, r *http.Request) {
 // lifecycle and is never reused for another connection. The caller must hold rq.mu
 // and ensure no other goroutine is still processing rq.
 func (rq *Request) releaseBuffersLocked() (buffers *requestBuffers) {
-	// Cancel first; a retained context observes cancellation regardless of what
-	// happens to the detached buffers below.
+	// Cancel first so a retained context observes cancellation, then detach the
+	// Request from its session and unregister its identity.
+	//
+	// Deliberately do NOT reset lastJid or clear Element.ui/handlers/deleted here.
+	// The Request is never reused, so a stale *Element is unreachable through the
+	// unregistered Request and needs no inerting; and mutating those fields would
+	// race an initial renderer that may still be inside JawsRender (which reads
+	// Element.ui and handlers lock-free) or duplicate an already-streamed Jid if the
+	// renderer keeps allocating. The render-input fields (initial, connectFn,
+	// remoteIP) are likewise preserved; they are collected with the Request.
 	if rq.cancelFn != nil {
 		rq.cancelFn(nil)
 	}
-	rq.lastJid = 0
-	rq.connectFn = nil
-	rq.initial = nil
 	rq.killSessionLocked()
 	rq.running.Store(false)
 	rq.claimed.Store(false)
 	rq.registered = false
-	rq.httpDoneCh = nil
-	clear(rq.todoDirt) // release tag references before pooling; mirrors makeUpdateList
-	rq.todoDirt = rq.todoDirt[:0]
-	rq.remoteIP = netip.Addr{}
-	for _, e := range rq.elems {
-		if e != nil {
-			// Nil the GC-reachable fields and set the deleted guard, which makes the
-			// render, update and queue paths of any retained *Element no-ops (see
-			// [Element.Deleted]). Elements are allocated fresh per newElementLocked and
-			// are never pooled.
-			e.handlers = nil
-			e.ui = nil
-			e.deleted.Store(true)
-		}
-	}
-	clear(rq.elems)
-	rq.elems = rq.elems[:0]
-	// wsQueue and tailsent are guarded by muQueue, not rq.mu. A /jaws/.tail/<key>
-	// fetch (drainTailScript) on a still-pending request runs on a separate HTTP
-	// goroutine holding only muQueue, so take muQueue here to serialize the reset
-	// with it; the documented rq.mu -> muQueue lock order is preserved since we
-	// already hold rq.mu.
-	rq.muQueue.Lock()
-	rq.tailsent = false
-	clear(rq.wsQueue) // release queued message payloads before pooling; mirrors todoDirt/elems above
-	rq.wsQueue = rq.wsQueue[:0]
-	rq.muQueue.Unlock()
-	clear(rq.tagMap)
 
-	// Hand the emptied storage back for reuse and detach it from this Request, so a
-	// pointer retained past the Request's lifetime cannot mutate storage that now
-	// belongs to another Request. Writes guard on the detached (nil) state; see
-	// TagExpanded and appendDirtyTags.
+	// Detach the reusable collections and hand them to the pool. Clearing the entries
+	// first drops the *Element and payload references so the pooled backing storage
+	// pins nothing. todoDirt, elems and tagMap are guarded by rq.mu (held here).
 	buffers = rq.buffers
+	clear(rq.todoDirt) // release tag references before pooling; mirrors makeUpdateList
+	clear(rq.elems)    // release *Element references so the pooled array pins nothing
+	clear(rq.tagMap)
 	if buffers != nil {
-		buffers.todoDirt = rq.todoDirt
-		buffers.elems = rq.elems
+		buffers.todoDirt = rq.todoDirt[:0]
+		buffers.elems = rq.elems[:0]
 		buffers.tagMap = rq.tagMap
-		buffers.wsQueue = rq.wsQueue
 	}
 	rq.buffers = nil
 	rq.todoDirt = nil
 	rq.elems = nil
 	rq.tagMap = nil
+
+	// wsQueue and tailsent are guarded by muQueue, not rq.mu. Hold muQueue across the
+	// clear, transfer AND detach: a concurrent Request.queue (initial renderer) or
+	// drainTailScript fetch takes only muQueue, so releasing it before rq.wsQueue is
+	// detached would let a late append land in the slice already handed to the pool,
+	// surfacing that message in the next Request that borrows the buffer.
+	rq.muQueue.Lock()
+	rq.tailsent = false
+	clear(rq.wsQueue) // release queued message payloads before pooling
+	if buffers != nil {
+		buffers.wsQueue = rq.wsQueue[:0]
+	}
 	rq.wsQueue = nil
+	rq.muQueue.Unlock()
 	return
 }
 

--- a/request.go
+++ b/request.go
@@ -171,25 +171,6 @@ func (rq *Request) destKey() (k key.Key) {
 	return
 }
 
-// initialRenderMayBeActiveLocked reports whether the initial HTTP render might
-// still own the Request, meaning it is not yet claimable by its WebSocket.
-//
-// It is true only while the initial request carries a cancelable context that has
-// not been canceled; net/http cancels that context when the rendering handler
-// returns (or the client connection closes), so consulting it at claim time is a
-// deterministic, synchronous "render complete" signal with no watcher goroutine to
-// race. A nil initial request, or one whose context cannot be canceled
-// ([context.Background], as httptest requests use), is treated as having no active
-// render so the Request is immediately claimable. Caller must hold jw.mu; rq.initial
-// is assigned once under jw.mu in getRequestLocked and is not reassigned.
-func (rq *Request) initialRenderMayBeActiveLocked() bool {
-	if rq.initial == nil {
-		return false
-	}
-	ctx := rq.initial.Context()
-	return ctx.Done() != nil && ctx.Err() == nil
-}
-
 // claim binds this request to the HTTP request making the WebSocket call. It
 // verifies the client IP matches, then atomically marks the request claimed and
 // layers a fresh cancelable context over the current one (preserving any context
@@ -313,12 +294,14 @@ func (rq *Request) releaseBuffersLocked() (buffers *requestBuffers) {
 	rq.claimed.Store(false)
 	rq.registered = false
 
-	// Detach the reusable collections and hand them to the pool. Clearing the entries
-	// first drops the *Element and payload references so the pooled backing storage
-	// pins nothing. todoDirt, elems and tagMap are guarded by rq.mu (held here).
+	// Detach the reusable collections and hand them to the pool. Clear through
+	// capacity, not just length: a drain may have resliced a buffer to len 0 while
+	// leaving payloads in the unused capacity (see getSendMsgs), and those references
+	// must not be pinned in the pooled backing storage. todoDirt, elems and tagMap are
+	// guarded by rq.mu (held here).
 	buffers = rq.buffers
-	clear(rq.todoDirt) // release tag references before pooling; mirrors makeUpdateList
-	clear(rq.elems)    // release *Element references so the pooled array pins nothing
+	clear(rq.todoDirt[:cap(rq.todoDirt)]) // release tag references before pooling
+	clear(rq.elems[:cap(rq.elems)])       // release *Element references so the pooled array pins nothing
 	clear(rq.tagMap)
 	if buffers != nil {
 		buffers.todoDirt = rq.todoDirt[:0]
@@ -337,7 +320,7 @@ func (rq *Request) releaseBuffersLocked() (buffers *requestBuffers) {
 	// surfacing that message in the next Request that borrows the buffer.
 	rq.muQueue.Lock()
 	rq.tailsent = false
-	clear(rq.wsQueue) // release queued message payloads before pooling
+	clear(rq.wsQueue[:cap(rq.wsQueue)]) // release queued message payloads (incl. drained tail) before pooling
 	if buffers != nil {
 		buffers.wsQueue = rq.wsQueue[:0]
 	}

--- a/request.go
+++ b/request.go
@@ -171,9 +171,11 @@ func (rq *Request) advanceLastWriteSeconds(now int32) {
 
 // destKey returns the Request's identity key while it is still registered, read
 // under rq.mu, for use as a broadcast destination. A zero return means the Request
-// has finished (unregistered) and is no longer a valid target; its stable key is
-// never reassigned to another Request, so a stale destination simply matches
-// nothing rather than reaching an unrelated connection.
+// has finished (unregistered) and is no longer a valid target. Its key is reserved
+// (not reassigned to another Request) for as long as the finished Request remains
+// reachable, so a stale destination matches nothing rather than reaching an
+// unrelated connection; the key becomes eligible for random reuse only after the
+// Request is collected, by which point no such stale destination can remain.
 func (rq *Request) destKey() (k key.Key) {
 	rq.mu.RLock()
 	if rq.registered {

--- a/request.go
+++ b/request.go
@@ -245,7 +245,8 @@ func (rq *Request) killSession() {
 }
 
 // deadSession detaches sess and returns the Request identity that belonged to it.
-// A zero return means rq was already recycled or rebound to another Session.
+// A zero return means rq no longer belongs to sess: it has finished, or has been
+// detached from this Session.
 func (rq *Request) deadSession(sess *Session) (k key.Key) {
 	rq.mu.Lock()
 	if rq.session == sess {
@@ -292,10 +293,12 @@ func (rq *Request) ensureAutoSession(w http.ResponseWriter, r *http.Request) {
 // The caller must hold rq.mu. The WebSocket processing loop must have exited, but an
 // initial HTTP renderer may still be running concurrently (an early callback can
 // claim and tear down a Request mid-render). This is race-safe rather than fully
-// non-destructive: clearing the collections can degrade that render (later
-// GetElements and getElementByJid find nothing), but the Element fields and Jid
-// counter it reads lock-free are left intact and wsQueue is transferred under
-// muQueue, so there is no data race, no reused identity, and no duplicated Jid.
+// non-destructive: clearing the collections forgets the elements and tags rendered
+// so far (a subsequent GetElements finds nothing; a later NewElement repopulates
+// rq.elems and is again findable by Jid). What safety needs is preserved — the
+// lock-free Element fields (ui, handlers) are left intact, lastJid is advanced only
+// under rq.mu so Jids stay monotonic and unique, and wsQueue is transferred under
+// muQueue — so there is no data race, no reused identity, and no duplicated Jid.
 func (rq *Request) releaseBuffersLocked() (buffers *requestBuffers) {
 	// Cancel first so a retained context observes cancellation, then detach the
 	// Request from its session and unregister its identity.

--- a/request.go
+++ b/request.go
@@ -47,8 +47,28 @@ const webSocketReadLimit = 32 * 1024
 // is borrowed for the callback; the lifetime rules documented on [Request] apply.
 type ConnectFn = func(rq *Request) error
 
+// requestBuffers holds the reusable per-Request storage: the pending-dirt list,
+// the element list, the tag-to-elements map and the outbound message queue.
+//
+// A [Request] borrows one from [Jaws.requestBufferPool] for its lifetime and
+// returns it when it finishes (see [Request.releaseBuffersLocked]). Pooling the
+// buffers rather than the whole Request keeps allocation low while giving every
+// Request a distinct, never-reused identity.
+type requestBuffers struct {
+	todoDirt []any
+	elems    []*Element
+	tagMap   map[any][]*Element
+	wsQueue  []wire.WsMsg
+}
+
 // Request maintains the state for a JaWS WebSocket connection, and handles processing
 // of events and broadcasts.
+//
+// Each Request has a stable identity that is never reused for another connection:
+// once it finishes, its context stays canceled and identity-targeted operations
+// are never retargeted to a different Request. A pointer retained past its
+// documented lifetime therefore stays inert rather than aliasing an unrelated
+// connection.
 //
 // A Request pointer is borrowed for the HTTP or WebSocket lifecycle that supplied
 // it. Do not retain it in application state or use it from a background goroutine:
@@ -68,6 +88,7 @@ type Request struct {
 	Jaws             *Jaws                   // (read-only) the JaWS instance the Request belongs to
 	JawsKey          key.Key                 // (read-only) random key assigned to this Request; routes JaWS URLs and request-targeted broadcasts only while registered
 	remoteIP         netip.Addr              // (read-only) remote IP, or the zero netip.Addr if unset
+	registered       bool                    // present as a live identity in Jaws.requests; guarded by mu
 	running          atomic.Bool             // if ServeHTTP() is running
 	claimed          atomic.Bool             // if UseRequest() has been called for it
 	lastWriteSeconds atomic.Int32            // [Jaws.runtimeSeconds] value at the most recent RequestWriter write; lock-free, drives pending-eviction preference (pendingEvictionVictimLocked) and idle expiry (maintenance)
@@ -80,6 +101,7 @@ type Request struct {
 	httpDoneCh       <-chan struct{}         // once claimed, set to http.Request.Context().Done()
 	cancelFn         context.CancelCauseFunc // cancel function
 	connectFn        ConnectFn               // a ConnectFn to call before starting message processing for the Request
+	buffers          *requestBuffers         // reusable storage borrowed from Jaws.requestBufferPool; detached and returned when the Request finishes
 	elems            []*Element              // our Elements
 	tagMap           map[any][]*Element      // maps tags to Elements
 	muQueue          deadlock.Mutex          // protects wsQueue and tailsent
@@ -135,14 +157,16 @@ func (rq *Request) advanceLastWriteSeconds(now int32) {
 	}
 }
 
-// destKey returns the Request's current identity key, read under rq.mu, for use as
-// a broadcast destination. Targeting the key value rather than the *Request pointer
-// lets the Serve loop reject a message aimed at a request that was recycled and
-// reused before delivery, since the pooled pointer is reused but its key is not. A
-// zero return means the Request has already been recycled and is not a valid target.
+// destKey returns the Request's identity key while it is still registered, read
+// under rq.mu, for use as a broadcast destination. A zero return means the Request
+// has finished (unregistered) and is no longer a valid target; its stable key is
+// never reassigned to another Request, so a stale destination simply matches
+// nothing rather than reaching an unrelated connection.
 func (rq *Request) destKey() (k key.Key) {
 	rq.mu.RLock()
-	k = rq.JawsKey
+	if rq.registered {
+		k = rq.JawsKey
+	}
 	rq.mu.RUnlock()
 	return
 }
@@ -242,24 +266,28 @@ func (rq *Request) ensureAutoSession(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// clearLocked resets rq so it can be reused from the [Jaws] request pool: it cancels
-// any live context, drops queued dirt and messages, detaches all elements and tags,
-// and kills any attached session. The caller must ensure no other goroutine is using
-// rq (it runs when rq is freshly allocated or being recycled).
-func (rq *Request) clearLocked() *Request {
-	rq.JawsKey = 0
+// releaseBuffersLocked detaches the reusable storage from a finished Request and
+// returns it for the caller to return to [Jaws.requestBufferPool].
+//
+// It cancels any live context, drops queued dirt and messages, marks every element
+// inert, kills any attached session and clears the registered flag. The Request
+// keeps its identity key and canceled context, so a pointer retained by the
+// initial renderer or by background work stays permanently bound to this finished
+// lifecycle and is never reused for another connection. The caller must hold rq.mu
+// and ensure no other goroutine is still processing rq.
+func (rq *Request) releaseBuffersLocked() (buffers *requestBuffers) {
+	// Cancel first; a retained context observes cancellation regardless of what
+	// happens to the detached buffers below.
+	if rq.cancelFn != nil {
+		rq.cancelFn(nil)
+	}
 	rq.lastJid = 0
 	rq.connectFn = nil
-	rq.lastWriteSeconds.Store(0)
 	rq.initial = nil
 	rq.killSessionLocked()
 	rq.running.Store(false)
 	rq.claimed.Store(false)
-	// Every field is reset to its zero state except ctx and cancelFn, which keep their
-	// (cancelled) values until getRequestLocked replaces them on reuse.
-	if rq.cancelFn != nil {
-		rq.cancelFn(nil)
-	}
+	rq.registered = false
 	rq.httpDoneCh = nil
 	clear(rq.todoDirt) // release tag references before pooling; mirrors makeUpdateList
 	rq.todoDirt = rq.todoDirt[:0]
@@ -268,11 +296,8 @@ func (rq *Request) clearLocked() *Request {
 		if e != nil {
 			// Nil the GC-reachable fields and set the deleted guard, which makes the
 			// render, update and queue paths of any retained *Element no-ops (see
-			// [Element.Deleted]). The Request back-pointer and frozen flag are
-			// deliberately left as-is: Elements are allocated fresh per newElementLocked
-			// and never pooled, so a stale frozen value can never be observed by a reused
-			// Element. Any future move to pool Elements must also reset frozen, since it
-			// gates the lock-free handler read.
+			// [Element.Deleted]). Elements are allocated fresh per newElementLocked and
+			// are never pooled.
 			e.handlers = nil
 			e.ui = nil
 			e.deleted.Store(true)
@@ -291,7 +316,24 @@ func (rq *Request) clearLocked() *Request {
 	rq.wsQueue = rq.wsQueue[:0]
 	rq.muQueue.Unlock()
 	clear(rq.tagMap)
-	return rq
+
+	// Hand the emptied storage back for reuse and detach it from this Request, so a
+	// pointer retained past the Request's lifetime cannot mutate storage that now
+	// belongs to another Request. Writes guard on the detached (nil) state; see
+	// TagExpanded and appendDirtyTags.
+	buffers = rq.buffers
+	if buffers != nil {
+		buffers.todoDirt = rq.todoDirt
+		buffers.elems = rq.elems
+		buffers.tagMap = rq.tagMap
+		buffers.wsQueue = rq.wsQueue
+	}
+	rq.buffers = nil
+	rq.todoDirt = nil
+	rq.elems = nil
+	rq.tagMap = nil
+	rq.wsQueue = nil
+	return
 }
 
 // HeadHTML writes the configured resources and Request key metadata for the page head.
@@ -403,8 +445,9 @@ func (rq *Request) SetContext(fn func(oldCtx context.Context) (newCtx context.Co
 	// that old select wakes. Register outside rq.mu because context.AfterFunc may
 	// synchronously invoke a custom context hook that re-enters the Request.
 	//
-	// Capture only the context and cancel closure: capturing rq would let a delayed
-	// callback cancel an unrelated Request after pool reuse.
+	// Capture only the context and cancel closure so the callback does not retain
+	// the whole Request and its rendered state; the captured cancelFn only ever
+	// cancels this Request, whose identity is never reused.
 	context.AfterFunc(newCtx, func() {
 		cancelFn(context.Cause(newCtx))
 	})
@@ -447,14 +490,15 @@ func (rq *Request) maintenance(nowSeconds int32, requestTimeout time.Duration) (
 	return
 }
 
-// cancelLocked cancels the request's context with a wrapped cause, but only for a
-// live request (non-zero key) whose context has not already been cancelled.
+// cancelLocked cancels the Request's context with a wrapped cause, but only when
+// the Request has a non-zero identity key and its context has not already been
+// cancelled.
 //
 // It does NOT log. It returns the cancellation cause (already set on the context)
 // so the caller can pass it to [Jaws.Log] AFTER releasing rq.mu and any outer lock;
-// the cause is nil whenever there is nothing to log (no live request to cancel, or
-// a nil err). Logging invokes the user-supplied [Jaws.Logger], which the package
-// locking contract forbids running under a lock. Caller must hold rq.mu.
+// the cause is nil whenever there is nothing to log (the context was already
+// cancelled, or a nil err). Logging invokes the user-supplied [Jaws.Logger], which
+// the package locking contract forbids running under a lock. Caller must hold rq.mu.
 func (rq *Request) cancelLocked(err error) (cause error) {
 	if rq.JawsKey != 0 && rq.ctx.Err() == nil {
 		cause = newErrRequestCancelledLocked(rq, err)
@@ -584,8 +628,11 @@ func (rq *Request) wantMessage(msg *wire.Message) (yes bool) {
 	switch dest := msg.Dest.(type) {
 	case key.Key: // the request with this identity key
 		rq.mu.RLock()
-		defer rq.mu.RUnlock()
-		return rq.JawsKey == dest
+		if rq.registered {
+			yes = rq.JawsKey == dest
+		}
+		rq.mu.RUnlock()
+		return
 	case []any: // more than one tag
 		rq.mu.RLock()
 		defer rq.mu.RUnlock()
@@ -689,23 +736,31 @@ func (rq *Request) HasTag(elem *Element, tagValue any) (yes bool) {
 // list. The Serve loop's update tick later drains the list (see makeUpdateList)
 // and re-renders the affected elements. Takes rq.mu.
 //
-// It may run on a Request that was recycled and reused after the caller's dirt
-// snapshot was taken; that is race-free (clearLocked also takes rq.mu) and harmless,
-// as explained on distributeDirt.
+// It may run after the caller's dirt snapshot was taken but before rq finished
+// (see distributeDirt). A finished Request has released its buffers, so the tags
+// are discarded rather than re-materializing storage on a dead identity.
 func (rq *Request) appendDirtyTags(tags []any) {
 	rq.mu.Lock()
-	rq.todoDirt = append(rq.todoDirt, tags...)
+	if rq.registered {
+		rq.todoDirt = append(rq.todoDirt, tags...)
+	}
 	rq.mu.Unlock()
 }
 
 // TagExpanded adds already-expanded tags to the given [Element].
+//
+// It is a no-op once rq has finished and released its buffers (rq.tagMap is nil),
+// so a still-running initial renderer that keeps tagging after a racy teardown
+// degrades to untracked elements instead of panicking on a nil-map write.
 func (rq *Request) TagExpanded(elem *Element, expandedTags []any) {
 	if elem != nil && !elem.deleted.Load() && elem.Request == rq {
 		rq.mu.Lock()
 		defer rq.mu.Unlock()
-		for _, tagValue := range expandedTags {
-			if !rq.hasTagLocked(elem, tagValue) {
-				rq.tagMap[tagValue] = append(rq.tagMap[tagValue], elem)
+		if rq.tagMap != nil {
+			for _, tagValue := range expandedTags {
+				if !rq.hasTagLocked(elem, tagValue) {
+					rq.tagMap[tagValue] = append(rq.tagMap[tagValue], elem)
+				}
 			}
 		}
 	}

--- a/request.go
+++ b/request.go
@@ -171,11 +171,14 @@ func (rq *Request) advanceLastWriteSeconds(now int32) {
 
 // destKey returns the Request's identity key while it is still registered, read
 // under rq.mu, for use as a broadcast destination. A zero return means the Request
-// has finished (unregistered) and is no longer a valid target. Its key is reserved
-// (not reassigned to another Request) for as long as the finished Request remains
-// reachable, so a stale destination matches nothing rather than reaching an
-// unrelated connection; the key becomes eligible for random reuse only after the
-// Request is collected, by which point no such stale destination can remain.
+// has finished (unregistered), so destKey never hands out a finished Request's key.
+// A key value captured elsewhere (a copied key.Key, a queued wire.Message.Dest, or a
+// browser /jaws/<key> URL) that outlives the Request matches nothing only while the
+// finished Request stays reachable, since its key is held reserved by a tombstone.
+// After the Request is collected the tombstone is removed and the CSPRNG may
+// eventually reissue that key value to a new Request, which such a stale value could
+// then match. The *Request pointer itself is never reused, so pointer-derived
+// operations never reach a different connection.
 func (rq *Request) destKey() (k key.Key) {
 	rq.mu.RLock()
 	if rq.registered {

--- a/request_identity_test.go
+++ b/request_identity_test.go
@@ -174,61 +174,34 @@ func TestRequestFinishConcurrentWithRenderIsRaceFree(t *testing.T) {
 	wg.Wait()
 }
 
-// TestEarlyCallbackDuringRenderIsRefusedWithoutConsumingKey exercises the render
-// gate: while the initial request's context is still live (render in progress), a
-// /jaws/<key> callback is refused with 404 and does NOT consume the single-use key,
-// so the real WebSocket can still claim it once rendering completes.
-func TestEarlyCallbackDuringRenderIsRefusedWithoutConsumingKey(t *testing.T) {
+// TestNoscriptDuringLiveRenderRecordsJavascriptDisabled guards against re-adding a
+// render-timing gate that would 404 the <noscript> probe while a streamed page is
+// still rendering (its initial request context still live). The probe must reach the
+// Request, return 204, and record ErrJavascriptDisabled.
+func TestNoscriptDuringLiveRenderRecordsJavascriptDisabled(t *testing.T) {
 	jw, err := New()
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer jw.Close()
+	go jw.Serve()
+	waitForServeLoop(t, jw)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	initial := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
-	initial.RemoteAddr = "192.0.2.1:1000"
 	rq := jw.NewRequest(initial)
-	jawsKey := rq.JawsKeyString()
 
-	cb := httptest.NewRequest(http.MethodGet, "/jaws/"+jawsKey, nil)
-	cb.RemoteAddr = initial.RemoteAddr
-	rec := httptest.NewRecorder()
-	jw.ServeHTTP(rec, cb)
-	if rec.Code != http.StatusNotFound {
-		t.Fatalf("early callback during render: status = %d, want 404", rec.Code)
-	}
-	if rq.claimed.Load() {
-		t.Fatal("early callback consumed the key (claimed) while the render was in progress")
-	}
-	if rq.JawsKeyString() != jawsKey {
-		t.Fatal("early callback changed the Request key during render")
-	}
+	w := httptest.NewRecorder()
+	probe := httptest.NewRequest(http.MethodGet, "/jaws/"+rq.JawsKeyString()+"/noscript", nil)
+	probe.RemoteAddr = initial.RemoteAddr
+	jw.ServeHTTP(w, probe)
 
-	// Render completes: the handler returns, so net/http cancels the initial context.
-	cancel()
-	ws := httptest.NewRequest(http.MethodGet, "/jaws/"+jawsKey, nil)
-	ws.RemoteAddr = initial.RemoteAddr
-	if got := jw.UseRequest(rq.JawsKey, ws); got != rq {
-		t.Fatal("WebSocket could not claim the Request after the render completed")
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("/noscript during live render: status = %d, want %d", w.Code, http.StatusNoContent)
 	}
-}
-
-// TestUseRequestNilInitialIsClaimable covers the render gate for a Request created
-// without an initial HTTP request: there is no render to wait for, so it is
-// immediately claimable.
-func TestUseRequestNilInitialIsClaimable(t *testing.T) {
-	jw, err := New()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer jw.Close()
-
-	rq := jw.NewRequest(nil)
-	defer jw.recycle(rq)
-	if got := jw.UseRequest(rq.JawsKey, nil); got != rq {
-		t.Fatalf("UseRequest(nil initial) = %v, want %v", got, rq)
+	if cause := context.Cause(rq.Context()); !errors.Is(cause, ErrJavascriptDisabled) {
+		t.Fatalf("cancellation cause = %v, want ErrJavascriptDisabled", cause)
 	}
 }
 

--- a/request_identity_test.go
+++ b/request_identity_test.go
@@ -24,11 +24,11 @@ import (
 
 // TestEarlyCallbackPreservesInitialRenderIdentity is the reproduction from issue
 // #195: an early /jaws/<key> callback that fails the WebSocket upgrade tears the
-// Request down — clearing its collections — but must not destroy the identity the
+// Request down — clearing its collections — but must not change the identity the
 // initial HTTP handler is still rendering with. Because Requests keep a stable
 // identity and are never reused, completion unregisters the Request and releases its
-// buffers but never zeroes the key or hands the pointer to another connection, so the
-// initial renderer's pointer keeps a valid key.
+// buffers but never zeroes or reassigns the key, so the initial renderer's pointer
+// keeps its stable, nonzero key (the Request is just unregistered).
 func TestEarlyCallbackPreservesInitialRenderIdentity(t *testing.T) {
 	jw, err := New()
 	if err != nil {
@@ -40,18 +40,22 @@ func TestEarlyCallbackPreservesInitialRenderIdentity(t *testing.T) {
 	initial := httptest.NewRequest(http.MethodGet, "/", nil)
 	initial.RemoteAddr = "192.0.2.1:1000"
 	rq := jw.NewRequest(initial)
+	wantKey := rq.JawsKeyString()
+	if wantKey == "" {
+		t.Fatal("NewRequest returned an empty key")
+	}
 
 	var page bytes.Buffer
 	if err := rq.HeadHTML(&page); err != nil {
 		t.Fatal(err)
 	}
 
-	callback := httptest.NewRequest(http.MethodGet, "/jaws/"+rq.JawsKeyString(), nil)
+	callback := httptest.NewRequest(http.MethodGet, "/jaws/"+wantKey, nil)
 	callback.RemoteAddr = initial.RemoteAddr
 	jw.ServeHTTP(httptest.NewRecorder(), callback)
 
-	if rq.JawsKeyString() == "" {
-		t.Fatal("early callback cleared the initial render's Request key")
+	if got := rq.JawsKeyString(); got != wantKey {
+		t.Fatalf("early callback changed the initial render's Request key: got %q, want stable %q", got, wantKey)
 	}
 }
 

--- a/request_identity_test.go
+++ b/request_identity_test.go
@@ -1,17 +1,22 @@
 package jaws
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/coder/websocket"
+	"github.com/linkdata/jaws/lib/key"
 	"github.com/linkdata/jaws/lib/tag"
 )
 
@@ -136,10 +141,11 @@ func TestRequestFinishDoesNotPanicOnContinuedRender(t *testing.T) {
 	}
 }
 
-// TestRequestFinishConcurrentWithRenderIsRaceFree drives element and tag
-// registration concurrently with completion across many Requests. Both paths take
-// rq.mu, so this must be race-free under -race, and the nil-map guard must keep a
-// post-completion registration from panicking.
+// TestRequestFinishConcurrentWithRenderIsRaceFree drives a live initial render
+// (NewElement, Tag and JawsRender, which reads Element.ui and handlers lock-free)
+// concurrently with completion across many Requests. Completion must not mutate the
+// render-visible Element fields or the Jid counter, so this is race-free under -race,
+// and the nil-map guard keeps a post-completion Tag from panicking.
 func TestRequestFinishConcurrentWithRenderIsRaceFree(t *testing.T) {
 	jw, err := New()
 	if err != nil {
@@ -155,7 +161,9 @@ func TestRequestFinishConcurrentWithRenderIsRaceFree(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for range 8 {
-				rq.Tag(rq.NewElement(&testUi{}), tag.Tag("t"))
+				elem := rq.NewElement(&testUi{})
+				rq.Tag(elem, tag.Tag("t"))
+				_ = elem.JawsRender(io.Discard, nil)
 			}
 		}()
 		go func() {
@@ -164,4 +172,100 @@ func TestRequestFinishConcurrentWithRenderIsRaceFree(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+// TestEarlyCallbackDuringRenderIsRefusedWithoutConsumingKey exercises the render
+// gate: while the initial request's context is still live (render in progress), a
+// /jaws/<key> callback is refused with 404 and does NOT consume the single-use key,
+// so the real WebSocket can still claim it once rendering completes.
+func TestEarlyCallbackDuringRenderIsRefusedWithoutConsumingKey(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	initial := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+	initial.RemoteAddr = "192.0.2.1:1000"
+	rq := jw.NewRequest(initial)
+	jawsKey := rq.JawsKeyString()
+
+	cb := httptest.NewRequest(http.MethodGet, "/jaws/"+jawsKey, nil)
+	cb.RemoteAddr = initial.RemoteAddr
+	rec := httptest.NewRecorder()
+	jw.ServeHTTP(rec, cb)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("early callback during render: status = %d, want 404", rec.Code)
+	}
+	if rq.claimed.Load() {
+		t.Fatal("early callback consumed the key (claimed) while the render was in progress")
+	}
+	if rq.JawsKeyString() != jawsKey {
+		t.Fatal("early callback changed the Request key during render")
+	}
+
+	// Render completes: the handler returns, so net/http cancels the initial context.
+	cancel()
+	ws := httptest.NewRequest(http.MethodGet, "/jaws/"+jawsKey, nil)
+	ws.RemoteAddr = initial.RemoteAddr
+	if got := jw.UseRequest(rq.JawsKey, ws); got != rq {
+		t.Fatal("WebSocket could not claim the Request after the render completed")
+	}
+}
+
+// TestUseRequestNilInitialIsClaimable covers the render gate for a Request created
+// without an initial HTTP request: there is no render to wait for, so it is
+// immediately claimable.
+func TestUseRequestNilInitialIsClaimable(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+
+	rq := jw.NewRequest(nil)
+	defer jw.recycle(rq)
+	if got := jw.UseRequest(rq.JawsKey, nil); got != rq {
+		t.Fatalf("UseRequest(nil initial) = %v, want %v", got, rq)
+	}
+}
+
+// TestRequestRecycledKeyNotReusedWhileReachable proves the recycle path reserves the
+// key with a tombstone: with the key generator forced to offer K, K, then K2, a
+// Request minted K and then recycled must not have K reassigned to the next Request
+// while the finished one is still reachable; the next Request gets K2 instead.
+func TestRequestRecycledKeyNotReusedWhileReachable(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+
+	const k = key.Key(0x1111111111111111)
+	const k2 = key.Key(0x2222222222222222)
+	var kb, k2b [8]byte
+	binary.LittleEndian.PutUint64(kb[:], uint64(k))
+	binary.LittleEndian.PutUint64(k2b[:], uint64(k2))
+	stream := append(append(append([]byte{}, kb[:]...), kb[:]...), bytes.Repeat(k2b[:], 4)...)
+	jw.mu.Lock()
+	jw.kg = bufio.NewReader(bytes.NewReader(stream))
+	jw.mu.Unlock()
+
+	rq1 := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	if rq1.JawsKey != k {
+		t.Fatalf("rq1 key = %v, want forced %v", rq1.JawsKey, k)
+	}
+	jw.recycle(rq1)
+
+	rq2 := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	defer jw.recycle(rq2)
+	if rq2.JawsKey == k {
+		t.Fatal("recycled key K was reassigned while the finished Request is still reachable")
+	}
+	if rq2.JawsKey != k2 {
+		t.Fatalf("rq2 key = %v, want %v (K skipped via tombstone)", rq2.JawsKey, k2)
+	}
+	runtime.KeepAlive(rq1) // keep rq1 reachable so its tombstone is not GC-cleaned mid-test
 }

--- a/request_identity_test.go
+++ b/request_identity_test.go
@@ -108,10 +108,11 @@ func TestRequestLateCancelDoesNotReachNextConnection(t *testing.T) {
 }
 
 // TestRequestFinishDoesNotPanicOnContinuedRender exercises the racy #195 window
-// where the initial renderer keeps registering after the Request finished. Element
-// and tag registration on a finished Request (whose buffers were released, leaving a
-// nil tagMap) must be an inert no-op rather than a nil-map panic, and must not leak
-// into a later, distinct Request.
+// where the initial renderer keeps registering after the Request finished. This must
+// not panic and must not leak into a later, distinct Request. Registration is not a
+// full no-op: NewElement still creates an Element and advances the Jid, while Tag
+// reaches the nil-map guard in TagExpanded (the buffers were released) and is dropped
+// — neither panics, and none of it is visible to another Request.
 func TestRequestFinishDoesNotPanicOnContinuedRender(t *testing.T) {
 	jw, err := New()
 	if err != nil {

--- a/request_identity_test.go
+++ b/request_identity_test.go
@@ -22,13 +22,14 @@ import (
 	"github.com/linkdata/jaws/lib/wire"
 )
 
-// TestEarlyCallbackDoesNotRecycleInitialRender is the reproduction from issue #195:
-// an early /jaws/<key> callback that fails the WebSocket upgrade must not clear the
-// Request the initial HTTP handler is still rendering with. Because Requests keep a
-// stable identity and are never reused, the callback's stopServe completion only
-// unregisters and releases buffers; it never zeroes the key or hands the pointer to
-// another connection, so the initial renderer keeps a valid key.
-func TestEarlyCallbackDoesNotRecycleInitialRender(t *testing.T) {
+// TestEarlyCallbackPreservesInitialRenderIdentity is the reproduction from issue
+// #195: an early /jaws/<key> callback that fails the WebSocket upgrade tears the
+// Request down — clearing its collections — but must not destroy the identity the
+// initial HTTP handler is still rendering with. Because Requests keep a stable
+// identity and are never reused, completion unregisters the Request and releases its
+// buffers but never zeroes the key or hands the pointer to another connection, so the
+// initial renderer's pointer keeps a valid key.
+func TestEarlyCallbackPreservesInitialRenderIdentity(t *testing.T) {
 	jw, err := New()
 	if err != nil {
 		t.Fatal(err)
@@ -50,7 +51,7 @@ func TestEarlyCallbackDoesNotRecycleInitialRender(t *testing.T) {
 	jw.ServeHTTP(httptest.NewRecorder(), callback)
 
 	if rq.JawsKeyString() == "" {
-		t.Fatal("Request was cleared while the initial render still owned it")
+		t.Fatal("early callback cleared the initial render's Request key")
 	}
 }
 

--- a/request_identity_test.go
+++ b/request_identity_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/coder/websocket"
 	"github.com/linkdata/jaws/lib/key"
 	"github.com/linkdata/jaws/lib/tag"
+	"github.com/linkdata/jaws/lib/what"
+	"github.com/linkdata/jaws/lib/wire"
 )
 
 // TestEarlyCallbackDoesNotRecycleInitialRender is the reproduction from issue #195:
@@ -172,6 +174,56 @@ func TestRequestFinishConcurrentWithRenderIsRaceFree(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+// TestFinishDoesNotResetJidCounter verifies teardown leaves the Jid counter intact,
+// so a renderer that keeps allocating Elements after a racy teardown cannot reuse an
+// already-streamed Jid. Restoring lastJid = 0 in teardown would fail this.
+func TestFinishDoesNotResetJidCounter(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	rq.NewElement(&testUi{})
+	last := rq.NewElement(&testUi{}).Jid()
+
+	jw.recycle(rq)
+
+	if got := rq.NewElement(&testUi{}).Jid(); got <= last {
+		t.Fatalf("Jid after teardown = %v, want > %v (counter must not reset)", got, last)
+	}
+}
+
+// TestRecycleQueueRaceDoesNotLeak stresses a queue concurrent with recycle. The
+// wsQueue transfer in releaseBuffersLocked must stay under muQueue, so a late queue
+// cannot race the transfer or land its message in a buffer already returned to the
+// pool. Moving the transfer outside muQueue would trip the race detector here. Run
+// with -race.
+func TestRecycleQueueRaceDoesNotLeak(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+
+	const n = 300
+	for range n {
+		rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			rq.queue(wire.WsMsg{Jid: 1, What: what.Inner, Data: "late"})
+		}()
+		go func() {
+			defer wg.Done()
+			jw.recycle(rq)
+		}()
+		wg.Wait()
+	}
 }
 
 // TestNoscriptDuringLiveRenderRecordsJavascriptDisabled guards against re-adding a

--- a/request_identity_test.go
+++ b/request_identity_test.go
@@ -1,0 +1,167 @@
+package jaws
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/linkdata/jaws/lib/tag"
+)
+
+// TestEarlyCallbackDoesNotRecycleInitialRender is the reproduction from issue #195:
+// an early /jaws/<key> callback that fails the WebSocket upgrade must not clear the
+// Request the initial HTTP handler is still rendering with. Because Requests keep a
+// stable identity and are never reused, the callback's stopServe completion only
+// unregisters and releases buffers; it never zeroes the key or hands the pointer to
+// another connection, so the initial renderer keeps a valid key.
+func TestEarlyCallbackDoesNotRecycleInitialRender(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+	go jw.Serve()
+
+	initial := httptest.NewRequest(http.MethodGet, "/", nil)
+	initial.RemoteAddr = "192.0.2.1:1000"
+	rq := jw.NewRequest(initial)
+
+	var page bytes.Buffer
+	if err := rq.HeadHTML(&page); err != nil {
+		t.Fatal(err)
+	}
+
+	callback := httptest.NewRequest(http.MethodGet, "/jaws/"+rq.JawsKeyString(), nil)
+	callback.RemoteAddr = initial.RemoteAddr
+	jw.ServeHTTP(httptest.NewRecorder(), callback)
+
+	if rq.JawsKeyString() == "" {
+		t.Fatal("Request was cleared while the initial render still owned it")
+	}
+}
+
+// TestRequestLateCancelDoesNotReachNextConnection proves the core identity-stability
+// guarantee: after a Request's WebSocket connects and disconnects, a later
+// NewRequest returns a distinct Request, the finished Request keeps its key, and a
+// late Cancel on the finished Request cannot cancel the later one.
+func TestRequestLateCancelDoesNotReachNextConnection(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+	go jw.Serve()
+	waitForServeLoop(t, jw)
+
+	server := httptest.NewServer(jw)
+	defer server.Close()
+	newInitialRequest := func(path string) *http.Request {
+		r := httptest.NewRequest(http.MethodGet, server.URL+path, nil)
+		r.RemoteAddr = "127.0.0.1:12345"
+		return r
+	}
+
+	finished := jw.NewRequest(newInitialRequest("/first"))
+	finishedKey := finished.JawsKey
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(server.URL, "http")+"/jaws/"+finished.JawsKeyString(), &websocket.DialOptions{
+		HTTPHeader: http.Header{"Origin": []string{server.URL}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = conn.Close(websocket.StatusNormalClosure, ""); err != nil {
+		t.Fatal(err)
+	}
+	waitForRequestCount(t, jw, 0, time.Second)
+
+	replacement := jw.NewRequest(newInitialRequest("/second"))
+	defer jw.recycle(replacement)
+	if replacement == finished {
+		t.Fatal("NewRequest reused the finished Request identity")
+	}
+	if finished.JawsKey != finishedKey {
+		t.Fatalf("finished Request key = %v, want stable key %v", finished.JawsKey, finishedKey)
+	}
+	replacementCtx := replacement.Context()
+	finished.Cancel(errors.New("background operation completed after disconnect"))
+	select {
+	case <-replacementCtx.Done():
+		t.Fatalf("late Cancel reached the next Request: %v", context.Cause(replacementCtx))
+	default:
+	}
+}
+
+// TestRequestFinishDoesNotPanicOnContinuedRender exercises the racy #195 window
+// where the initial renderer keeps registering after the Request finished. Element
+// and tag registration on a finished Request (whose buffers were released, leaving a
+// nil tagMap) must be an inert no-op rather than a nil-map panic, and must not leak
+// into a later, distinct Request.
+func TestRequestFinishDoesNotPanicOnContinuedRender(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	rq.Tag(rq.NewElement(&testUi{}), tag.Tag("live"))
+
+	// Finish the Request out from under the still-running initial renderer, as a racy
+	// early /jaws/<key> callback would.
+	jw.recycle(rq)
+
+	// The renderer keeps going. A fresh element created after completion is not marked
+	// deleted, so tagging it reaches the nil-map guard in TagExpanded; this must not
+	// panic.
+	late := rq.NewElement(&testUi{})
+	rq.Tag(late, tag.Tag("late"))
+	rq.Dirty(tag.Tag("live"))
+
+	other := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/next", nil))
+	defer jw.recycle(other)
+	if other == rq {
+		t.Fatal("NewRequest reused a finished Request identity")
+	}
+	if got := len(other.GetElements(tag.Tag("live"))) + len(other.GetElements(tag.Tag("late"))); got != 0 {
+		t.Fatalf("finished Request's elements leaked into a later Request: %d", got)
+	}
+}
+
+// TestRequestFinishConcurrentWithRenderIsRaceFree drives element and tag
+// registration concurrently with completion across many Requests. Both paths take
+// rq.mu, so this must be race-free under -race, and the nil-map guard must keep a
+// post-completion registration from panicking.
+func TestRequestFinishConcurrentWithRenderIsRaceFree(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+
+	const n = 200
+	var wg sync.WaitGroup
+	for range n {
+		rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for range 8 {
+				rq.Tag(rq.NewElement(&testUi{}), tag.Tag("t"))
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			jw.recycle(rq)
+		}()
+	}
+	wg.Wait()
+}

--- a/request_test.go
+++ b/request_test.go
@@ -144,12 +144,12 @@ func TestRequest_wantMessage_KeyDest(t *testing.T) {
 	}
 }
 
-// TestRequest_wantMessage_RejectsRecycledKey is the core broadcast regression:
-// matching on the identity key rather than the *Request pointer lets the loop
-// reject a message aimed at a request that was recycled and reused under a new key,
-// even when it is the very same pooled object. A dest==*Request match could not
-// tell the reused object from the original; a key match can.
-func TestRequest_wantMessage_RejectsRecycledKey(t *testing.T) {
+// TestRequest_wantMessage_RejectsFinishedRequest is the core broadcast regression:
+// wantMessage gates the identity-key match on rq.registered, so a finished Request
+// stops matching its own key. Because a Request identity is never reused for another
+// connection, a message aimed at a finished Request's key reaches no one, and a
+// later Request matches only its own distinct key.
+func TestRequest_wantMessage_RejectsFinishedRequest(t *testing.T) {
 	is := newTestHelper(t)
 	jw, _ := New()
 	go jw.Serve()
@@ -159,22 +159,17 @@ func TestRequest_wantMessage_RejectsRecycledKey(t *testing.T) {
 	staleKey := rq.JawsKey
 	is.True(rq.wantMessage(&wire.Message{Dest: staleKey}))
 
-	// Recycle zeroes the key, so the same object no longer matches the old key.
+	// Finishing unregisters rq; it keeps its key but no longer matches it.
 	jw.recycle(rq)
 	is.Equal(rq.wantMessage(&wire.Message{Dest: staleKey}), false)
 
-	// Reuse the same object under a fresh key, as the pool handing it back to a new
-	// connection would. Re-key directly under rq.mu (the lock destKey/wantMessage
-	// use) so the aliasing is deterministic rather than dependent on the pool
-	// returning this struct. A message still aimed at the old key must be rejected
-	// even though rq is the same object it once identified; one aimed at the new
-	// key is accepted.
-	newKey := staleKey + 1
-	rq.mu.Lock()
-	rq.JawsKey = newKey
-	rq.mu.Unlock()
-	is.Equal(rq.wantMessage(&wire.Message{Dest: staleKey}), false)
-	is.True(rq.wantMessage(&wire.Message{Dest: newKey}))
+	// A later client gets a distinct Request with a distinct key. It matches only its
+	// own key, and the finished Request's key is never reassigned to it.
+	replacement := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/next", nil))
+	defer jw.recycle(replacement)
+	is.True(replacement != rq)
+	is.True(replacement.wantMessage(&wire.Message{Dest: replacement.JawsKey}))
+	is.Equal(replacement.wantMessage(&wire.Message{Dest: staleKey}), false)
 }
 
 func TestRequest_HeadHTML(t *testing.T) {
@@ -655,7 +650,7 @@ func (ctx *deferredAfterContext) fire() {
 	}
 }
 
-func TestRequest_SetContextDelayedCallbackDoesNotCancelReusedRequest(t *testing.T) {
+func TestRequest_SetContextDelayedCallbackDoesNotCancelNextRequest(t *testing.T) {
 	jw, err := New()
 	if err != nil {
 		t.Fatal(err)
@@ -682,13 +677,14 @@ func TestRequest_SetContextDelayedCallbackDoesNotCancelReusedRequest(t *testing.
 	deferred.cancel()
 	jw.recycle(first)
 
-	poolNew := jw.reqPool.New
-	jw.reqPool.New = func() any { return first }
-	defer func() { jw.reqPool.New = poolNew }()
+	// Requests keep a stable identity and are never reused, so NewRequest returns a
+	// distinct Request. A delayed SetContext callback still bound to first must not
+	// reach this next Request's context.
 	second := jw.NewRequest(nil)
-	if second != first {
-		t.Fatal("request pool did not reuse the Request")
+	if second == first {
+		t.Fatal("NewRequest reused a finished Request identity")
 	}
+	defer jw.recycle(second)
 	secondCtx := second.Context()
 	callbackArmed.Store(true)
 	deferred.fire()
@@ -699,10 +695,9 @@ func TestRequest_SetContextDelayedCallbackDoesNotCancelReusedRequest(t *testing.
 	}
 	select {
 	case <-secondCtx.Done():
-		t.Fatal("delayed SetContext callback canceled the reused Request")
+		t.Fatal("delayed SetContext callback canceled the next Request")
 	default:
 	}
-	jw.recycle(second)
 }
 
 func TestRequest_OutboundRespectsContextDone(t *testing.T) {
@@ -3658,27 +3653,30 @@ func waitForRequestCounts(t *testing.T, jw *Jaws, wantTotal, wantActive int, tim
 	}
 }
 
-// TestClearLockedZeroesWsQueue verifies clearLocked releases the queued wire
-// message payloads before the Request is pooled, mirroring its clear() of todoDirt
-// and elems. A bare [:0] reslice would leave the WsMsg values (including Data,
-// which holds full Inner/Replace/Append HTML payloads) live in the backing array
-// for the pooled Request's idle lifetime.
-func TestClearLockedZeroesWsQueue(t *testing.T) {
-	rq := &Request{tagMap: map[any][]*Element{}}
+// TestReleaseBuffersLockedZeroesWsQueue verifies releaseBuffersLocked releases the
+// queued wire message payloads before the storage is returned to the buffer pool,
+// mirroring its clear() of todoDirt and elems. A bare [:0] reslice would leave the
+// WsMsg values (including Data, which holds full Inner/Replace/Append HTML payloads)
+// live in the pooled backing array for its idle lifetime.
+func TestReleaseBuffersLockedZeroesWsQueue(t *testing.T) {
+	rq := &Request{tagMap: map[any][]*Element{}, buffers: &requestBuffers{}}
 	rq.wsQueue = append(
 		rq.wsQueue,
 		wire.WsMsg{Data: "payload-a", Jid: 1, What: what.Inner},
 		wire.WsMsg{Data: "payload-b", Jid: 2, What: what.Inner},
 	)
 
-	rq.clearLocked()
+	buffers := rq.releaseBuffersLocked()
 
-	if len(rq.wsQueue) != 0 {
-		t.Fatalf("wsQueue len = %d, want 0", len(rq.wsQueue))
+	if buffers == nil {
+		t.Fatal("releaseBuffersLocked returned nil buffers")
 	}
-	for i, m := range rq.wsQueue[:cap(rq.wsQueue)] {
+	if len(buffers.wsQueue) != 0 {
+		t.Fatalf("wsQueue len = %d, want 0", len(buffers.wsQueue))
+	}
+	for i, m := range buffers.wsQueue[:cap(buffers.wsQueue)] {
 		if m != (wire.WsMsg{}) {
-			t.Errorf("wsQueue backing slot %d retained data after clearLocked: %+v", i, m)
+			t.Errorf("wsQueue backing slot %d retained data after releaseBuffersLocked: %+v", i, m)
 		}
 	}
 }
@@ -3718,11 +3716,13 @@ func TestDelRequestNilsVacatedSlot(t *testing.T) {
 }
 
 // TestRequest_JawsKeyReadsAreLockedDuringRecycle verifies that the request-key
-// readers used while the application renders the initial HTML page
-// (JawsKeyString, String, HeadHTML and TailHTML) read rq.JawsKey under rq.mu, so
-// they do not race the rq.mu-guarded writes to rq.JawsKey that clearLocked and
-// getRequestLocked perform when a Request completes and its pooled storage is
-// reused. Run with -race.
+// readers used while the application renders the initial HTML page (JawsKeyString,
+// String, HeadHTML and TailHTML) read rq.JawsKey under rq.mu, so they do not race
+// the rq.mu-guarded writers active during the same window: getRequestLocked assigns
+// rq.JawsKey under rq.mu, and claim and releaseBuffersLocked mutate rq.mu-guarded
+// fields when a Request is claimed or finishes. The writer goroutine drives a
+// concurrent rq.mu-guarded key write to prove the readers hold the lock. Run with
+// -race.
 func TestRequest_JawsKeyReadsAreLockedDuringRecycle(t *testing.T) {
 	jw, err := New()
 	if err != nil {
@@ -3736,8 +3736,7 @@ func TestRequest_JawsKeyReadsAreLockedDuringRecycle(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 
-	// Writer: mimic clearLocked / getRequestLocked, which assign rq.JawsKey while
-	// holding rq.mu.
+	// Writer: mimic getRequestLocked, which assigns rq.JawsKey while holding rq.mu.
 	go func() {
 		defer wg.Done()
 		for i := range iterations {

--- a/request_test.go
+++ b/request_test.go
@@ -2721,17 +2721,13 @@ func newTestServerWithSession(t *testing.T, withSession bool, logger Logger) (ts
 	jw.Logger = logger
 	ctx, cancel := context.WithTimeout(t.Context(), time.Hour)
 	rr := httptest.NewRecorder()
-	// The initial render request uses a background (non-cancelable) context so the
-	// Request is immediately claimable: the synthetic render is already complete.
-	// The controllable context is carried by the WebSocket claim below, so ts.cancel
-	// ends the request through its httpDoneCh, mirroring a real WebSocket HTTP request.
-	hr := httptest.NewRequest(http.MethodGet, "/", nil)
+	hr := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
 	var sess *Session
 	if withSession {
 		sess = jw.NewSession(rr, hr)
 	}
 	rq := jw.NewRequest(hr)
-	if rq != jw.UseRequest(rq.JawsKey, hr.WithContext(ctx)) {
+	if rq != jw.UseRequest(rq.JawsKey, hr) {
 		panic("UseRequest failed")
 	}
 	go jw.Serve()
@@ -3258,11 +3254,9 @@ func TestWS_ConnectFnFailureDoesNotBlockOnNonReadingPeer(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(t.Context(), testTimeout)
 	defer cancel()
-	// The initial render request is claimable immediately (background context); the
-	// controllable context is carried by the WebSocket claim so it becomes httpDoneCh.
-	initial := httptest.NewRequest(http.MethodGet, "/", nil)
+	initial := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
 	rq := jw.NewRequest(initial)
-	if got := jw.UseRequest(rq.JawsKey, initial.WithContext(ctx)); got != rq {
+	if got := jw.UseRequest(rq.JawsKey, initial); got != rq {
 		t.Fatalf("UseRequest() = %v, want %v", got, rq)
 	}
 	rqCtx := rq.Context()
@@ -3369,11 +3363,9 @@ func TestWS_ConnectFnSubscriptionCleanup(t *testing.T) {
 
 			ctx, cancel := context.WithTimeout(t.Context(), testTimeout)
 			defer cancel()
-			// The initial render request is claimable immediately (background context);
-			// the controllable context rides the WebSocket claim as httpDoneCh.
-			initial := httptest.NewRequest(http.MethodGet, "/", nil)
+			initial := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
 			rq := jw.NewRequest(initial)
-			if got := jw.UseRequest(rq.JawsKey, initial.WithContext(ctx)); got != rq {
+			if got := jw.UseRequest(rq.JawsKey, initial); got != rq {
 				t.Fatalf("UseRequest() = %v, want %v", got, rq)
 			}
 			rq.SetConnectFn(tt.connectFn)
@@ -3694,6 +3686,12 @@ func TestReleaseBuffersLockedZeroesWsQueue(t *testing.T) {
 		wire.WsMsg{Data: "payload-a", Jid: 1, What: what.Inner},
 		wire.WsMsg{Data: "payload-b", Jid: 2, What: what.Inner},
 	)
+	// Simulate a drain that resliced the queue to zero length while leaving the
+	// payloads in the backing array's unused capacity (the getSendMsgs pattern before
+	// its own clear). releaseBuffersLocked must clear through capacity, not just
+	// length, so the pooled buffer retains no HTML payloads.
+	backing := rq.wsQueue[:cap(rq.wsQueue)]
+	rq.wsQueue = rq.wsQueue[:0]
 
 	buffers := rq.releaseBuffersLocked()
 
@@ -3703,7 +3701,7 @@ func TestReleaseBuffersLockedZeroesWsQueue(t *testing.T) {
 	if len(buffers.wsQueue) != 0 {
 		t.Fatalf("wsQueue len = %d, want 0", len(buffers.wsQueue))
 	}
-	for i, m := range buffers.wsQueue[:cap(buffers.wsQueue)] {
+	for i, m := range backing {
 		if m != (wire.WsMsg{}) {
 			t.Errorf("wsQueue backing slot %d retained data after releaseBuffersLocked: %+v", i, m)
 		}

--- a/request_test.go
+++ b/request_test.go
@@ -428,9 +428,9 @@ func TestRequest_TailScriptConcurrentWithRecycle(t *testing.T) {
 }
 
 // TestRequest_wantMessageConcurrentWithRecycle stresses the broadcast identity
-// check: wantMessage reads rq.JawsKey under rq.mu while recycle zeroes it under the
-// same lock. The read and write must be serialized so there is no data race on the
-// key. Run with -race.
+// check: wantMessage reads rq.registered and rq.JawsKey under rq.mu while completion
+// clears registered under the same lock. The read and write must be serialized so
+// there is no data race. Run with -race.
 func TestRequest_wantMessageConcurrentWithRecycle(t *testing.T) {
 	jw, _ := New()
 	defer jw.Close()
@@ -1150,10 +1150,11 @@ func TestBroadcast_ZeroKeyDestDropped(t *testing.T) {
 }
 
 // TestRequest_ProducersSkipRecycled covers the destKey()==0 branch in Request.Alert
-// and Request.Redirect. Once a Request is recycled it carries the zero key, so both
-// take the skip branch and never call Broadcast. A zero-key broadcast would be
-// dropped by Jaws.Broadcast anyway (see TestBroadcast_ZeroKeyDestDropped); the guard
-// avoids the round-trip, and exercising it is the only coverage of the branch.
+// and Request.Redirect. Once a Request is finished it is unregistered, so destKey()
+// returns zero (the key itself is preserved) and both take the skip branch and never
+// call Broadcast. A zero-key broadcast would be dropped by Jaws.Broadcast anyway
+// (see TestBroadcast_ZeroKeyDestDropped); the guard avoids the round-trip, and
+// exercising it is the only coverage of the branch.
 func TestRequest_ProducersSkipRecycled(t *testing.T) {
 	th := newTestHelper(t)
 	jw, _ := New()

--- a/request_test.go
+++ b/request_test.go
@@ -164,7 +164,8 @@ func TestRequest_wantMessage_RejectsFinishedRequest(t *testing.T) {
 	is.Equal(rq.wantMessage(&wire.Message{Dest: staleKey}), false)
 
 	// A later client gets a distinct Request with a distinct key. It matches only its
-	// own key, and the finished Request's key is never reassigned to it.
+	// own key, and the finished Request's key is not reassigned to it (rq is still
+	// reachable here, so its key stays reserved).
 	replacement := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/next", nil))
 	defer jw.recycle(replacement)
 	is.True(replacement != rq)

--- a/request_test.go
+++ b/request_test.go
@@ -397,8 +397,8 @@ func TestRequest_writeTailScript_IsolatesEachFixup(t *testing.T) {
 // TestRequest_TailScriptConcurrentWithRecycle exercises a /jaws/.tail fetch
 // racing recycle of the same still-pending request. The handler holds jw.mu (read)
 // across the drainTailScript call and recycle needs the jw.mu write lock, so the
-// drain and recycle are serialized: the fetch can never drain a recycled+reused
-// request. clearLocked also takes muQueue to reset wsQueue/tailsent, the lock
+// drain and recycle are serialized: the fetch can never drain a finished request.
+// releaseBuffersLocked also takes muQueue to reset wsQueue/tailsent, the lock
 // drainTailScript holds, so that reset cannot race the drain either. Run with -race.
 func TestRequest_TailScriptConcurrentWithRecycle(t *testing.T) {
 	jw, _ := New()
@@ -896,9 +896,9 @@ func TestRequest_EventFnQueueOverflowCancelsRequest(t *testing.T) {
 
 // TestRequest_ClaimRefreshesLastWriteAndStartServeGuards verifies that claim()
 // refreshes lastWrite so a request claimed long after its initial render is not
-// treated as idle and recycled before ServeHTTP sets running, and that startServe()
-// refuses a request that was recycled (clearLocked resets claimed) rather than
-// driving a dead, pooled *Request.
+// treated as idle and retired before ServeHTTP sets running, and that startServe()
+// refuses a request that has finished (recycle unregisters it and resets claimed)
+// rather than driving a finished, unregistered *Request.
 func TestRequest_ClaimRefreshesLastWriteAndStartServeGuards(t *testing.T) {
 	jw, err := New()
 	if err != nil {
@@ -1125,10 +1125,11 @@ func TestBroadcast_ZeroKeyDestDropped(t *testing.T) {
 	defer tj.Close()
 	rq := tj.newRequest(nil)
 
-	// A zero key (captured from an already-recycled request) targets no live
-	// request: Broadcast drops it before it reaches the Serve loop rather than
-	// treating it as a tag. A real follow-up still arrives, proving only the
-	// zero-key message was dropped, and no bad-destination misuse is logged.
+	// A zero key targets no live request: a real Request's key is always non-zero,
+	// and a finished Request keeps its non-zero key but is unregistered. Broadcast
+	// drops a zero-key message before it reaches the Serve loop rather than treating
+	// it as a tag. A real follow-up still arrives, proving only the zero-key message
+	// was dropped, and no bad-destination misuse is logged.
 	rq.Jaws.Broadcast(wire.Message{Dest: key.Key(0), What: what.Alert, Data: alertData("info", "dropped")})
 	rq.Alert("info", "kept")
 

--- a/request_test.go
+++ b/request_test.go
@@ -2289,13 +2289,34 @@ func TestRequestRecycle_StaleElementIsInert(t *testing.T) {
 
 	rq := jw.NewRequest(httptest.NewRequest("GET", "/", nil))
 	elem := rq.NewElement(testDivWidget{inner: "x"})
+	rq.Tag(elem, tag.Tag("stale"))
+	jawsKey := rq.JawsKey
 
 	jw.recycle(rq)
-	if elem.ui != nil {
-		t.Fatal("expected recycled element to have nil ui")
+
+	// The Request is never reused, so recycle deliberately does NOT clear the stale
+	// Element's fields (that would race an initial renderer still inside JawsRender).
+	// Inertness instead comes from the Request being unregistered and its buffers
+	// detached, and the key is reserved with a nil tombstone rather than deleted or
+	// reassigned to a different Request.
+	rq.mu.RLock()
+	registered := rq.registered
+	tagCount := len(rq.tagMap)
+	rq.mu.RUnlock()
+	if registered {
+		t.Fatal("recycled Request is still registered")
 	}
-	if got := len(rq.tagMap); got != 0 {
-		t.Fatalf("expected no tags in recycled request, got %d", got)
+	if tagCount != 0 {
+		t.Fatalf("recycled Request retained %d tags, want 0 (buffers detached)", tagCount)
+	}
+	jw.mu.RLock()
+	entry, ok := jw.requests[jawsKey]
+	jw.mu.RUnlock()
+	if !ok || entry != nil {
+		t.Fatalf("recycled key entry = (%v, present=%v), want reserved tombstone (nil, true)", entry, ok)
+	}
+	if elem.Request != rq {
+		t.Fatal("stale Element lost its Request back-pointer")
 	}
 }
 
@@ -2700,13 +2721,17 @@ func newTestServerWithSession(t *testing.T, withSession bool, logger Logger) (ts
 	jw.Logger = logger
 	ctx, cancel := context.WithTimeout(t.Context(), time.Hour)
 	rr := httptest.NewRecorder()
-	hr := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+	// The initial render request uses a background (non-cancelable) context so the
+	// Request is immediately claimable: the synthetic render is already complete.
+	// The controllable context is carried by the WebSocket claim below, so ts.cancel
+	// ends the request through its httpDoneCh, mirroring a real WebSocket HTTP request.
+	hr := httptest.NewRequest(http.MethodGet, "/", nil)
 	var sess *Session
 	if withSession {
 		sess = jw.NewSession(rr, hr)
 	}
 	rq := jw.NewRequest(hr)
-	if rq != jw.UseRequest(rq.JawsKey, hr) {
+	if rq != jw.UseRequest(rq.JawsKey, hr.WithContext(ctx)) {
 		panic("UseRequest failed")
 	}
 	go jw.Serve()
@@ -3233,9 +3258,11 @@ func TestWS_ConnectFnFailureDoesNotBlockOnNonReadingPeer(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(t.Context(), testTimeout)
 	defer cancel()
-	initial := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+	// The initial render request is claimable immediately (background context); the
+	// controllable context is carried by the WebSocket claim so it becomes httpDoneCh.
+	initial := httptest.NewRequest(http.MethodGet, "/", nil)
 	rq := jw.NewRequest(initial)
-	if got := jw.UseRequest(rq.JawsKey, initial); got != rq {
+	if got := jw.UseRequest(rq.JawsKey, initial.WithContext(ctx)); got != rq {
 		t.Fatalf("UseRequest() = %v, want %v", got, rq)
 	}
 	rqCtx := rq.Context()
@@ -3342,9 +3369,11 @@ func TestWS_ConnectFnSubscriptionCleanup(t *testing.T) {
 
 			ctx, cancel := context.WithTimeout(t.Context(), testTimeout)
 			defer cancel()
-			initial := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+			// The initial render request is claimable immediately (background context);
+			// the controllable context rides the WebSocket claim as httpDoneCh.
+			initial := httptest.NewRequest(http.MethodGet, "/", nil)
 			rq := jw.NewRequest(initial)
-			if got := jw.UseRequest(rq.JawsKey, initial); got != rq {
+			if got := jw.UseRequest(rq.JawsKey, initial.WithContext(ctx)); got != rq {
 				t.Fatalf("UseRequest() = %v, want %v", got, rq)
 			}
 			rq.SetConnectFn(tt.connectFn)

--- a/request_test.go
+++ b/request_test.go
@@ -3686,12 +3686,7 @@ func TestReleaseBuffersLockedZeroesWsQueue(t *testing.T) {
 		wire.WsMsg{Data: "payload-a", Jid: 1, What: what.Inner},
 		wire.WsMsg{Data: "payload-b", Jid: 2, What: what.Inner},
 	)
-	// Simulate a drain that resliced the queue to zero length while leaving the
-	// payloads in the backing array's unused capacity (the getSendMsgs pattern before
-	// its own clear). releaseBuffersLocked must clear through capacity, not just
-	// length, so the pooled buffer retains no HTML payloads.
 	backing := rq.wsQueue[:cap(rq.wsQueue)]
-	rq.wsQueue = rq.wsQueue[:0]
 
 	buffers := rq.releaseBuffersLocked()
 
@@ -3701,9 +3696,40 @@ func TestReleaseBuffersLockedZeroesWsQueue(t *testing.T) {
 	if len(buffers.wsQueue) != 0 {
 		t.Fatalf("wsQueue len = %d, want 0", len(buffers.wsQueue))
 	}
+	// The live queued entries must be zeroed before the buffer returns to the pool so
+	// no HTML payload is pinned. (Vacated capacity is already zeroed by the drain
+	// paths, so releaseBuffersLocked clears only the live length; see
+	// TestGetSendMsgsZeroesDrainedQueue.)
 	for i, m := range backing {
 		if m != (wire.WsMsg{}) {
 			t.Errorf("wsQueue backing slot %d retained data after releaseBuffersLocked: %+v", i, m)
+		}
+	}
+}
+
+// TestGetSendMsgsZeroesDrainedQueue verifies the outbound drain zeroes the entries it
+// removes before reslicing to zero length, so their HTML payloads are not left in the
+// backing array's unused capacity (and later carried into the pooled buffer).
+func TestGetSendMsgsZeroesDrainedQueue(t *testing.T) {
+	rq := &Request{tagMap: map[any][]*Element{}}
+	rq.wsQueue = append(
+		rq.wsQueue,
+		wire.WsMsg{Jid: 0, What: what.Reload, Data: "payload-a"},
+		wire.WsMsg{Jid: 0, What: what.Alert, Data: "payload-b"},
+	)
+	backing := rq.wsQueue[:cap(rq.wsQueue)]
+
+	toSend := rq.getSendMsgs()
+
+	if len(toSend) != 2 {
+		t.Fatalf("getSendMsgs returned %d messages, want 2", len(toSend))
+	}
+	if len(rq.wsQueue) != 0 {
+		t.Fatalf("wsQueue len after drain = %d, want 0", len(rq.wsQueue))
+	}
+	for i, m := range backing {
+		if m != (wire.WsMsg{}) {
+			t.Errorf("drained slot %d retained data after getSendMsgs: %+v", i, m)
 		}
 	}
 }

--- a/request_test.go
+++ b/request_test.go
@@ -146,9 +146,11 @@ func TestRequest_wantMessage_KeyDest(t *testing.T) {
 
 // TestRequest_wantMessage_RejectsFinishedRequest is the core broadcast regression:
 // wantMessage gates the identity-key match on rq.registered, so a finished Request
-// stops matching its own key. Because a Request identity is never reused for another
-// connection, a message aimed at a finished Request's key reaches no one, and a
-// later Request matches only its own distinct key.
+// stops matching its own key. The *Request pointer is never reused, and while the
+// finished Request stays reachable its key value is held reserved by a tombstone, so
+// a message aimed at that key reaches no one and a later Request matches only its own
+// distinct key. (Once the finished Request is collected the tombstone is removed and
+// the key value may eventually be reissued to a new Request.)
 func TestRequest_wantMessage_RejectsFinishedRequest(t *testing.T) {
 	is := newTestHelper(t)
 	jw, _ := New()

--- a/requestloop.go
+++ b/requestloop.go
@@ -340,6 +340,11 @@ func (rq *Request) getSendMsgs() (toSend []wire.WsMsg) {
 				toSend = append(toSend, rq.wsQueue[i])
 			}
 		}
+		// Zero the drained entries before reslicing so their Data payloads (full
+		// Inner/Replace/Append HTML) are released promptly rather than lingering in the
+		// backing array's unused capacity for the rest of the request (and into the
+		// pooled buffer after teardown).
+		clear(rq.wsQueue)
 		rq.wsQueue = rq.wsQueue[:0]
 	}
 

--- a/requestloop.go
+++ b/requestloop.go
@@ -26,9 +26,9 @@ import (
 func (rq *Request) process(broadcastMsgCh chan wire.Message, incomingMsgCh <-chan wire.WsMsg, outboundMsgCh chan<- wire.WsMsg) {
 	jawsDoneCh := rq.Jaws.Done()
 	// Snapshot cancelFn under rq.mu, the same way ServeHTTP does: its only writers
-	// (claim, getRequestLocked, clearLocked) run strictly before or after process,
-	// so the captured value is stable for the loop's lifetime and the cleanup defer
-	// avoids a lock-free field read.
+	// (claim, getRequestLocked, releaseBuffersLocked) run strictly before or after
+	// process, so the captured value is stable for the loop's lifetime and the
+	// cleanup defer avoids a lock-free field read.
 	rq.mu.RLock()
 	httpDoneCh := rq.httpDoneCh
 	cancelFn := rq.cancelFn

--- a/requestpool.go
+++ b/requestpool.go
@@ -1,9 +1,11 @@
 package jaws
 
-// This file manages the server-side Request pool: NewRequest creates a pending
-// Request, UseRequest claims it when the WebSocket connects, the per-IP pending
-// limit retires the oldest unclaimed Request, the random helpers mint identity
-// keys, and recycle/cancelIfCurrent tear completed Requests down.
+// This file manages server-side Request lifecycles: NewRequest creates a pending
+// Request with a fresh, never-reused identity and reusable buffers, UseRequest
+// claims it when the WebSocket connects, the per-IP pending limit retires the
+// oldest unclaimed Request, the random helpers mint identity keys, and
+// recycle/cancelIfCurrent finish completed Requests, returning only their buffers
+// to the pool.
 
 import (
 	"context"
@@ -42,10 +44,11 @@ import (
 // A Request created after [Jaws.Close] has an already-canceled context and cannot
 // be claimed by [Jaws.UseRequest].
 //
-// When timeout maintenance or the per-IP pending limit retires an unclaimed
-// Request, its key becomes unclaimable. The key also remains unavailable for
-// assignment to another Request while the retired Request is reachable; no
-// deadline is guaranteed for later reuse.
+// Every call returns a distinct Request identity that is never reused for another
+// connection. When timeout maintenance or the per-IP pending limit retires an
+// unclaimed Request, its key remains unavailable for assignment to another Request
+// while the retired Request is reachable; no deadline is guaranteed for later key
+// reuse.
 //
 // NewRequest panics if the system CSPRNG ([crypto/rand]) fails while generating
 // the request key, which does not happen on supported platforms.
@@ -234,20 +237,36 @@ func (jw *Jaws) UseRequest(jawsKey key.Key, r *http.Request) (rq *Request) {
 	return
 }
 
-// getRequestLocked allocates a Request from the pool for jawsKey. remoteIP is the
-// already-resolved client IP for r (see NewRequest, the sole caller), passed in to
-// avoid recomputing jw.clientIP(r). attachSession is false after Jaws.Close, when
-// the canceled Request is returned without registration. Caller must hold jw.mu.
-func (jw *Jaws) getRequestLocked(jawsKey key.Key, r *http.Request, remoteIP netip.Addr, attachSession bool) (rq *Request) {
-	rq = jw.reqPool.Get().(*Request)
+// getRequestLocked allocates a fresh Request identity for jawsKey, borrowing
+// reusable storage from jw.requestBufferPool. remoteIP is the already-resolved
+// client IP for r (see NewRequest, the sole caller), passed in to avoid recomputing
+// jw.clientIP(r). registered is false after Jaws.Close, when the canceled Request
+// is returned without being registered in jw.requests. Caller must hold jw.mu.
+func (jw *Jaws) getRequestLocked(jawsKey key.Key, r *http.Request, remoteIP netip.Addr, registered bool) (rq *Request) {
+	buffers := jw.requestBufferPool.Get().(*requestBuffers)
+	rq = &Request{
+		Jaws:     jw,
+		buffers:  buffers,
+		todoDirt: buffers.todoDirt,
+		elems:    buffers.elems,
+		tagMap:   buffers.tagMap,
+		wsQueue:  buffers.wsQueue,
+	}
+	// Detach the storage from the pooled holder; releaseBuffersLocked reattaches it
+	// on completion. The holder must not alias a live Request's fields.
+	buffers.todoDirt = nil
+	buffers.elems = nil
+	buffers.tagMap = nil
+	buffers.wsQueue = nil
 	rq.mu.Lock()
 	defer rq.mu.Unlock()
 	rq.JawsKey = jawsKey
+	rq.registered = registered
 	rq.lastWriteSeconds.Store(jw.runtimeSeconds.Load())
 	rq.initial = r
 	rq.remoteIP = remoteIP
 	rq.ctx, rq.cancelFn = context.WithCancelCause(jw.BaseContext)
-	if attachSession && r != nil {
+	if registered && r != nil {
 		if sess := jw.getSessionLocked(getCookieSessionsIDs(r.Header, jw.CookieName), rq.remoteIP); sess != nil {
 			sess.addRequest(rq)
 			rq.session = sess
@@ -308,6 +327,7 @@ func (jw *Jaws) retireNonRunningRequestCoreLocked(rq *Request, err error, causeO
 		// WebSocket that never reached ServeHTTP still earns the session grace
 		// period granted by Session.delRequest.
 		rq.killSessionLocked()
+		rq.registered = false
 		rq.claimed.Store(false)
 		runtime.AddCleanup(rq, releaseRetiredRequestKey, retiredRequestKey{jw: weak.Make(jw), jawsKey: jawsKey})
 	}
@@ -315,22 +335,31 @@ func (jw *Jaws) retireNonRunningRequestCoreLocked(rq *Request, err error, causeO
 	runtime.KeepAlive(rq)
 }
 
-// recycleLockedWithCause cancels and recycles rq.
+// recycleLockedWithCause finishes rq and returns its reusable buffers to
+// jw.requestBufferPool. The Request itself is never pooled or reused; it keeps its
+// identity and canceled context and is reclaimed by the garbage collector once no
+// borrower retains it.
 //
 // It uses err as the cancellation cause when non-nil.
 // It returns the cancellation cause (or nil) instead of logging it, so the caller
 // can log it after releasing jw.mu (see the package locking contract). Caller must
 // hold jw.mu.
 func (jw *Jaws) recycleLockedWithCause(rq *Request, err error) (cause error) {
+	var buffers *requestBuffers
 	rq.mu.Lock()
-	defer rq.mu.Unlock()
 	if rq.JawsKey != 0 && jw.requests[rq.JawsKey] == rq {
 		cause = rq.cancelLocked(err)
 		jw.removePendingRequestLocked(rq)
 		delete(jw.requests, rq.JawsKey)
 		jw.requestCount--
-		rq.clearLocked()
-		jw.reqPool.Put(rq)
+		buffers = rq.releaseBuffersLocked()
+	}
+	rq.mu.Unlock()
+	// Return the buffers after releasing rq.mu; requestBufferPool.Put takes no lock,
+	// but keeping the pool interaction outside the Request lock mirrors the recycle
+	// path's other post-unlock work and avoids holding rq.mu longer than needed.
+	if buffers != nil {
+		jw.requestBufferPool.Put(buffers)
 	}
 	return
 }
@@ -347,11 +376,11 @@ func (jw *Jaws) recycle(rq *Request) {
 
 // cancelIfCurrent cancels rq only if it is still the [Request] registered for
 // jawsKey. A caller that looks up a Request and later cancels it without holding
-// jw.mu in between (the /jaws/.tail write-error path in [Jaws.ServeHTTP]) holds
-// a pointer that may have been recycled and reused for a different connection,
-// and cancelling such a stale pointer would kill the unrelated new request.
-// Holding jw.mu across the cancel keeps the identity check valid, since
-// recycling requires the jw.mu write lock.
+// jw.mu in between (the /jaws/.tail write-error path in [Jaws.ServeHTTP]) holds a
+// pointer whose Request may have finished and been unregistered. Cancelling a
+// finished Request is harmless (its identity is never reused), but the identity
+// check avoids logging a spurious cancellation; holding jw.mu across the cancel
+// keeps that check valid, since finishing requires the jw.mu write lock.
 func (jw *Jaws) cancelIfCurrent(jawsKey key.Key, rq *Request, err error) {
 	var cause error
 	jw.mu.RLock()

--- a/requestpool.go
+++ b/requestpool.go
@@ -216,15 +216,8 @@ func (jw *Jaws) nonZeroRandomLocked() key.Key {
 // WebSocket messages.
 //
 // Returns nil if the key was not found, the request was already claimed by an
-// earlier WebSocket callback, the initial HTTP render is still in progress, or the
-// IP doesn't match, in which case you should return an HTTP "404 Not Found" status.
-//
-// A Request is not claimable until its initial render completes: while the initial
-// request's context is still live (the rendering handler has not returned), this
-// returns nil WITHOUT consuming the single-use key. An early or malformed
-// /jaws/<key> callback that arrives mid-render therefore gets a 404 and cannot claim
-// (and so cannot tear down) the Request while the renderer still owns it, while the
-// real WebSocket, which connects only after the page has loaded, claims it normally.
+// earlier WebSocket callback, or the IP doesn't match, in which case you
+// should return an HTTP "404 Not Found" status.
 //
 // The returned pointer is borrowed for WebSocket handling. Do not retain it
 // after [Request.ServeHTTP] returns; see [Request].
@@ -232,7 +225,7 @@ func (jw *Jaws) UseRequest(jawsKey key.Key, r *http.Request) (rq *Request) {
 	if jawsKey != 0 {
 		var err error
 		jw.mu.Lock()
-		if waitingRq, ok := jw.requests[jawsKey]; ok && waitingRq != nil && !waitingRq.initialRenderMayBeActiveLocked() {
+		if waitingRq, ok := jw.requests[jawsKey]; ok && waitingRq != nil {
 			if err = waitingRq.claim(r); err == nil {
 				rq = waitingRq
 				jw.removePendingRequestLocked(rq)

--- a/requestpool.go
+++ b/requestpool.go
@@ -216,8 +216,15 @@ func (jw *Jaws) nonZeroRandomLocked() key.Key {
 // WebSocket messages.
 //
 // Returns nil if the key was not found, the request was already claimed by an
-// earlier WebSocket callback, or the IP doesn't match, in which case you
-// should return an HTTP "404 Not Found" status.
+// earlier WebSocket callback, the initial HTTP render is still in progress, or the
+// IP doesn't match, in which case you should return an HTTP "404 Not Found" status.
+//
+// A Request is not claimable until its initial render completes: while the initial
+// request's context is still live (the rendering handler has not returned), this
+// returns nil WITHOUT consuming the single-use key. An early or malformed
+// /jaws/<key> callback that arrives mid-render therefore gets a 404 and cannot claim
+// (and so cannot tear down) the Request while the renderer still owns it, while the
+// real WebSocket, which connects only after the page has loaded, claims it normally.
 //
 // The returned pointer is borrowed for WebSocket handling. Do not retain it
 // after [Request.ServeHTTP] returns; see [Request].
@@ -225,7 +232,7 @@ func (jw *Jaws) UseRequest(jawsKey key.Key, r *http.Request) (rq *Request) {
 	if jawsKey != 0 {
 		var err error
 		jw.mu.Lock()
-		if waitingRq, ok := jw.requests[jawsKey]; ok && waitingRq != nil {
+		if waitingRq, ok := jw.requests[jawsKey]; ok && waitingRq != nil && !waitingRq.initialRenderMayBeActiveLocked() {
 			if err = waitingRq.claim(r); err == nil {
 				rq = waitingRq
 				jw.removePendingRequestLocked(rq)
@@ -348,11 +355,18 @@ func (jw *Jaws) recycleLockedWithCause(rq *Request, err error) (cause error) {
 	var buffers *requestBuffers
 	rq.mu.Lock()
 	if rq.JawsKey != 0 && jw.requests[rq.JawsKey] == rq {
+		jawsKey := rq.JawsKey
 		cause = rq.cancelLocked(err)
 		jw.removePendingRequestLocked(rq)
-		delete(jw.requests, rq.JawsKey)
+		// Reserve the key with a nil tombstone and free it only once the finished
+		// Request is unreachable (releaseRetiredRequestKey via runtime cleanup),
+		// rather than deleting it immediately. The Request keeps its identity key, so
+		// a page still emitting it must not be able to reach a different Request that
+		// happened to be minted the same key. This mirrors the retirement path.
+		jw.requests[jawsKey] = nil
 		jw.requestCount--
 		buffers = rq.releaseBuffersLocked()
+		runtime.AddCleanup(rq, releaseRetiredRequestKey, retiredRequestKey{jw: weak.Make(jw), jawsKey: jawsKey})
 	}
 	rq.mu.Unlock()
 	// Return the buffers after releasing rq.mu; requestBufferPool.Put takes no lock,

--- a/session.go
+++ b/session.go
@@ -75,7 +75,7 @@ func (sess *Session) delRequest(rq *Request) {
 			if l > 1 {
 				sess.requests[i] = sess.requests[l-1]
 			}
-			sess.requests[l-1] = nil // release the freed tail slot so it doesn't pin a recycled *Request
+			sess.requests[l-1] = nil // release the freed tail slot so it doesn't pin a finished *Request
 			sess.requests = sess.requests[:l-1]
 			break
 		}
@@ -88,7 +88,7 @@ func (sess *Session) delRequest(rq *Request) {
 		// would be reaped with its stale deadline despite recent live activity.
 		sess.deadline = time.Now().Add(time.Minute)
 	}
-	// For an unclaimed request (its bootstrap render was recycled before the
+	// For an unclaimed request (its bootstrap render finished before the
 	// WebSocket connected) leave the existing deadline intact: the creation-time
 	// grace window (see newSession), or the window left by a claimed request that
 	// departed earlier, governs the session's lifetime until a WebSocket attaches.

--- a/session_test.go
+++ b/session_test.go
@@ -463,11 +463,12 @@ func TestSession_ProducersSkipRecycled(t *testing.T) {
 	jw.recycle(live)
 }
 
-// TestSessionCloseRejectsReusedRequest covers the race between Session.Close's
-// Request snapshot and Request pooling. A pointer removed from the Session may be
-// recycled for another client before Close detaches it; that new identity must not
-// receive the old Session's reload.
-func TestSessionCloseRejectsReusedRequest(t *testing.T) {
+// TestSessionCloseDoesNotReachLaterRequest covers the window between Session.Close
+// snapshotting a Request and detaching it: the Request may finish after Close's
+// snapshot but before Close detaches it. Because Request identities are never
+// reused, a later client gets a distinct Request that must not receive the old
+// Session's reload.
+func TestSessionCloseDoesNotReachLaterRequest(t *testing.T) {
 	jw, err := New()
 	if err != nil {
 		t.Fatal(err)
@@ -525,20 +526,14 @@ func TestSessionCloseRejectsReusedRequest(t *testing.T) {
 		time.Sleep(time.Millisecond)
 	}
 
-	// sync.Pool may discard entries at any time. Keep the production reuse path
-	// deterministic by using stale as the allocation fallback as well.
-	poolNew := jw.reqPool.New
-	jw.reqPool.New = func() any { return stale }
-	defer func() { jw.reqPool.New = poolNew }()
-
 	// Drive the stale Request through the real capability endpoint. The missing
 	// WebSocket upgrade headers make ServeHTTP fail the upgrade and execute its
-	// normal stopServe/recycle path, placing stale in the production Request pool.
+	// normal stopServe completion path after Session.Close has snapshotted it.
 	staleEndpoint := httptest.NewRequest(http.MethodGet, "/jaws/"+stale.JawsKeyString(), nil)
 	staleEndpoint.RemoteAddr = sessionHTTP.RemoteAddr
 	jw.ServeHTTP(httptest.NewRecorder(), staleEndpoint)
-	if stale.JawsKey != 0 {
-		t.Fatalf("failed WebSocket upgrade did not recycle stale Request: key %v", stale.JawsKey)
+	if stale.Context().Err() == nil {
+		t.Fatal("failed WebSocket upgrade left stale Request live")
 	}
 
 	server := httptest.NewServer(jw)
@@ -546,11 +541,11 @@ func TestSessionCloseRejectsReusedRequest(t *testing.T) {
 	unrelatedHTTP := httptest.NewRequest(http.MethodGet, server.URL+"/unrelated", nil)
 	unrelatedHTTP.RemoteAddr = "127.0.0.1:2000"
 	unrelated := jw.NewRequest(unrelatedHTTP)
-	if unrelated != stale {
-		t.Fatal("request pool did not reuse stale pointer")
+	if unrelated == stale {
+		t.Fatal("later client reused stale Request identity")
 	}
 	if unrelated.Session() != nil {
-		t.Fatal("reused Request retained old Session")
+		t.Fatal("later Request retained old Session")
 	}
 	unrelatedKey := unrelated.JawsKey
 	connected := make(chan struct{})
@@ -571,7 +566,7 @@ func TestSessionCloseRejectsReusedRequest(t *testing.T) {
 	select {
 	case <-connected:
 	case <-time.After(time.Second):
-		t.Fatal("unrelated reused Request did not start its WebSocket")
+		t.Fatal("unrelated Request did not start its WebSocket")
 	}
 
 	close(releaseFirst)
@@ -592,7 +587,7 @@ func TestSessionCloseRejectsReusedRequest(t *testing.T) {
 		t.Fatalf("reading marker from unrelated Request: %v", err)
 	}
 	if strings.Contains(string(data), what.Reload.String()+"\t") {
-		t.Fatalf("old Session close reached unrelated reused Request: %q", data)
+		t.Fatalf("old Session close reached later Request: %q", data)
 	}
 	if !strings.Contains(string(data), marker) {
 		t.Fatalf("WebSocket message = %q, want marker %q", data, marker)

--- a/session_test.go
+++ b/session_test.go
@@ -396,9 +396,9 @@ func TestSession_Broadcast(t *testing.T) {
 	jw.recycle(rq2)
 }
 
-// TestSession_ProducersSkipRecycled covers stale Request pointers retained by a
-// Session snapshot while the Request is recycled or rebound. Both producers must
-// target only Requests that still belong to the Session.
+// TestSession_ProducersSkipRecycled covers a stale Request pointer retained by a
+// Session snapshot after the Request finished and detached from the Session. Both
+// producers must target only Requests that still belong to the Session.
 func TestSession_ProducersSkipRecycled(t *testing.T) {
 	th := newTestHelper(t)
 	jw, _ := New()
@@ -412,16 +412,16 @@ func TestSession_ProducersSkipRecycled(t *testing.T) {
 	live := jw.NewRequest(hr)
 	th.True(live.Session() == sess)
 
-	// Session methods operate on a snapshot after releasing sess.mu. These entries
-	// model pointers that were recycled after that snapshot: one has been cleared,
-	// and one has already acquired an unrelated nonzero identity.
-	cleared := &Request{Jaws: jw}
-	rebound := &Request{Jaws: jw, JawsKey: key.Key(0x9876)}
+	// Session methods operate on a snapshot taken after releasing sess.mu. This entry
+	// models a Request captured in that snapshot that then finished: identities are
+	// never reused, so it keeps its own (nonzero) key, but completion detached it from
+	// the Session (session == nil), so both producers must skip it.
+	finished := &Request{Jaws: jw, JawsKey: key.Key(0x9876)}
 	sess.mu.Lock()
-	sess.requests = append(sess.requests, cleared, rebound)
+	sess.requests = append(sess.requests, finished)
 	sess.mu.Unlock()
 
-	// Session.Broadcast targets only the live request, never the rebound identity.
+	// Session.Broadcast targets only the live request, never the finished one.
 	done := make(chan struct{})
 	go func() {
 		sess.Broadcast(wire.Message{What: what.Alert, Data: "info\nhi"})
@@ -440,7 +440,7 @@ func TestSession_ProducersSkipRecycled(t *testing.T) {
 	default:
 	}
 
-	// Session.Close reloads only the live request, never the rebound identity.
+	// Session.Close reloads only the live request, never the finished one.
 	closeDone := make(chan struct{})
 	go func() {
 		sess.Close()

--- a/session_test.go
+++ b/session_test.go
@@ -412,10 +412,11 @@ func TestSession_ProducersSkipRecycled(t *testing.T) {
 	live := jw.NewRequest(hr)
 	th.True(live.Session() == sess)
 
-	// Session methods operate on a snapshot taken after releasing sess.mu. This entry
-	// models a Request captured in that snapshot that then finished: identities are
-	// never reused, so it keeps its own (nonzero) key, but completion detached it from
-	// the Session (session == nil), so both producers must skip it.
+	// Session methods snapshot sess.requests under sess.mu, then process the snapshot
+	// after releasing it. This entry models a Request captured in that snapshot that
+	// then finished: identities are never reused, so it keeps its own (nonzero) key,
+	// but completion detached it from the Session (session == nil), so both producers
+	// must skip it.
 	finished := &Request{Jaws: jw, JawsKey: key.Key(0x9876)}
 	sess.mu.Lock()
 	sess.requests = append(sess.requests, finished)

--- a/tailscript.go
+++ b/tailscript.go
@@ -64,12 +64,13 @@ var jsInlineScriptEscaper = strings.NewReplacer(
 // Request (subsequent calls return sent=false so the response is 204).
 func (rq *Request) drainTailScript() (b []byte, sent bool) {
 	// Takes only muQueue and never touches the network. Jaws.ServeHTTP calls it while
-	// holding jw.mu (read), which blocks recycling (which needs the jw.mu write lock),
-	// so this Request cannot be recycled and reused under a different key mid-drain: the
-	// bytes returned always belong to the identity the handler looked up. The slow
+	// holding jw.mu (read), which blocks finishing (which needs the jw.mu write lock),
+	// so this Request cannot be unregistered and have its buffers released mid-drain:
+	// the bytes returned always belong to the identity the handler looked up. The slow
 	// network write happens afterwards in writeTailResponse with no lock held, so a
-	// stalled client cannot block recycling or the Serve loop. The data race on
-	// wsQueue/tailsent is prevented because clearLocked also takes muQueue to reset them.
+	// stalled client cannot block completion or the Serve loop. The data race on
+	// wsQueue/tailsent is prevented because releaseBuffersLocked also takes muQueue to
+	// reset them.
 	rq.muQueue.Lock()
 	defer rq.muQueue.Unlock()
 	if !rq.tailsent {
@@ -164,17 +165,17 @@ func (jw *Jaws) serveTailScript(w http.ResponseWriter, r *http.Request) (handled
 	if jawsKeyString, ok := strings.CutPrefix(r.URL.Path, "/jaws/.tail/"); ok {
 		if jawsKey, tail := key.Parse(jawsKeyString); tail == "" {
 			remoteIP := jw.clientIP(r)
-			// Hold jw.mu (read) across both the lookup and the drain: recycling needs
-			// the jw.mu write lock, so rq cannot be recycled and reused under a different
-			// key while we drain its queue. A stale key either misses the map (404) or
-			// drains its own genuine content. The network write is done after releasing
-			// jw.mu so a slow client cannot stall recycling or the Serve loop.
+			// Hold jw.mu (read) across both the lookup and the drain: finishing needs
+			// the jw.mu write lock, so rq cannot be unregistered while we drain its
+			// queue. A stale key either misses the map (404) or drains its own genuine
+			// content. The network write is done after releasing jw.mu so a slow client
+			// cannot stall completion or the Serve loop.
 			jw.mu.RLock()
 			rq := jw.requests[jawsKey]
 			// Bind the tail fetch to the client like the WebSocket claim path
 			// (Request.claim): the one-shot tail is drained only when the fetch comes from
 			// the same client IP the initial request was issued to (loopback-aware, see
-			// equalIP). rq.remoteIP is stable here because recycling requires the jw.mu
+			// equalIP). rq.remoteIP is stable here because finishing requires the jw.mu
 			// write lock. A mismatch is treated as not found, so a leaked key cannot drain
 			// (and thereby deny) another client's tail. The WebSocket carries all live
 			// data, so this only closes the cross-IP read of the already-rendered

--- a/testhelpers_test.go
+++ b/testhelpers_test.go
@@ -3,6 +3,7 @@ package jaws
 import (
 	"bytes"
 	"cmp"
+	"context"
 	"errors"
 	"fmt"
 	"html/template"
@@ -733,14 +734,12 @@ func TestNewRequestHarness_ReturnsNilOnClaimFailure(t *testing.T) {
 	}
 	t.Cleanup(jw.Close)
 
-	jw.reqPool.New = func() any {
-		rq := (&Request{
-			Jaws:   jw,
-			tagMap: make(map[any][]*Element),
-		}).clearLocked()
-		rq.claimed.Store(true)
-		return rq
-	}
+	// A canceled BaseContext makes NewRequest hand back a Request whose context is
+	// already done, so claim (and thus the harness's UseRequest) fails. Requests are
+	// never pooled or pre-claimed, so this replaces the former reqPool injection.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	jw.BaseContext = ctx
 
 	hr := httptest.NewRequest(http.MethodGet, "/", nil)
 	if rh := newRequestHarness(jw, hr); rh != nil {

--- a/testserve.go
+++ b/testserve.go
@@ -67,7 +67,7 @@ func (jw *Jaws) TestServe(rq *Request, onPanic func(recovered any)) (inCh chan w
 		// process iterates its elements would let an idle or context-cancelled
 		// request be canceled and unregistered mid-loop. Take jw.mu so the
 		// transition is serialized with the maintenance pass, which reads running
-		// under jw.mu; the final recycle resets running via clearLocked.
+		// under jw.mu; the final recycle resets running via releaseBuffersLocked.
 		jw.mu.Lock()
 		rq.running.Store(true)
 		jw.mu.Unlock()


### PR DESCRIPTION
## Problem

`Jaws.ServeHTTP` could recycle a `Request` while its initial HTTP renderer still owned the pointer (issue #195, severity: high). An early or malformed `GET /jaws/<key>` claimed a still-rendering Request, failed the WebSocket upgrade, and the deferred teardown cleared the Request and returned it to a `sync.Pool`; once reused for another connection, continued rendering corrupted an unrelated client's Request.

## Fix

Stop reusing `*Request` identities — the structural root cause. Each `NewRequest` allocates a fresh Request with a stable identity that is never handed to another connection; only the internal buffers (`todoDirt`, `elems`, `tagMap`, `wsQueue`) are pooled via `Jaws.requestBufferPool`.

- **No pointer reuse:** completion (`releaseBuffersLocked`) cancels the context, unregisters the identity, detaches the session, and returns the buffers to the pool. The `*Request` is never re-pooled, so a stale pointer can never alias a different connection.
- **Non-destructive teardown:** completion does not touch render-visible state — it leaves `Element.ui`/`handlers`, the `Jid` counter, and `JawsKey` intact. Those are read lock-free by an initial `JawsRender` that may still be running, and resetting the Jid counter would duplicate an already-streamed id. A stale Element needs no inerting since the identity is never reused.
- **Queue handoff under `muQueue`:** the `wsQueue` clear/transfer/detach is done entirely under `muQueue`, so a concurrent `Request.queue` cannot land a message in a buffer already returned to the pool.
- **Key tombstoning:** the recycle path reserves the finished key with a nil tombstone + `runtime.AddCleanup` (mirroring retirement) instead of deleting it, so a stable key is never reassigned to a different Request while a page might still emit it.
- **Prompt/bounded payload release:** the outbound drain (`getSendMsgs`) zeroes drained `wsQueue` entries, and completion clears only the live length (the shrink paths already zero vacated entries), so empty recycling stays O(1) rather than rescanning a pooled buffer's high-water capacity.

An early callback that claims and tears down a still-rendering Request is now harmless: no corruption, no race, no key reassignment — at worst a degraded render on a page that was already being probed. (An earlier revision gated claims on the initial request's context to make render/WebSocket lifetimes sequential, but that signal is unreliable — client disconnect cancels it early, a detached context stays live — and it broke streamed `/noscript` probes, so it was removed once teardown was made race-safe.)

## Tests

`request_identity_test.go` adds the #195 reproduction, the identity/late-cancel guarantee, non-destructive-teardown coverage (live `JawsRender` racing teardown; monotonic Jid across teardown; queue-vs-recycle under `-race`), the key tombstone (forced K,K,K2), and a `/noscript`-during-live-render guard. `TestGetSendMsgsZeroesDrainedQueue` and `TestReleaseBuffersLockedZeroesWsQueue` cover payload release. Existing pointer-reuse assertions were reworked to the stable-identity invariant.

## Verification

`go vet ./...`, `staticcheck` (clean), `golangci-lint` (0 issues), `go test -race ./...` and `go test -tags debug -race ./...` all pass. 100% coverage on the changed functions.

## Performance

`BenchmarkRequestLifecyclePooling/impl=pooled` (production path, main whole-Request pool → this buffer-pool + tombstone) and `BenchmarkRequestRecycleAfterHighWater`:

- Cost is a fixed per-request overhead: one fresh `*Request` struct plus the key-reservation `runtime.AddCleanup` — **+3 allocs/op** on the empty-request path.
- For real pages it is **+0.04–0.43% allocs** (100–1000 elements); the large per-page buffers stay pooled.
- Empty recycling is flat across the high-water axis (~0.5µs at highwater 0, 1K and 100K), confirming completion does not rescan retained capacity.

A follow-up will consolidate `registered`/`running`/`claimed`/`tailsent` into a single `int32` lifecycle state (kept out of this PR to keep the security fix reviewable).

Fixes #195.
