### PR TITLE
refactor: consolidate Request lifecycle flags into an atomic int32 state

### DIFF
--- a/broadcast.go
+++ b/broadcast.go
@@ -167,9 +167,9 @@ func (jw *Jaws) distributeDirt() int {
 	//     buffers until they connect or finish (bounded by the request timeout),
 	//     so a value mutated in the render-to-connect window is reflected on the first
 	//     update pass.
-	//   - A Request can finish between snapshot and append. appendDirtyTags checks
-	//     rq.registered under rq.mu (which releaseBuffersLocked also holds while
-	//     clearing it), so a finished Request discards the stale tags instead of
+	//   - A Request can finish between snapshot and append. appendDirtyTags checks the
+	//     lifecycle state under rq.mu (which finishLocked also holds when it transitions
+	//     to reqFinished), so a finished Request discards the stale tags instead of
 	//     re-materializing storage on a dead identity.
 	for _, rq := range reqs {
 		rq.appendDirtyTags(dirt)

--- a/jaws.go
+++ b/jaws.go
@@ -250,7 +250,7 @@ func (jw *Jaws) Close() {
 		if rq == nil {
 			continue
 		}
-		if rq.running.Load() {
+		if rq.loadState() == reqRunning {
 			rq.mu.Lock()
 			// Shutdown has no error cause. CancelCauseFunc is idempotent, so it
 			// also safely handles a Request whose context is already done.
@@ -322,7 +322,7 @@ func (jw *Jaws) RequestCounts() (total, active int) {
 	total = jw.requestCount
 	for _, rq := range jw.requests {
 		if rq != nil {
-			if rq.running.Load() {
+			if rq.loadState() == reqRunning {
 				active++
 			}
 		}

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -242,10 +242,10 @@ func TestJaws_CloseCancelsMixedRequestsWithoutLogging(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("active Request did not become ready")
 	}
-	if pending.running.Load() {
+	if pending.loadState() == reqRunning {
 		t.Fatal("pending Request unexpectedly marked running")
 	}
-	if !active.running.Load() {
+	if active.loadState() != reqRunning {
 		t.Fatal("active Request not marked running")
 	}
 
@@ -966,8 +966,8 @@ func TestJaws_MaxPendingRequestsPerIPToleratesUnretirableVictim(t *testing.T) {
 
 	req1 := newPendingLimitRequest("192.0.2.1:1000")
 	rq1 := jw.NewRequest(req1)
-	rq1.running.Store(true)
-	defer rq1.running.Store(false)
+	rq1.storeState(reqRunning)
+	defer rq1.storeState(reqPending)
 
 	rq2 := jw.NewRequest(newPendingLimitRequest("192.0.2.1:1001"))
 	if got := jw.Pending(); got != 2 {
@@ -1826,7 +1826,8 @@ func TestJaws_distributeDirt_AscendingOrder(t *testing.T) {
 	}
 	defer jw.Close()
 
-	rq := &Request{registered: true}
+	rq := &Request{}
+	rq.storeState(reqPending)
 	jw.mu.Lock()
 	jw.requests[1] = rq
 	jw.requestCount++
@@ -2916,7 +2917,7 @@ func newUnpooledBenchRequest(jw *Jaws) (rq *Request) {
 			}
 			rq.mu.Lock()
 			rq.JawsKey = jawsKey
-			rq.registered = true
+			rq.storeState(reqPending)
 			rq.lastWriteSeconds.Store(jw.runtimeSeconds.Load())
 			rq.remoteIP = remoteIP
 			rq.ctx, rq.cancelFn = context.WithCancelCause(jw.BaseContext)
@@ -2945,7 +2946,7 @@ func recycleUnpooledBenchRequest(jw *Jaws, rq *Request) {
 		jw.removePendingRequestLocked(rq)
 		delete(jw.requests, rq.JawsKey)
 		jw.requestCount--
-		rq.registered = false
+		rq.storeState(reqFinished)
 	}
 }
 

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -3073,6 +3073,29 @@ func BenchmarkRequestRecycleAfterHighWater(b *testing.B) {
 	}
 }
 
+// BenchmarkRequestClaimStartFinish measures the full lifecycle transition path —
+// NewRequest (pending) -> UseRequest (claimed) -> startServe (running) -> recycle
+// (finished) — which the create/recycle and high-water benchmarks do not exercise.
+// It isolates the claim/start CAS work so the lifecycle-state consolidation can be
+// compared before vs after; it does not run the WebSocket process loop.
+func BenchmarkRequestClaimStartFinish(b *testing.B) {
+	jw := newBenchPoolJaws(b)
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rq := jw.NewRequest(r)
+		if jw.UseRequest(rq.JawsKey, r) != rq {
+			b.Fatal("claim failed")
+		}
+		if !rq.startServe() {
+			b.Fatal("startServe failed")
+		}
+		jw.recycle(rq)
+		runtime.KeepAlive(rq)
+	}
+}
+
 func benchmarkSyncSubscription(b *testing.B, jw *Jaws) {
 	b.Helper()
 	for i := 0; i <= cap(jw.subCh); i++ {

--- a/request.go
+++ b/request.go
@@ -10,6 +10,7 @@ import (
 	"net/netip"
 	"net/url"
 	"slices"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -102,9 +103,7 @@ type Request struct {
 	Jaws             *Jaws                   // (read-only) the JaWS instance the Request belongs to
 	JawsKey          key.Key                 // (read-only) random key assigned to this Request; routes JaWS URLs and request-targeted broadcasts only while registered
 	remoteIP         netip.Addr              // (read-only) remote IP, or the zero netip.Addr if unset
-	registered       bool                    // present as a live identity in Jaws.requests; guarded by mu
-	running          atomic.Bool             // if ServeHTTP() is running
-	claimed          atomic.Bool             // if UseRequest() has been called for it
+	state            atomic.Int32            // reqState lifecycle (reqUnclaimable/reqPending/reqClaimed/reqRunning/reqFinished); see loadState/casState
 	lastWriteSeconds atomic.Int32            // [Jaws.runtimeSeconds] value at the most recent RequestWriter write; lock-free, drives pending-eviction preference (pendingEvictionVictimLocked) and idle expiry (maintenance)
 	mu               deadlock.RWMutex        // protects following
 	lastJid          Jid                     // last element Jid allocated within this Request
@@ -127,6 +126,69 @@ type eventFnCall struct {
 	jid  Jid
 	wht  what.What
 	data string
+}
+
+// reqState is the lifecycle state of a [Request], stored in Request.state as an
+// atomic int32. It consolidates what were separate registered/claimed/running flags
+// so the transitions are explicit and race-safe. The live states are reqPending,
+// reqClaimed and reqRunning; reqUnclaimable and reqFinished are terminal.
+type reqState int32
+
+const (
+	reqUnclaimable reqState = iota // created after Jaws.Close: canceled, never registered
+	reqPending                     // registered; initial render and the wait-for-WebSocket window
+	reqClaimed                     // UseRequest claimed it; ServeHTTP not yet running
+	reqRunning                     // ServeHTTP WebSocket loop running
+	reqFinished                    // completed or retired; unregistered
+)
+
+func (s reqState) String() string {
+	switch s {
+	case reqUnclaimable:
+		return "unclaimable"
+	case reqPending:
+		return "pending"
+	case reqClaimed:
+		return "claimed"
+	case reqRunning:
+		return "running"
+	case reqFinished:
+		return "finished"
+	default:
+		return "reqState(" + strconv.Itoa(int(s)) + ")"
+	}
+}
+
+// registered reports whether the Request is a live entry in Jaws.requests and a
+// valid identity-targeted broadcast destination.
+func (s reqState) registered() bool { return s == reqPending || s == reqClaimed || s == reqRunning }
+
+// claimed reports whether UseRequest has claimed the Request (it has reached at least
+// reqClaimed and is not a terminal state).
+func (s reqState) claimed() bool { return s == reqClaimed || s == reqRunning }
+
+func (rq *Request) loadState() reqState   { return reqState(rq.state.Load()) }
+func (rq *Request) storeState(s reqState) { rq.state.Store(int32(s)) }
+func (rq *Request) casState(old, want reqState) bool {
+	return rq.state.CompareAndSwap(int32(old), int32(want))
+}
+
+// finishLocked detaches a live Request from its Session and transitions it to
+// reqFinished. It captures whether the Request had been claimed before the
+// transition so [Session.delRequest] can still grant the claimed-WebSocket grace
+// window. Caller must hold rq.mu (and, for the map bookkeeping, jw.mu); the Request
+// must be in a live state (debug builds panic otherwise, catching a double-finish or
+// a terminal-state resurrection).
+func (rq *Request) finishLocked() {
+	// Capture the claimed status before the transition so delRequest can grant the
+	// grace window; rq.mu is held, so the state cannot change between here and the
+	// store below.
+	prev := rq.loadState()
+	if deadlock.Debug && !prev.registered() {
+		panic("jaws: finishLocked called on a terminal (non-live) Request state")
+	}
+	rq.killSessionLocked(prev.claimed())
+	rq.storeState(reqFinished)
 }
 
 // JawsKeyString returns the request key in the text form used by JaWS URLs.
@@ -188,7 +250,7 @@ func (rq *Request) advanceLastWriteSeconds(now int32) {
 // itself outlive the Request.)
 func (rq *Request) destKey() (k key.Key) {
 	rq.mu.RLock()
-	if rq.registered {
+	if rq.loadState().registered() {
 		k = rq.JawsKey
 	}
 	rq.mu.RUnlock()
@@ -202,7 +264,7 @@ func (rq *Request) destKey() (k key.Key) {
 // cleanup). Returns [ErrWebSocketIPMismatch] if the client IP does not match,
 // or [ErrRequestAlreadyClaimed] if it was already claimed.
 func (rq *Request) claim(r *http.Request) error {
-	if !rq.claimed.Load() {
+	if !rq.loadState().claimed() {
 		var actualIP netip.Addr
 		var httpDoneCh <-chan struct{}
 		if r != nil { // can be nil in tests
@@ -217,7 +279,7 @@ func (rq *Request) claim(r *http.Request) error {
 		if rq.ctx.Err() != nil {
 			return context.Cause(rq.ctx)
 		}
-		if rq.claimed.CompareAndSwap(false, true) {
+		if rq.casState(reqPending, reqClaimed) {
 			// Layer a fresh cancelable context over the current one (which may
 			// have been customized via SetContext) so the claim has its own
 			// cancel handle. The previous cancelFn must still be invoked on
@@ -243,16 +305,20 @@ func (rq *Request) claim(r *http.Request) error {
 	return ErrRequestAlreadyClaimed
 }
 
-func (rq *Request) killSessionLocked() {
+// killSessionLocked detaches the Request from its Session, if any. wasClaimed tells
+// [Session.delRequest] whether to grant the claimed-WebSocket grace window; the
+// caller must capture it from the lifecycle state before the finish transition, since
+// the state is not consulted here. Caller must hold rq.mu.
+func (rq *Request) killSessionLocked(wasClaimed bool) {
 	if rq.session != nil {
-		rq.session.delRequest(rq)
+		rq.session.delRequest(rq, wasClaimed)
 		rq.session = nil
 	}
 }
 
-func (rq *Request) killSession() {
+func (rq *Request) killSession(wasClaimed bool) {
 	rq.mu.Lock()
-	rq.killSessionLocked()
+	rq.killSessionLocked(wasClaimed)
 	rq.mu.Unlock()
 }
 
@@ -312,8 +378,10 @@ func (rq *Request) ensureAutoSession(w http.ResponseWriter, r *http.Request) {
 // under rq.mu so Jids stay monotonic and unique, and wsQueue is transferred under
 // muQueue — so there is no data race, no reused identity, and no duplicated Jid.
 func (rq *Request) releaseBuffersLocked() (buffers *requestBuffers) {
-	// Cancel first so a retained context observes cancellation, then detach the
-	// Request from its session and unregister its identity.
+	// Pure buffer mechanics: the caller (recycleLockedWithCause) has already cancelled
+	// the context, called finishLocked (which detached the session and transitioned to
+	// reqFinished), and removed the map entry. This only detaches the reusable
+	// collections for the pool.
 	//
 	// Deliberately do NOT reset lastJid or clear Element.ui/handlers/deleted here.
 	// The Request is never reused, so a stale *Element is unreachable through the
@@ -322,13 +390,6 @@ func (rq *Request) releaseBuffersLocked() (buffers *requestBuffers) {
 	// Element.ui and handlers lock-free) or duplicate an already-streamed Jid if the
 	// renderer keeps allocating. The render-input fields (initial, connectFn,
 	// remoteIP) are likewise preserved; they are collected with the Request.
-	if rq.cancelFn != nil {
-		rq.cancelFn(nil)
-	}
-	rq.killSessionLocked()
-	rq.running.Store(false)
-	rq.claimed.Store(false)
-	rq.registered = false
 
 	// Detach the reusable collections and hand them to the pool. Clear only the live
 	// length: every production path that shrinks a buffer already zeroes the vacated
@@ -505,7 +566,7 @@ func (rq *Request) replaceContext(fn func(oldCtx context.Context) (newCtx contex
 // can log it after releasing jw.mu — logging runs the user [Jaws.Logger], which
 // must not be invoked under a lock.
 func (rq *Request) maintenance(nowSeconds int32, requestTimeout time.Duration) (expired bool, cause error) {
-	if !rq.running.Load() {
+	if rq.loadState() != reqRunning {
 		rq.mu.Lock()
 		if rq.ctx.Err() != nil {
 			expired = true
@@ -659,7 +720,7 @@ func (rq *Request) wantMessage(msg *wire.Message) (yes bool) {
 	switch dest := msg.Dest.(type) {
 	case key.Key: // the request with this identity key
 		rq.mu.RLock()
-		if rq.registered {
+		if rq.loadState().registered() {
 			yes = rq.JawsKey == dest
 		}
 		rq.mu.RUnlock()
@@ -772,7 +833,7 @@ func (rq *Request) HasTag(elem *Element, tagValue any) (yes bool) {
 // the tags are discarded rather than accumulating on a dead identity.
 func (rq *Request) appendDirtyTags(tags []any) {
 	rq.mu.Lock()
-	if rq.registered {
+	if rq.loadState().registered() {
 		rq.todoDirt = append(rq.todoDirt, tags...)
 	}
 	rq.mu.Unlock()
@@ -990,7 +1051,9 @@ func (rq *Request) startServe() (ok bool) {
 	registered := rq.Jaws.requests[rq.JawsKey] == rq
 	contextLive := rq.ctx != nil && rq.ctx.Err() == nil
 	rq.mu.RUnlock()
-	return registered && contextLive && rq.claimed.Load() && rq.running.CompareAndSwap(false, true)
+	// casState(reqClaimed, reqRunning) atomically requires the Request to be claimed
+	// (not already running, retired, or unclaimed) and transitions it to running.
+	return registered && contextLive && rq.casState(reqClaimed, reqRunning)
 }
 
 func (rq *Request) stopServe() {

--- a/request.go
+++ b/request.go
@@ -176,13 +176,19 @@ func (rq *Request) casState(old, want reqState) bool {
 // finishLocked detaches a live Request from its Session and transitions it to
 // reqFinished. It captures whether the Request had been claimed before the
 // transition so [Session.delRequest] can still grant the claimed-WebSocket grace
-// window. Caller must hold rq.mu (and, for the map bookkeeping, jw.mu); the Request
-// must be in a live state (debug builds panic otherwise, catching a double-finish or
-// a terminal-state resurrection).
+// window.
+//
+// Caller must hold both rq.mu and jw.mu. Both are required to keep the read-then-store
+// atomic against the other lifecycle transitions: [Request.claim] runs its
+// reqPending->reqClaimed CAS under rq.mu, while [Request.startServe] runs its
+// reqClaimed->reqRunning CAS under jw.mu (not rq.mu). Holding only one lock would let
+// the other transition interleave between the load and the store below. The Request
+// must be in a live state (debug builds panic otherwise, catching a double-finish or a
+// terminal-state resurrection).
 func (rq *Request) finishLocked() {
 	// Capture the claimed status before the transition so delRequest can grant the
-	// grace window; rq.mu is held, so the state cannot change between here and the
-	// store below.
+	// grace window. Holding both rq.mu and jw.mu (see the doc comment) keeps the state
+	// stable between this load and the store below.
 	prev := rq.loadState()
 	if deadlock.Debug && !prev.registered() {
 		panic("jaws: finishLocked called on a terminal (non-live) Request state")
@@ -360,13 +366,15 @@ func (rq *Request) ensureAutoSession(w http.ResponseWriter, r *http.Request) {
 // releaseBuffersLocked detaches the reusable storage from a finished Request and
 // returns it for the caller to return to [Jaws.requestBufferPool].
 //
-// It cancels any live context, detaches and clears the reusable collections (the
-// element list, tag map, dirt list and message queue), kills any attached session
-// and clears the registered flag. It does NOT mutate the individual Element objects'
-// fields or the Jid counter. The Request keeps its identity key and canceled context,
-// so a pointer retained by the initial renderer or by background work stays
-// permanently bound to this finished lifecycle and is never reused for another
-// connection.
+// It detaches and clears the reusable collections (the element list, tag map, dirt
+// list and message queue) only. It does NOT cancel the context, detach the session,
+// or change the lifecycle state: the caller (recycleLockedWithCause) has already
+// cancelled the context and called [Request.finishLocked], which detaches the session
+// and transitions the Request to reqFinished. It also does not mutate the individual
+// Element objects' fields or the Jid counter. The Request keeps its identity key and
+// canceled context, so a pointer retained by the initial renderer or by background
+// work stays permanently bound to this finished lifecycle and is never reused for
+// another connection.
 //
 // The caller must hold rq.mu. The WebSocket processing loop must have exited, but an
 // initial HTTP renderer may still be running concurrently (an early callback can

--- a/request_state_test.go
+++ b/request_state_test.go
@@ -259,12 +259,17 @@ func TestServe_CloseRaceIsSafe(t *testing.T) {
 			t.Fatal("claim failed")
 		}
 
-		// Only the TestServe goroutine touches gotPanic and served; the WaitGroup's
-		// Done->Wait edge publishes both to the assertions below without a data race.
+		// gotPanic is the synchronous setup panic (Close won before serving started);
+		// asyncPanic is anything TestServe's process/recycle goroutine recovers, handed
+		// back via onPanic before doneCh closes. Both are written only by the TestServe
+		// goroutine (asyncPanic under the onPanic->close(doneCh)->{<-doneCh} edge), and
+		// the WaitGroup's Done->Wait edge publishes them to the assertions below, so the
+		// reads are race-free.
 		var (
-			wg       sync.WaitGroup
-			gotPanic any
-			served   bool
+			wg         sync.WaitGroup
+			gotPanic   any
+			asyncPanic any
+			served     bool
 		)
 		wg.Add(2)
 		go func() {
@@ -274,7 +279,7 @@ func TestServe_CloseRaceIsSafe(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			defer func() { gotPanic = recover() }()
-			inCh, _, _, readyCh, doneCh := jw.TestServe(rq, func(any) {})
+			inCh, _, _, readyCh, doneCh := jw.TestServe(rq, func(recovered any) { asyncPanic = recovered })
 			<-readyCh
 			close(inCh)
 			<-doneCh
@@ -282,6 +287,13 @@ func TestServe_CloseRaceIsSafe(t *testing.T) {
 		}()
 		wg.Wait()
 
+		// A panic escaping the process/recycle goroutine is delivered here via onPanic
+		// instead of being discarded: a terminal->running resurrection reaching recycle
+		// would trip finishLocked's assertion, which the final reqFinished check below
+		// cannot see (recycle still ends the request finished).
+		if asyncPanic != nil {
+			t.Fatalf("iteration %d: TestServe process/recycle goroutine panicked: %#v", i, asyncPanic)
+		}
 		if gotPanic != nil {
 			if msg, ok := gotPanic.(string); !ok || !strings.HasPrefix(msg, "jaws: TestServe") {
 				t.Fatalf("iteration %d: unexpected panic %#v", i, gotPanic)

--- a/request_state_test.go
+++ b/request_state_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -157,6 +158,10 @@ func TestFinishLockedTerminalStatePanicsInDebug(t *testing.T) {
 			t.Error("finishLocked on a terminal state did not panic")
 		}
 	}()
+	// finishLocked requires both jw.mu and rq.mu (jw.mu is acquired first, matching the
+	// production lock order in recycleLockedWithCause/retireNonRunningRequestCoreLocked).
+	jw.mu.Lock()
+	defer jw.mu.Unlock()
 	rq.mu.Lock()
 	defer rq.mu.Unlock()
 	rq.finishLocked()
@@ -233,11 +238,15 @@ func TestServe_DuplicatePanicsWithoutDisturbingFirst(t *testing.T) {
 	<-doneCh
 }
 
-// TestServe_CloseRaceIsSafe races Jaws.Close against TestServe. TestServe either
-// serves cleanly (Close lost) or panics on the failed transition (Close won); either
-// is fine, and a finished Request is never resurrected into running. Run with -race.
+// TestServe_CloseRaceIsSafe races Jaws.Close against TestServe. Exactly one outcome
+// is legal: TestServe won and served cleanly, or Close won and TestServe refused via
+// one of its "jaws: TestServe" setup-failure panics (the subscription timed out
+// against the stopped Serve loop, or the checked reqClaimed->reqRunning transition
+// failed). Any other panic — a terminal->running resurrection, a nil dereference, a
+// double-finish assertion — is a bug. Whichever side wins, the Request must end
+// reqFinished and must never be resurrected from a terminal state. Run with -race.
 func TestServe_CloseRaceIsSafe(t *testing.T) {
-	for range 50 {
+	for i := range 50 {
 		jw, err := New()
 		if err != nil {
 			t.Fatal(err)
@@ -250,7 +259,13 @@ func TestServe_CloseRaceIsSafe(t *testing.T) {
 			t.Fatal("claim failed")
 		}
 
-		var wg sync.WaitGroup
+		// Only the TestServe goroutine touches gotPanic and served; the WaitGroup's
+		// Done->Wait edge publishes both to the assertions below without a data race.
+		var (
+			wg       sync.WaitGroup
+			gotPanic any
+			served   bool
+		)
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
@@ -258,12 +273,25 @@ func TestServe_CloseRaceIsSafe(t *testing.T) {
 		}()
 		go func() {
 			defer wg.Done()
-			defer func() { _ = recover() }() // TestServe panics if Close won the race
+			defer func() { gotPanic = recover() }()
 			inCh, _, _, readyCh, doneCh := jw.TestServe(rq, func(any) {})
 			<-readyCh
 			close(inCh)
 			<-doneCh
+			served = true
 		}()
 		wg.Wait()
+
+		if gotPanic != nil {
+			if msg, ok := gotPanic.(string); !ok || !strings.HasPrefix(msg, "jaws: TestServe") {
+				t.Fatalf("iteration %d: unexpected panic %#v", i, gotPanic)
+			}
+			if served {
+				t.Fatalf("iteration %d: TestServe both served and panicked", i)
+			}
+		}
+		if got := rq.loadState(); got != reqFinished {
+			t.Fatalf("iteration %d: final state = %v, want finished", i, got)
+		}
 	}
 }

--- a/request_state_test.go
+++ b/request_state_test.go
@@ -1,0 +1,269 @@
+package jaws
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/linkdata/deadlock"
+)
+
+func TestReqStateString(t *testing.T) {
+	for s, want := range map[reqState]string{
+		reqUnclaimable: "unclaimable",
+		reqPending:     "pending",
+		reqClaimed:     "claimed",
+		reqRunning:     "running",
+		reqFinished:    "finished",
+		reqState(99):   "reqState(99)",
+	} {
+		if got := s.String(); got != want {
+			t.Errorf("reqState(%d).String() = %q, want %q", int(s), got, want)
+		}
+	}
+}
+
+// TestRequestStateTransitions covers the lifecycle state machine: the normal
+// pending -> claimed -> running -> finished path, the direct finish paths a
+// never-claimed or claimed-but-not-running Request takes, and that duplicate
+// claim/startServe are rejected (a normal CAS failure) without moving the state.
+func TestRequestStateTransitions(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+	go jw.Serve()
+	waitForServeLoop(t, jw)
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	t.Run("pending->claimed->running->finished", func(t *testing.T) {
+		rq := jw.NewRequest(r)
+		if got := rq.loadState(); got != reqPending {
+			t.Fatalf("after NewRequest = %v, want pending", got)
+		}
+		if jw.UseRequest(rq.JawsKey, r) != rq {
+			t.Fatal("claim failed")
+		}
+		if got := rq.loadState(); got != reqClaimed {
+			t.Fatalf("after claim = %v, want claimed", got)
+		}
+		if !rq.startServe() {
+			t.Fatal("startServe failed")
+		}
+		if got := rq.loadState(); got != reqRunning {
+			t.Fatalf("after startServe = %v, want running", got)
+		}
+		jw.recycle(rq)
+		if got := rq.loadState(); got != reqFinished {
+			t.Fatalf("after recycle = %v, want finished", got)
+		}
+	})
+
+	t.Run("recycle_never_claimed_pending->finished", func(t *testing.T) {
+		rq := jw.NewRequest(r)
+		if got := rq.loadState(); got != reqPending {
+			t.Fatalf("state = %v, want pending", got)
+		}
+		jw.recycle(rq)
+		if got := rq.loadState(); got != reqFinished {
+			t.Fatalf("after recycle = %v, want finished", got)
+		}
+	})
+
+	t.Run("retire_claimed_not_running->finished", func(t *testing.T) {
+		rq := jw.NewRequest(r)
+		if jw.UseRequest(rq.JawsKey, r) != rq {
+			t.Fatal("claim failed")
+		}
+		if got := rq.loadState(); got != reqClaimed {
+			t.Fatalf("state = %v, want claimed", got)
+		}
+		jw.mu.Lock()
+		jw.retireNonRunningRequestLocked(rq)
+		jw.mu.Unlock()
+		if got := rq.loadState(); got != reqFinished {
+			t.Fatalf("after retire = %v, want finished", got)
+		}
+	})
+
+	t.Run("double_claim_and_double_startServe_rejected", func(t *testing.T) {
+		rq := jw.NewRequest(r)
+		if jw.UseRequest(rq.JawsKey, r) != rq {
+			t.Fatal("first claim failed")
+		}
+		if jw.UseRequest(rq.JawsKey, r) != nil {
+			t.Fatal("second claim should fail")
+		}
+		if got := rq.loadState(); got != reqClaimed {
+			t.Fatalf("after double claim = %v, want claimed", got)
+		}
+		if !rq.startServe() {
+			t.Fatal("first startServe failed")
+		}
+		if rq.startServe() {
+			t.Fatal("second startServe should fail")
+		}
+		if got := rq.loadState(); got != reqRunning {
+			t.Fatalf("after double startServe = %v, want running", got)
+		}
+		jw.recycle(rq)
+	})
+
+	t.Run("terminal_stays_finished", func(t *testing.T) {
+		rq := jw.NewRequest(r)
+		jw.recycle(rq)
+		if got := rq.loadState(); got != reqFinished {
+			t.Fatalf("state = %v, want finished", got)
+		}
+		// A finished Request is not claimable, not startable, and a second recycle is
+		// a no-op (the map-identity guard fails), so it never resurrects.
+		if jw.UseRequest(rq.JawsKey, r) != nil {
+			t.Fatal("finished Request must not be claimable")
+		}
+		if rq.startServe() {
+			t.Fatal("finished Request must not start serving")
+		}
+		jw.recycle(rq)
+		if got := rq.loadState(); got != reqFinished {
+			t.Fatalf("after double recycle = %v, want finished", got)
+		}
+	})
+}
+
+// TestFinishLockedTerminalStatePanicsInDebug verifies the debug-only invariant
+// assertion in finishLocked: calling it on a terminal (non-live) state panics in
+// debug/race builds, catching a double-finish or terminal-state resurrection. The
+// assertion is compiled out in release builds, so this only exercises the panic
+// when deadlock.Debug is set (the module's tests always run with -race).
+func TestFinishLockedTerminalStatePanicsInDebug(t *testing.T) {
+	if !deadlock.Debug {
+		t.Skip("finishLocked assertion is only active when deadlock.Debug is set (run with -race)")
+	}
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+
+	rq := &Request{Jaws: jw}
+	rq.storeState(reqFinished)
+
+	defer func() {
+		if recover() == nil {
+			t.Error("finishLocked on a terminal state did not panic")
+		}
+	}()
+	rq.mu.Lock()
+	defer rq.mu.Unlock()
+	rq.finishLocked()
+}
+
+// TestClaimPostCloseReturnsCauseNotAlreadyClaimed covers the claim fast path for a
+// terminal (reqUnclaimable) Request: it must return the cancellation cause, as an
+// unclaimed canceled Request always has, not ErrRequestAlreadyClaimed.
+func TestClaimPostCloseReturnsCauseNotAlreadyClaimed(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	jw.Close()
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	rq := jw.NewRequest(r)
+	if got := rq.loadState(); got != reqUnclaimable {
+		t.Fatalf("post-Close state = %v, want unclaimable", got)
+	}
+	err = rq.claim(r)
+	if err == nil {
+		t.Fatal("post-Close claim should fail")
+	}
+	if errors.Is(err, ErrRequestAlreadyClaimed) {
+		t.Fatalf("post-Close claim = %v, want the cancellation cause, not ErrRequestAlreadyClaimed", err)
+	}
+	if rq.loadState().claimed() {
+		t.Fatal("post-Close Request must not be marked claimed")
+	}
+}
+
+// TestServe_DuplicatePanicsWithoutDisturbingFirst verifies the checked transition:
+// a second TestServe on an already-running Request panics (failed reqClaimed ->
+// reqRunning) and must not recycle the Request or stop the first serve.
+func TestServe_DuplicatePanicsWithoutDisturbingFirst(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+	go jw.Serve()
+	waitForServeLoop(t, jw)
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	rq := jw.NewRequest(r)
+	if jw.UseRequest(rq.JawsKey, r) != rq {
+		t.Fatal("claim failed")
+	}
+
+	inCh, _, _, readyCh, doneCh := jw.TestServe(rq, func(recovered any) {
+		if recovered != nil {
+			panic(recovered)
+		}
+	})
+	<-readyCh
+
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Error("duplicate TestServe did not panic")
+			}
+		}()
+		jw.TestServe(rq, func(any) {})
+	}()
+
+	// The first serve must be undisturbed: still running, stoppable via its own inCh.
+	select {
+	case <-doneCh:
+		t.Fatal("first TestServe stopped after the duplicate")
+	default:
+	}
+	close(inCh)
+	<-doneCh
+}
+
+// TestServe_CloseRaceIsSafe races Jaws.Close against TestServe. TestServe either
+// serves cleanly (Close lost) or panics on the failed transition (Close won); either
+// is fine, and a finished Request is never resurrected into running. Run with -race.
+func TestServe_CloseRaceIsSafe(t *testing.T) {
+	for range 50 {
+		jw, err := New()
+		if err != nil {
+			t.Fatal(err)
+		}
+		go jw.Serve()
+		waitForServeLoop(t, jw)
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		rq := jw.NewRequest(r)
+		if jw.UseRequest(rq.JawsKey, r) != rq {
+			t.Fatal("claim failed")
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			jw.Close()
+		}()
+		go func() {
+			defer wg.Done()
+			defer func() { _ = recover() }() // TestServe panics if Close won the race
+			inCh, _, _, readyCh, doneCh := jw.TestServe(rq, func(any) {})
+			<-readyCh
+			close(inCh)
+			<-doneCh
+		}()
+		wg.Wait()
+	}
+}

--- a/request_test.go
+++ b/request_test.go
@@ -145,12 +145,13 @@ func TestRequest_wantMessage_KeyDest(t *testing.T) {
 }
 
 // TestRequest_wantMessage_RejectsFinishedRequest is the core broadcast regression:
-// wantMessage gates the identity-key match on rq.registered, so a finished Request
-// stops matching its own key. The *Request pointer is never reused, and while the
-// finished Request stays reachable its key value is held reserved by a tombstone, so
-// a message aimed at that key reaches no one and a later Request matches only its own
-// distinct key. (Once the finished Request is collected the tombstone is removed and
-// the key value may eventually be reissued to a new Request.)
+// wantMessage gates the identity-key match on the registered() lifecycle state, so
+// a finished Request stops matching its own key. The *Request pointer is never
+// reused, and while the finished Request stays reachable its key value is held
+// reserved by a tombstone, so a message aimed at that key reaches no one and a later
+// Request matches only its own distinct key. (Once the finished Request is collected
+// the tombstone is removed and the key value may eventually be reissued to a new
+// Request.)
 func TestRequest_wantMessage_RejectsFinishedRequest(t *testing.T) {
 	is := newTestHelper(t)
 	jw, _ := New()
@@ -431,9 +432,9 @@ func TestRequest_TailScriptConcurrentWithRecycle(t *testing.T) {
 }
 
 // TestRequest_wantMessageConcurrentWithRecycle stresses the broadcast identity
-// check: wantMessage reads rq.registered and rq.JawsKey under rq.mu while completion
-// clears registered under the same lock. The read and write must be serialized so
-// there is no data race. Run with -race.
+// check: wantMessage reads the lifecycle state and rq.JawsKey under rq.mu while
+// completion transitions the state to reqFinished under the same lock. The read and
+// write must be serialized so there is no data race. Run with -race.
 func TestRequest_wantMessageConcurrentWithRecycle(t *testing.T) {
 	jw, _ := New()
 	defer jw.Close()
@@ -973,7 +974,7 @@ func TestRequest_ClaimRejectsCanceledRequest(t *testing.T) {
 	if !errors.Is(err, wantCause) {
 		t.Fatalf("claim error = %v, want cause %v", err, wantCause)
 	}
-	if rq.claimed.Load() {
+	if rq.loadState().claimed() {
 		t.Fatal("canceled request was marked claimed")
 	}
 	if rq.httpDoneCh != nil {
@@ -2305,7 +2306,7 @@ func TestRequestRecycle_StaleElementIsInert(t *testing.T) {
 	// detached, and the key is reserved with a nil tombstone rather than deleted or
 	// reassigned to a different Request.
 	rq.mu.RLock()
-	registered := rq.registered
+	registered := rq.loadState().registered()
 	tagCount := len(rq.tagMap)
 	rq.mu.RUnlock()
 	if registered {
@@ -3747,7 +3748,7 @@ func TestDelRequestNilsVacatedSlot(t *testing.T) {
 		rq1, rq2 := &Request{}, &Request{}
 		sess.requests = []*Request{rq1, rq2}
 
-		sess.delRequest(rq1)
+		sess.delRequest(rq1, false)
 
 		if len(sess.requests) != 1 || sess.requests[0] != rq2 {
 			t.Fatalf("requests = %v, want [rq2]", sess.requests)
@@ -3762,7 +3763,7 @@ func TestDelRequestNilsVacatedSlot(t *testing.T) {
 		rq1 := &Request{}
 		sess.requests = []*Request{rq1}
 
-		sess.delRequest(rq1)
+		sess.delRequest(rq1, false)
 
 		if len(sess.requests) != 0 {
 			t.Fatalf("requests len = %d, want 0", len(sess.requests))
@@ -3843,7 +3844,7 @@ func TestServe_MarksRequestRunningSoMaintenanceSkips(t *testing.T) {
 	}()
 
 	<-tr.ReadyCh
-	if !tr.running.Load() {
+	if tr.loadState() != reqRunning {
 		t.Fatal("TestServe must mark the request running so maintenance cannot retire it mid-process")
 	}
 

--- a/requestloop.go
+++ b/requestloop.go
@@ -39,7 +39,9 @@ func (rq *Request) process(broadcastMsgCh chan wire.Message, incomingMsgCh <-cha
 
 	defer func() {
 		rq.Jaws.unsubscribe(broadcastMsgCh)
-		rq.killSession()
+		// process runs only for a running (hence claimed) Request, so its WebSocket
+		// earns the session grace window.
+		rq.killSession(rq.loadState().claimed())
 		cancelFn(nil)
 		close(eventCallCh)
 		for {

--- a/requestpool.go
+++ b/requestpool.go
@@ -261,7 +261,11 @@ func (jw *Jaws) getRequestLocked(jawsKey key.Key, r *http.Request, remoteIP neti
 	rq.mu.Lock()
 	defer rq.mu.Unlock()
 	rq.JawsKey = jawsKey
-	rq.registered = registered
+	if registered {
+		rq.storeState(reqPending)
+	} else {
+		rq.storeState(reqUnclaimable) // created after Jaws.Close: canceled, not claimable
+	}
 	rq.lastWriteSeconds.Store(jw.runtimeSeconds.Load())
 	rq.initial = r
 	rq.remoteIP = remoteIP
@@ -313,7 +317,7 @@ func (jw *Jaws) retireNonRunningRequestWithCauseLocked(rq *Request, err error) (
 // must hold jw.mu, and rq must not be running.
 func (jw *Jaws) retireNonRunningRequestCoreLocked(rq *Request, err error, causeOut *error) {
 	rq.mu.Lock()
-	if rq.JawsKey != 0 && jw.requests[rq.JawsKey] == rq && !rq.running.Load() {
+	if rq.JawsKey != 0 && jw.requests[rq.JawsKey] == rq && rq.loadState() != reqRunning {
 		jawsKey := rq.JawsKey
 		if causeOut != nil {
 			*causeOut = rq.cancelLocked(err)
@@ -323,12 +327,11 @@ func (jw *Jaws) retireNonRunningRequestCoreLocked(rq *Request, err error, causeO
 		jw.removePendingRequestLocked(rq)
 		jw.requests[jawsKey] = nil
 		jw.requestCount--
-		// Preserve the claimed state until session removal observes it. A claimed
-		// WebSocket that never reached ServeHTTP still earns the session grace
-		// period granted by Session.delRequest.
-		rq.killSessionLocked()
-		rq.registered = false
-		rq.claimed.Store(false)
+		// finishLocked captures whether the Request had been claimed before it detaches
+		// the session, so a claimed WebSocket that never reached ServeHTTP still earns
+		// the session grace period granted by Session.delRequest, then transitions the
+		// state to reqFinished.
+		rq.finishLocked()
 		runtime.AddCleanup(rq, releaseRetiredRequestKey, retiredRequestKey{jw: weak.Make(jw), jawsKey: jawsKey})
 	}
 	rq.mu.Unlock()
@@ -358,6 +361,7 @@ func (jw *Jaws) recycleLockedWithCause(rq *Request, err error) (cause error) {
 		// happened to be minted the same key. This mirrors the retirement path.
 		jw.requests[jawsKey] = nil
 		jw.requestCount--
+		rq.finishLocked() // detach session (grace if claimed) + transition to reqFinished
 		buffers = rq.releaseBuffersLocked()
 		runtime.AddCleanup(rq, releaseRetiredRequestKey, retiredRequestKey{jw: weak.Make(jw), jawsKey: jawsKey})
 	}

--- a/session.go
+++ b/session.go
@@ -66,7 +66,11 @@ func (sess *Session) addRequest(rq *Request) {
 	sess.mu.Unlock()
 }
 
-func (sess *Session) delRequest(rq *Request) {
+// delRequest removes rq from the Session. wasClaimed is captured by the caller from
+// rq's lifecycle state before it finishes (see Request.killSessionLocked), rather than
+// read here, so the grace-window decision does not depend on the order in which the
+// finish transition and the session detach happen.
+func (sess *Session) delRequest(rq *Request, wasClaimed bool) {
 	sess.mu.Lock()
 	defer sess.mu.Unlock()
 	for i := range sess.requests {
@@ -80,7 +84,7 @@ func (sess *Session) delRequest(rq *Request) {
 			break
 		}
 	}
-	if rq.claimed.Load() {
+	if wasClaimed {
 		// A claimed request's WebSocket has ended; grant a fresh grace window so
 		// other tabs or a reconnect can re-attach before the session expires. This
 		// must fire even when other requests remain attached, otherwise an aged

--- a/session_test.go
+++ b/session_test.go
@@ -903,7 +903,7 @@ func TestSession_ClaimedNonLastLeaveKeepsGrace(t *testing.T) {
 		if rqA.Session() != sess {
 			t.Fatal("expected rqA bound to session")
 		}
-		rqA.claimed.Store(true)
+		rqA.storeState(reqClaimed)
 
 		// Let the 1-minute creation grace window elapse. The session stays alive only
 		// because rqA is attached (len(requests) > 0), not because of its deadline.
@@ -925,11 +925,11 @@ func TestSession_ClaimedNonLastLeaveKeepsGrace(t *testing.T) {
 
 		// The live tab's WebSocket ends first, while rqB is still attached: this is a
 		// claimed request leaving non-last, so delRequest must still refresh the grace.
-		rqA.killSession()
+		rqA.killSession(rqA.loadState().claimed())
 
 		// The second tab's bootstrap is then recycled before its WebSocket connects:
 		// an unclaimed request leaving last, which leaves the refreshed deadline intact.
-		rqB.killSession()
+		rqB.killSession(rqB.loadState().claimed())
 
 		// A session that had a live WebSocket connection moments ago keeps its grace
 		// window so the client can reconnect.

--- a/testserve.go
+++ b/testserve.go
@@ -10,9 +10,14 @@ import (
 // including the out-of-package harness in github.com/linkdata/jaws/jawstest.
 //
 // It subscribes rq to broadcasts, waits for the running Serve loop to process
-// the subscription, then runs rq.process in a new goroutine using freshly created
-// inbound/outbound channels, recycling rq when the loop stops. It panics if the
-// Jaws processing loop ([Jaws.Serve] or [Jaws.ServeWithTimeout]) is not running.
+// the subscription, transitions rq to running with the same checked transition
+// [Request.ServeHTTP] uses, then runs rq.process in a new goroutine using freshly
+// created inbound/outbound channels, recycling rq when the loop stops.
+//
+// rq must already be claimed via [Jaws.UseRequest]. TestServe panics — like its other
+// setup-failure panics — if the Jaws processing loop ([Jaws.Serve] or
+// [Jaws.ServeWithTimeout]) is not running, or if rq is not servable (unclaimed,
+// already being served, retired, or the instance is closed).
 //
 // TestServe is exported solely to let test harnesses outside package jaws drive a
 // request loop without access to unexported internals. It is not intended for
@@ -47,6 +52,18 @@ func (jw *Jaws) TestServe(rq *Request, onPanic func(recovered any)) (inCh chan w
 		panic("jaws: TestServe timed out subscribing; the Jaws processing loop (Serve or ServeWithTimeout) must be running")
 	}
 
+	// Transition to running with the same checked transition Request.ServeHTTP uses,
+	// synchronously and before creating the per-run channels. casState(reqClaimed,
+	// reqRunning) requires the Request to be claimed (via UseRequest) and not already
+	// running, retired, or closed, so a concurrent Jaws.Close/retirement or a second
+	// TestServe/ServeHTTP cannot resurrect it into reqRunning. On failure, release the
+	// subscription and panic (like TestServe's other setup-failure panics) rather than
+	// return a half-started harness or recycle a Request another owner is serving.
+	if !rq.startServe() {
+		jw.unsubscribe(bcastCh)
+		panic("jaws: TestServe: request is not servable; claim it via UseRequest first, and serve it only once and before Close")
+	}
+
 	inCh = make(chan wire.WsMsg)
 	outCh = make(chan wire.WsMsg, cap(bcastCh))
 	readyCh = make(chan struct{})
@@ -61,16 +78,6 @@ func (jw *Jaws) TestServe(rq *Request, onPanic func(recovered any)) (inCh chan w
 			onPanic(recover())
 			close(doneCh)
 		}()
-		// Mark the request running before driving rq.process, mirroring how
-		// ServeHTTP gates process with startServe. The maintenance pass retires
-		// only not-running requests, so leaving the request not-running while
-		// process iterates its elements would let an idle or context-cancelled
-		// request be canceled and unregistered mid-loop. Take jw.mu so the
-		// transition is serialized with the maintenance pass, which reads running
-		// under jw.mu; the final recycle resets running via releaseBuffersLocked.
-		jw.mu.Lock()
-		rq.running.Store(true)
-		jw.mu.Unlock()
 		close(readyCh)
 		rq.process(bcastCh, inCh, outCh)
 		jw.recycle(rq)


### PR DESCRIPTION
## Summary

Follow-up to #206 (stable Request identities). Replaces the three separate lifecycle flags on `Request` — `registered bool`, `running atomic.Bool`, `claimed atomic.Bool` — with a single `reqState int32` held in `Request.state`, so the lifecycle transitions are explicit and race-safe.

```
reqUnclaimable                                   (terminal; created after Jaws.Close)
reqPending -> reqClaimed -> reqRunning -> reqFinished
reqPending/reqClaimed ------------------> reqFinished   (never served)
```

- **Claim** and **start-serve** are now single checked CAS transitions: `casState(reqPending, reqClaimed)` and `casState(reqClaimed, reqRunning)`. A claim/serve can only succeed from the exact expected state, so a concurrent `Close`/retirement or a duplicate claim can never resurrect a Request.
- **`finishLocked`** centralizes the finish transition. It captures whether the Request had been claimed *before* detaching the session — so `Session.delRequest` still grants the claimed-WebSocket grace window — then stores `reqFinished`. `Session.delRequest` now takes `wasClaimed` explicitly rather than reading a flag, so the grace decision no longer depends on the order of the finish transition vs. the session detach.
- Lock-free reads (`maintenance`, `Close`, `RequestCounts`) use `loadState()`; identity-gated paths (`destKey`, `wantMessage`, `appendDirtyTags`) use `loadState().registered()` under `rq.mu`, exactly as they read `registered` before.

## TestServe contract change (intentional, not a pure refactor)

`TestServe` now performs the same checked `startServe` transition **synchronously, before** creating its per-run channels, and panics (after releasing the broadcast subscription) if the Request is not servable — instead of the old fire-and-forget `running.Store(true)` inside the serve goroutine. This tightens the contract: **the Request must already be claimed via `UseRequest`**, and it may be served only once and only before `Close`.

This is a deliberate test-API tightening, not behavior-preserving. An audit of all callers (in-tree and `github.com/linkdata/jaws/jawstest`) confirmed none rely on the old loose behavior; the harness always claims via `UseRequest` first. The upside: a concurrent `Close`/retirement can no longer race a `TestServe` into a half-started state (covered by `TestServe_CloseRaceIsSafe`, 50 iterations under `-race`).

## Performance

Consolidating three fields into one shrinks each `Request` by **16 bytes** with **no change in allocation count**. benchstat (Apple M5 Max, `-count=10`, `-benchtime=200ms`), old = separate flags (e23d53f), new = int32 state:

```
                                                       │   old sec/op   │   new sec/op  vs base           │
RequestLifecyclePooling/elems=0/impl=pooled/serial       580.8n ± 3%      565.2n ± 2%   -2.68% (p=0.011)
RequestLifecyclePooling/elems=0/impl=pooled/parallel     613.8n ± 1%      601.0n ± 1%   -2.09% (p=0.000)
RequestLifecyclePooling/elems=0/impl=unpooled/serial     226.4n ± 2%      218.7n ± 1%   -3.40% (p=0.000)
RequestLifecyclePooling/elems=0/impl=unpooled/parallel   420.4n ± 2%      416.8n ± 3%        ~   (p=0.928)
RequestRecycleAfterHighWater/highwater=0                 574.5n ± 1%      575.5n ± 1%        ~   (p=0.617)
RequestRecycleAfterHighWater/highwater=1000              578.4n ± 1%      600.1n ± 5%   +3.75% (p=0.034)
RequestRecycleAfterHighWater/highwater=100000            636.8n ± 8%      577.5n ± 1%   -9.32% (p=0.000)
RequestClaimStartFinish                                  972.8n ± 1%      922.6n ± 3%   -5.16% (p=0.000)
geomean                                                  537.7n           524.2n        -2.51%

                                                       │    old B/op    │    new B/op   vs base           │
(every benchmark)                                        401/416/432 B    385/400/416 B  ~ -3.9%  (16 B)
geomean                                                  450.3            433.8         -3.65%

allocs/op: unchanged across all benchmarks (geomean +0.00%)
```

The `Request*` benchmarks are added by the first commit (e23d53f) and stay in the tree as a regression guard.

## Tests

- New `request_state_test.go`: `reqState.String`; full-transition table (`pending->claimed->running->finished`, never-claimed recycle, claimed-not-running retire, double claim/startServe rejected, terminal-stays-finished); post-Close claim returns the cancellation cause (not `ErrRequestAlreadyClaimed`); the debug-only `finishLocked` terminal-state assertion; duplicate `TestServe` panics without disturbing the first serve; `TestServe`/`Close` race (50×).
- Existing lifecycle/session/broadcast tests migrated 1:1 to the state helpers; none weakened.

## Gate

`gofmt` clean · `go vet` clean · `staticcheck` clean · `golangci-lint` 0 issues · `go test -race ./...` and `go test -tags debug -race ./...` green · coverage 99.7% (only the pre-existing `errunusableui` path below 100%; `finishLocked` at 100%).