### PR TITLE
fix: don't render nil JsVar Ptr through value-receiver callbacks (#196)

### DIFF
--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -418,25 +418,14 @@ func (jsvar *JsVar[T]) JawsSet(elem *jaws.Element, value T) (err error) {
 // JsVar (for example call JawsGet or JawsSet on it), which would self-deadlock the
 // non-reentrant lock.
 func (jsvar *JsVar[T]) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err error) {
+	// The render-time snapshot is taken under the write lock; see renderSnapshot.
+	// Everything below runs without the lock: ApplyParams and, crucially, writing to
+	// w must not hold the value lock, because a slow client stalling a network write
+	// would otherwise block every goroutine sharing the locker.
 	var getterAttrs []template.HTMLAttr
 	var jsvarName string
 	var data []byte
-
-	// Hold the write lock only while deriving the dirty tag (ApplyGetter) and
-	// marshaling Ptr, so the marshaled value stays consistent with that tag even if
-	// another request sharing this JsVar sets it concurrently. Release before
-	// ApplyParams and, crucially, before writing to w: holding the value lock across a
-	// network write would let a slow client stall every goroutine sharing the locker.
-	jsvar.Lock()
-	if jsvar.dirtyTag, getterAttrs, err = elem.ApplyGetter(jsvar.Ptr); err == nil {
-		elem.AddHandlers(jsvar)
-		if jsvarName, err = validateJsVarName(params); err == nil && jsvar.Ptr != nil {
-			data, err = json.Marshal(jsvar.Ptr)
-		}
-	}
-	jsvar.Unlock()
-
-	if err == nil {
+	if getterAttrs, jsvarName, data, err = jsvar.renderSnapshot(elem, params); err == nil {
 		attrs := append(elem.ApplyParams(params[1:]), getterAttrs...)
 		var b []byte
 		b = append(b, "\n<div id="...)
@@ -448,6 +437,35 @@ func (jsvar *JsVar[T]) JawsRender(elem *jaws.Element, w io.Writer, params []any)
 		b = htmlio.AppendAttrs(b, attrs)
 		b = append(b, " hidden></div>"...)
 		_, err = w.Write(b)
+	}
+	return
+}
+
+// renderSnapshot runs the render-time critical section under the write lock.
+//
+// It resolves the dirty tag and any initial HTML attrs from the bound value,
+// registers this JsVar as elem's handler, validates the JsVar name, and marshals a
+// snapshot of Ptr. The lock spans [Element.ApplyGetter] and the marshal so the
+// serialized value stays consistent with the dirty tag even if another request
+// sharing this JsVar sets it concurrently. The deferred unlock ensures a panic from
+// a bound-value callback or from marshaling cannot leak the lock.
+//
+// A nil Ptr has no bound value to inspect, so the getter and init callbacks are
+// skipped and the initial data is omitted. Passing the typed-nil Ptr to ApplyGetter
+// instead would call a value-receiver [tag.TagGetter] or [jaws.InitHandler] through
+// the nil pointer and panic.
+func (jsvar *JsVar[T]) renderSnapshot(elem *jaws.Element, params []any) (getterAttrs []template.HTMLAttr, jsvarName string, data []byte, err error) {
+	jsvar.Lock()
+	defer jsvar.Unlock()
+	var getter any
+	if jsvar.Ptr != nil {
+		getter = jsvar.Ptr
+	}
+	if jsvar.dirtyTag, getterAttrs, err = elem.ApplyGetter(getter); err == nil {
+		elem.AddHandlers(jsvar)
+		if jsvarName, err = validateJsVarName(params); err == nil && jsvar.Ptr != nil {
+			data, err = json.Marshal(jsvar.Ptr)
+		}
 	}
 	return
 }

--- a/lib/ui/jsvar_test.go
+++ b/lib/ui/jsvar_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/linkdata/jaws"
 	"github.com/linkdata/jaws/jawstest"
+	"github.com/linkdata/jaws/lib/tag"
 	"github.com/linkdata/jaws/lib/what"
 )
 
@@ -512,4 +513,80 @@ func TestJsVar_RenderIncludesZeroValueData(t *testing.T) {
 	if got := sb.String(); !strings.Contains(got, `data-jawsdata="`) {
 		t.Fatalf("expected data-jawsdata for zero value, got %q", got)
 	}
+}
+
+// jsVarTagState has a value-receiver JawsGetTag, so *jsVarTagState also satisfies
+// tag.TagGetter and calling JawsGetTag through a nil *jsVarTagState panics.
+type jsVarTagState struct {
+	Value string `json:"value"`
+}
+
+func (jsVarTagState) JawsGetTag(tag.Context) any {
+	return tag.Tag("state")
+}
+
+// TestJsVar_RenderNilPointerWithTagGetterDoesNotLeakLock reproduces issue #196:
+// rendering a JsVar bound to a nil pointer whose type implements tag.TagGetter via
+// a value receiver must not invoke the getter through the typed-nil pointer, so it
+// neither panics nor leaves the write lock held.
+func TestJsVar_RenderNilPointerWithTagGetterDoesNotLeakLock(t *testing.T) {
+	_, rq := newCoreRequest(t)
+
+	var mu sync.Mutex
+	var ptr *jsVarTagState
+	jsv := NewJsVar(&mu, ptr)
+	elem := rq.NewElement(jsv)
+
+	var sb bytes.Buffer
+	var panicValue any
+	func() {
+		defer func() { panicValue = recover() }()
+		if err := jsv.JawsRender(elem, &sb, []any{"state"}); err != nil {
+			t.Errorf("render returned error: %v", err)
+		}
+	}()
+	if panicValue != nil {
+		t.Errorf("render panicked: %v", panicValue)
+	}
+	if !mu.TryLock() {
+		t.Fatal("render left the JsVar locker held")
+	}
+	mu.Unlock()
+	// A nil Ptr omits the initial data and adds no bound-value tag.
+	if got := sb.String(); strings.Contains(got, "data-jawsdata=") {
+		t.Errorf("expected no data-jawsdata for nil pointer, got %q", got)
+	}
+}
+
+type jsVarPanicMarshal struct{}
+
+// MarshalJSON always panics, standing in for a bound value whose supported
+// marshaling callback fails while the render write lock is held.
+func (jsVarPanicMarshal) MarshalJSON() ([]byte, error) {
+	panic("marshal boom")
+}
+
+// TestJsVar_RenderMarshalPanicDoesNotLeakLock verifies the render critical section
+// releases the write lock even when marshaling the bound value panics.
+func TestJsVar_RenderMarshalPanicDoesNotLeakLock(t *testing.T) {
+	_, rq := newCoreRequest(t)
+
+	var mu sync.Mutex
+	v := jsVarPanicMarshal{}
+	jsv := NewJsVar(&mu, &v)
+	elem := rq.NewElement(jsv)
+
+	var sb bytes.Buffer
+	var panicValue any
+	func() {
+		defer func() { panicValue = recover() }()
+		_ = jsv.JawsRender(elem, &sb, []any{"boom"})
+	}()
+	if panicValue == nil {
+		t.Fatal("expected marshal panic to propagate")
+	}
+	if !mu.TryLock() {
+		t.Fatal("render left the JsVar locker held after a marshal panic")
+	}
+	mu.Unlock()
 }


### PR DESCRIPTION
## Summary

Fixes #196. Rendering a `JsVar` bound to a nil pointer could panic and then permanently retain the shared application lock.

`JawsRender` passed the typed-nil `Ptr` to `Element.ApplyGetter`. Because a typed-nil pointer is a non-nil interface, `ApplyGetter` recognized `tag.TagGetter` and called its **value-receiver** `JawsGetTag` through the nil pointer, causing a runtime panic. The write lock was released with a bare `Unlock` (not a deferred one), so the panic unwound past it and left the locker held forever — stalling every goroutine sharing that application state.

## Fix

- Extract the render-time critical section into `renderSnapshot`, which holds the write lock under a `defer Unlock()`. A panic from a supported bound-value callback or from marshaling can no longer leak the lock.
- When `Ptr` is nil, skip the bound-value getter/init callbacks and omit the initial data — the behavior `NewJsVar` already documents ("reads return the zero value, rendering omits the initial data").

Behavior for a non-nil `Ptr` is unchanged (same `getter` value passed to `ApplyGetter`, same lock scope covering `ApplyGetter` + marshal so the serialized value stays consistent with the dirty tag).

## Tests

Two regression tests, both verified to **fail on the pre-fix code** and pass after:

- `TestJsVar_RenderNilPointerWithTagGetterDoesNotLeakLock` — the exact scenario from #196 (nil pointer to a type with a value-receiver `JawsGetTag`); asserts no panic, lock released, and no `data-jawsdata`.
- `TestJsVar_RenderMarshalPanicDoesNotLeakLock` — a bound value whose `MarshalJSON` panics; asserts the panic propagates but the lock is still released.

`go test -race ./...` passes across the module; `go vet`, `gofmt`, and `staticcheck` are clean on the touched files.