### PR TITLE
fix: gate full tag rendering behind the debug/race build tags (#197)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,14 @@ jobs:
           JAWS_REQUIRE_NODE: "1"
         run: go test -race -coverprofile=coverage.out ./...
 
+      - name: Test (production build)
+        env:
+          JAWS_REQUIRE_NODE: "1"
+        # -race selects the debug tag renderer via the "race" build tag, so this
+        # non-race leg is what exercises the crash-safe release renderer and the
+        # default TagString forwarding used in production.
+        run: go test ./...
+
       - name: Calculate code coverage
         id: coverage
         run: |

--- a/README.md
+++ b/README.md
@@ -739,24 +739,29 @@ items explicitly:
   server writes and `PathSetter` values bypass `ClientCheck`.
 * Enable `Jaws.TrustForwardedHeaders` only behind a single trusted reverse proxy
   that overwrites `X-Forwarded-For`, `X-Real-IP` and `X-Forwarded-Proto`.
-* Run the test suite with `-race` before release so the deadlock lock-order
-  detector and JaWS debug-gated checks are exercised. If the race detector is
-  unavailable, use `-tags "debug deadlock"`.
+* Run the test suite both with and without `-race` before release: `-race`
+  exercises the deadlock lock-order detector and JaWS debug-gated checks, while a
+  plain `go test` exercises the crash-safe release tag renderer that `-race` and
+  `-tags debug` replace. If the race detector is unavailable, use
+  `-tags "debug deadlock"` in place of `-race`.
 
 ### Testing
 
-Always run the test suite with the `-race` flag:
+Run the test suite both with and without the `-race` flag:
 
     go test -race ./...
+    go test ./...
 
 Race detection sets `deadlock.Debug = true` and `deadlock.Enabled = true` (see
 [Dependencies](#dependencies)), which exercises the deadlock lock-order detector
-and JaWS debug-gated checks such as the late-handler panic. The tag
-comparability checks in [`lib/tag`](./lib/tag) run in normal code paths too.
-Plain `go test` does not exercise the debug-only branches or the deadlock
-detector. CI builds with `-race`. If the race detector is unavailable, use
-`go test -tags "debug deadlock" ./...`; the `debug` tag alone sets
-`deadlock.Debug`, but does not enable the deadlock detector.
+and JaWS debug-gated checks such as the late-handler panic. A `-race` build (like
+`-tags debug`) also selects the full-detail tag renderer in
+[`lib/tag`](./lib/tag), so the plain `go test` build is what exercises the
+crash-safe release renderer used in production. The tag comparability checks in
+`lib/tag` run in every build. CI runs both legs. If the race detector is
+unavailable, run `go test -tags "debug deadlock" ./...` (the `debug` tag alone
+sets `deadlock.Debug` but does not enable the deadlock detector) alongside a
+plain `go test ./...`.
 
 ### Dependencies
 

--- a/element.go
+++ b/element.go
@@ -44,6 +44,13 @@ type Element struct {
 	frozen   atomic.Bool // set when handlers are sealed (JawsRender returns or Freeze called); guards handler mutators in all builds
 }
 
+// String returns a debug representation of elem: its UI type, Jid, and tags.
+//
+// The tags render through [tag.TagsString], so in the default build they show
+// their types (and a pointer's address when readable; see [tag.TagStringRelease]),
+// while debug and -race builds render them in full — more informative, but able
+// to crash on a self-referential or oversized tag. String tolerates an Element
+// whose Request is not yet set, but not a nil *Element.
 func (elem *Element) String() string {
 	// Guard elem.Request like Request.String()/JawsKeyString guard a nil
 	// receiver, so String() stays safe on a not-fully-constructed Element.
@@ -51,7 +58,7 @@ func (elem *Element) String() string {
 	if elem.Request != nil {
 		tags = elem.Request.TagsOf(elem)
 	}
-	return fmt.Sprintf("Element{%T, id=%q, Tags: %v}", elem.UI(), elem.Jid(), tags)
+	return fmt.Sprintf("Element{%T, id=%q, Tags: %s}", elem.UI(), elem.Jid(), tag.TagsString(tags))
 }
 
 // appendHandlers is the single internal chokepoint for mutating elem.handlers.

--- a/element_test.go
+++ b/element_test.go
@@ -162,7 +162,9 @@ func TestElement_Tag(t *testing.T) {
 	e.Tag(tag.Tag("zomg"))
 	is.True(e.HasTag(tag.Tag("zomg")))
 	s := e.String()
-	if !strings.Contains(s, "zomg") {
+	// Element.String renders tags with tag.TagsString, whose per-tag form depends
+	// on the build (the value in debug/-race, only the type otherwise).
+	if !strings.Contains(s, tag.TagString(tag.Tag("zomg"))) {
 		t.Error(s)
 	}
 }
@@ -636,6 +638,12 @@ func TestElement_RenderDebugAndDeletedBranches(t *testing.T) {
 }
 
 func TestElement_JawsRenderDebugTagCanReenterRequest(t *testing.T) {
+	// The re-entrancy this guards against only happens when renderDebug invokes the
+	// tag's String method, which the default build never does; it applies in the
+	// debug and -race builds where TagString renders values in full.
+	if !tag.DebugRender {
+		t.Skip("tag String is only invoked in debug/-race builds")
+	}
 	jw, err := New()
 	if err != nil {
 		t.Fatal(err)

--- a/jaws.go
+++ b/jaws.go
@@ -72,8 +72,12 @@
 // active: the debug tag sets deadlock.Debug, while the deadlock tag enables the
 // detector. Those JaWS debug branches are compile-time dead in normal builds, so
 // a plain "go test" neither exercises them nor reports their statement coverage.
-// Runtime tag-comparability checks in [github.com/linkdata/jaws/lib/tag] run in
-// every build. CI builds with -race.
+//
+// Also run a plain "go test" (no -race), because -race and -tags debug select the
+// full-detail tag renderer in [github.com/linkdata/jaws/lib/tag]; only a build
+// with neither exercises the crash-safe release renderer used in production. CI
+// runs both legs. Runtime tag-comparability checks in that package run in every
+// build.
 package jaws
 
 import (

--- a/lib/tag/tag.go
+++ b/lib/tag/tag.go
@@ -1,7 +1,6 @@
 package tag
 
 import (
-	"fmt"
 	"html/template"
 	"reflect"
 	"runtime"
@@ -13,19 +12,6 @@ import (
 
 // Tag is a simple comparable tag value.
 type Tag string
-
-// TagString returns a debug string for tag.
-func TagString(tag any) string {
-	if rv := reflect.ValueOf(tag); rv.IsValid() {
-		if rv.Kind() == reflect.Pointer {
-			return fmt.Sprintf("%T(%p)", tag, tag)
-		}
-		if stringer, ok := tag.(fmt.Stringer); ok {
-			return fmt.Sprintf("%T(%s)", tag, stringer.String())
-		}
-	}
-	return fmt.Sprintf("%#v", tag)
-}
 
 // Expansion limits guarding against runaway recursion or pathological input.
 const (

--- a/lib/tag/tag_test.go
+++ b/lib/tag/tag_test.go
@@ -77,12 +77,168 @@ func (tt testDeepTagGetter) JawsGetTag(Context) any {
 	return tt.next
 }
 
-func TestTagString_StringerAndPointer(t *testing.T) {
-	if got := TagString(testStringTag{}); !strings.Contains(got, "testStringTag(str)") {
-		t.Fatalf("TagString(testStringTag{}) = %q, want value stringer representation", got)
+func TestTagStringDebug_StringerAndPointer(t *testing.T) {
+	if got := TagStringDebug(testStringTag{}); !strings.Contains(got, "testStringTag(str)") {
+		t.Fatalf("TagStringDebug(testStringTag{}) = %q, want value stringer representation", got)
 	}
-	if got := TagString(&testStringTag{}); !strings.Contains(got, "*tag.testStringTag(") {
-		t.Fatalf("TagString(&testStringTag{}) = %q, want pointer representation", got)
+	if got := TagStringDebug(&testStringTag{}); !strings.Contains(got, "*tag.testStringTag(") {
+		t.Fatalf("TagStringDebug(&testStringTag{}) = %q, want pointer representation", got)
+	}
+	if got := TagStringDebug(Tag("plain")); !strings.Contains(got, `"plain"`) {
+		t.Fatalf("TagStringDebug(Tag(\"plain\")) = %q, want quoted value", got)
+	}
+}
+
+func TestTagStringRelease_TypeAndAddress(t *testing.T) {
+	// Release rendering shows the type — plus a pointer's address when it can be
+	// read safely — but never the value or a method result, so it cannot descend.
+	if got, want := TagStringRelease(testStringTag{}), "tag.testStringTag"; got != want {
+		t.Fatalf("TagStringRelease(testStringTag{}) = %q, want %q", got, want)
+	}
+	if got := TagStringRelease(&testStringTag{}); !strings.HasPrefix(got, "*tag.testStringTag(0x") {
+		t.Fatalf("TagStringRelease(&testStringTag{}) = %q, want type and address", got)
+	}
+	if got, want := TagStringRelease(Tag("plain")), "tag.Tag"; got != want {
+		t.Fatalf("TagStringRelease(Tag(\"plain\")) = %q, want %q", got, want)
+	}
+	if got, want := TagStringRelease(nil), "<nil>"; got != want {
+		t.Fatalf("TagStringRelease(nil) = %q, want %q", got, want)
+	}
+}
+
+func TestPointerAddr_RecoversPanic(t *testing.T) {
+	// reflect.Value.Pointer panics on a non-pointer kind (and on some cgo /
+	// not-in-heap pointers); pointerAddr must recover and report failure so release
+	// rendering degrades to type-only instead of crashing.
+	if _, ok := pointerAddr(reflect.ValueOf(42)); ok {
+		t.Error("pointerAddr(non-pointer) reported ok, want a recovered failure")
+	}
+	x := 0
+	if addr, ok := pointerAddr(reflect.ValueOf(&x)); !ok || addr == 0 {
+		t.Errorf("pointerAddr(&x) = (%#x, %v), want a non-zero address and ok", addr, ok)
+	}
+}
+
+func TestTagStringRelease_SafeOnCyclic(t *testing.T) {
+	// The release renderer must stay bounded on values that overflow fmt. This runs
+	// in every build (including -race) because it never descends into the value.
+	cyclic := []any{nil}
+	cyclic[0] = cyclic
+	if got, want := TagStringRelease(cyclic), "[]interface {}"; got != want {
+		t.Errorf("TagStringRelease(cyclic slice) = %q, want %q", got, want)
+	}
+	if got, want := TagsStringRelease(cyclic), "[[]interface {}]"; got != want {
+		t.Errorf("TagsStringRelease(cyclic slice) = %q, want %q", got, want)
+	}
+	m := map[int]any{}
+	m[0] = m
+	if got, want := TagStringRelease(m), "map[int]interface {}"; got != want {
+		t.Errorf("TagStringRelease(cyclic map) = %q, want %q", got, want)
+	}
+}
+
+// panicOnRender's formatting methods all panic if called.
+//
+// Invoking one directly crashes; invoking one via fmt yields a recovered
+// "%!v(PANIC=...)" marker. A renderer that produces neither — just the plain
+// type — therefore never called them.
+type panicOnRender struct{}
+
+func (panicOnRender) String() string         { panic("String called") }
+func (panicOnRender) GoString() string       { panic("GoString called") }
+func (panicOnRender) Format(fmt.State, rune) { panic("Format called") }
+
+func TestTagStringRelease_NeverInvokesMethods(t *testing.T) {
+	// The release path reads only the type and address, so a tag whose String,
+	// GoString or Format methods panic (or would recurse) still renders safely.
+	for _, v := range []any{panicOnRender{}, &panicOnRender{}} {
+		got := TagStringRelease(v)
+		if strings.Contains(got, "PANIC") || strings.Contains(got, "called") {
+			t.Errorf("TagStringRelease(%T) = %q, want no method invocation", v, got)
+		}
+		if !strings.Contains(got, "panicOnRender") {
+			t.Errorf("TagStringRelease(%T) = %q, want the type name", v, got)
+		}
+	}
+	if got := TagsStringRelease([]any{panicOnRender{}}); !strings.Contains(got, "panicOnRender") || strings.Contains(got, "PANIC") {
+		t.Errorf("TagsStringRelease = %q, want type name and no panic", got)
+	}
+}
+
+func TestTagStringRelease_BoundsHugeTypeName(t *testing.T) {
+	// A valid comparable tag can still have a pathologically long type name (here
+	// via deeply nested arrays). Release rendering must truncate it so the output
+	// stays bounded rather than proportional to the type name.
+	typ := reflect.TypeOf(byte(0))
+	for range 5000 {
+		typ = reflect.ArrayOf(1, typ)
+	}
+	v := reflect.New(typ).Elem().Interface()
+	got := TagStringRelease(v)
+	if len(got) > maxTagString+len(truncMarker) {
+		t.Errorf("TagStringRelease(huge type) = %d bytes, want <= %d", len(got), maxTagString+len(truncMarker))
+	}
+	if !strings.HasSuffix(got, truncMarker) {
+		t.Errorf("truncated render should end with %q, got …%q", truncMarker, got[max(0, len(got)-8):])
+	}
+}
+
+func TestClipTagString(t *testing.T) {
+	if got := clipTagString("short"); got != "short" {
+		t.Errorf("clipTagString(short) = %q, want it unchanged", got)
+	}
+	// Place a two-byte rune straddling the cap so truncation must back up to the
+	// rune boundary rather than split it.
+	s := strings.Repeat("a", maxTagString-1) + "é" + "tail"
+	got := clipTagString(s)
+	if len(got) > maxTagString+len(truncMarker) {
+		t.Errorf("clipTagString len = %d, want <= %d", len(got), maxTagString+len(truncMarker))
+	}
+	if !strings.HasSuffix(got, truncMarker) {
+		t.Errorf("clipTagString should end with %q, got …%q", truncMarker, got[len(got)-4:])
+	}
+	if strings.ToValidUTF8(got, "�") != got {
+		t.Error("clipTagString split a multi-byte rune (invalid UTF-8)")
+	}
+}
+
+func TestTagsStringRelease_BoundsHugeList(t *testing.T) {
+	// An enormous tag list must render to a bounded string, not one proportional to
+	// the slice length.
+	tags := make([]any, 100_000)
+	for i := range tags {
+		tags[i] = Tag("x")
+	}
+	if got := TagsStringRelease(tags); len(got) > maxTagString+64 {
+		t.Errorf("TagsStringRelease(100k tags) = %d bytes, want bounded near %d", len(got), maxTagString)
+	}
+}
+
+func TestTagsStringDebug_RendersElements(t *testing.T) {
+	// Debug rendering of a slice quotes each element via TagStringDebug.
+	if got, want := TagsStringDebug([]any{Tag("a"), Tag("b")}), `["a" "b"]`; got != want {
+		t.Errorf("TagsStringDebug = %q, want %q", got, want)
+	}
+}
+
+func TestTagString_ForwardsByBuild(t *testing.T) {
+	// TagString/TagsString forward to the release or debug variant per build. Verify
+	// the routing with a safe value (a cyclic one would crash the debug forwarder).
+	v := Tag("x")
+	want := TagStringRelease(v)
+	if DebugRender {
+		want = TagStringDebug(v)
+	}
+	if got := TagString(v); got != want {
+		t.Errorf("TagString(%v) = %q, want %q (DebugRender=%v)", v, got, want, DebugRender)
+	}
+	tags := []any{Tag("a"), Tag("b")}
+	twant := TagsStringRelease(tags)
+	if DebugRender {
+		twant = TagsStringDebug(tags)
+	}
+	if got := TagsString(tags); got != twant {
+		t.Errorf("TagsString = %q, want %q", got, twant)
 	}
 }
 
@@ -476,13 +632,6 @@ func (ctx *mustLogContext) Log(err error) error {
 
 func (ctx *mustLogContext) MustLog(err error) {
 	ctx.err = err
-}
-
-func TestTagString_DefaultFormatting(t *testing.T) {
-	got := TagString(Tag("plain"))
-	if !strings.Contains(got, `"plain"`) {
-		t.Fatalf("TagString(Tag(\"plain\")) = %q, want quoted fallback formatting", got)
-	}
 }
 
 func TestTagExpand_TagGetterRecurses(t *testing.T) {

--- a/lib/tag/tagstring.go
+++ b/lib/tag/tagstring.go
@@ -1,0 +1,133 @@
+package tag
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"unicode/utf8"
+)
+
+// maxTagString bounds a rendered tag in the release build.
+//
+// A single tag's type name is truncated to this many bytes, and a tag list stops
+// appending once it reaches this size (so its output stays under roughly twice
+// this, one element being allowed to complete). Ordinary tags are far shorter, so
+// the cap only affects pathological input such as a reflect-built type with a
+// huge name.
+const maxTagString = 4096
+
+// truncMarker is appended where release rendering truncates.
+const truncMarker = "…"
+
+// TagStringRelease renders tag showing only its type, plus its address when tag
+// is a pointer whose address can be read without panicking.
+//
+// It reads the type via reflection, never hands tag itself to a formatting verb,
+// and never invokes a String/GoString/Format/Error method or touches the
+// pointed-to memory; the address is read under a recover (see pointerAddr)
+// because [reflect.Value.Pointer] can panic on some cgo / not-in-heap pointers,
+// and an over-long type name is truncated. It therefore cannot recurse, overflow
+// the stack, exhaust memory, or panic no matter what tag contains — at the cost
+// of not showing the tag's contents.
+//
+// [TagString] forwards here in the default build.
+func TagStringRelease(tag any) string {
+	rv := reflect.ValueOf(tag)
+	if !rv.IsValid() {
+		return "<nil>"
+	}
+	s := clipTagString(rv.Type().String())
+	if rv.Kind() == reflect.Pointer {
+		if addr, ok := pointerAddr(rv); ok {
+			return s + fmt.Sprintf("(0x%x)", addr)
+		}
+	}
+	return s
+}
+
+// pointerAddr returns rv's address as a uintptr.
+//
+// [reflect.Value.Pointer] panics on some cgo / not-in-heap pointers (and on a
+// non-pointer kind), so pointerAddr recovers and reports ok=false, letting release
+// rendering fall back to type-only for such a tag instead of crashing.
+func pointerAddr(rv reflect.Value) (addr uintptr, ok bool) {
+	defer func() {
+		if recover() != nil {
+			addr, ok = 0, false
+		}
+	}()
+	return rv.Pointer(), true
+}
+
+// clipTagString truncates s to maxTagString bytes on a UTF-8 boundary, appending
+// truncMarker, so a pathologically long type name cannot produce unbounded output.
+func clipTagString(s string) string {
+	if len(s) <= maxTagString {
+		return s
+	}
+	n := maxTagString
+	for n > 0 && !utf8.RuneStart(s[n]) {
+		n--
+	}
+	return s[:n] + truncMarker
+}
+
+// TagStringDebug renders tag in full: a pointer as its type and address, a
+// [fmt.Stringer] as its type and String(), and every other value through "%#v".
+//
+// It is the most informative form, but because it descends into the value it can
+// overflow the stack or exhaust memory on a self-referential or oversized tag, so
+// it is unsuitable for untrusted input.
+//
+// [TagString] forwards here in the debug and -race builds.
+func TagStringDebug(tag any) string {
+	if rv := reflect.ValueOf(tag); rv.IsValid() {
+		if rv.Kind() == reflect.Pointer {
+			return fmt.Sprintf("%T(%p)", tag, tag)
+		}
+		if stringer, ok := tag.(fmt.Stringer); ok {
+			return fmt.Sprintf("%T(%s)", tag, stringer.String())
+		}
+	}
+	return fmt.Sprintf("%#v", tag)
+}
+
+// TagsStringRelease renders a slice of tags, each with [TagStringRelease].
+//
+// It stops once the output reaches maxTagString, so it inherits the per-element
+// crash-safety and stays bounded however long the slice is. [TagsString] forwards
+// here in the default build.
+func TagsStringRelease(tags []any) string {
+	return tagsString(tags, TagStringRelease, maxTagString)
+}
+
+// TagsStringDebug renders a slice of tags in full, each with [TagStringDebug].
+//
+// It applies no aggregate size limit, matching the informative (unsafe) debug
+// contract. [TagsString] forwards here in the debug and -race builds.
+func TagsStringDebug(tags []any) string {
+	return tagsString(tags, TagStringDebug, 0)
+}
+
+// tagsString renders tags as "[e0 e1 …]" using one to format each element.
+//
+// The slice itself is never handed to fmt, so the rendering inherits the
+// per-element formatter's crash-safety. When limit > 0 it stops once the output
+// reaches limit bytes, so an enormous slice cannot produce unbounded output;
+// limit <= 0 renders every element.
+func tagsString(tags []any, one func(any) string, limit int) string {
+	var sb strings.Builder
+	sb.WriteByte('[')
+	for i, t := range tags {
+		if limit > 0 && sb.Len() >= limit {
+			sb.WriteString(truncMarker)
+			break
+		}
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(one(t))
+	}
+	sb.WriteByte(']')
+	return sb.String()
+}

--- a/lib/tag/tagstring_debug.go
+++ b/lib/tag/tagstring_debug.go
@@ -1,0 +1,23 @@
+//go:build debug || race
+
+package tag
+
+// DebugRender reports whether [TagString] and [TagsString] render tags in full.
+//
+// It is true in the development build (-tags debug or -race), where they forward
+// to the full-detail [TagStringDebug]/[TagsStringDebug]. The default build makes
+// it false and forwards to the crash-safe release variants instead.
+const DebugRender = true
+
+// TagString returns a debug string for tag.
+//
+// This is the development build, so it forwards to the full-detail
+// [TagStringDebug], which can overflow the stack or exhaust memory on a
+// self-referential or oversized tag; see [DebugRender].
+func TagString(tag any) string { return TagStringDebug(tag) }
+
+// TagsString returns a debug string for a slice of tags.
+//
+// This is the development build, so it forwards to the full-detail, unbounded
+// [TagsStringDebug]; see [DebugRender].
+func TagsString(tags []any) string { return TagsStringDebug(tags) }

--- a/lib/tag/tagstring_release.go
+++ b/lib/tag/tagstring_release.go
@@ -1,0 +1,22 @@
+//go:build !debug && !race
+
+package tag
+
+// DebugRender reports whether [TagString] and [TagsString] render tags in full.
+//
+// It is false in the default (production) build, where they forward to the
+// bounded, crash-safe [TagStringRelease]/[TagsStringRelease]. Build with -tags
+// debug or -race to make it true.
+const DebugRender = false
+
+// TagString returns a debug string for tag.
+//
+// In the default build it forwards to the crash-safe [TagStringRelease]; see
+// [DebugRender].
+func TagString(tag any) string { return TagStringRelease(tag) }
+
+// TagsString returns a debug string for a slice of tags.
+//
+// In the default build it forwards to the crash-safe [TagsStringRelease]; see
+// [DebugRender].
+func TagsString(tags []any) string { return TagsStringRelease(tags) }

--- a/lib/ui/template_handler_test.go
+++ b/lib/ui/template_handler_test.go
@@ -133,8 +133,10 @@ func TestTemplate_RenderUpdateEventAndHelpers(t *testing.T) {
 
 	td := &templateDot{}
 	tpl := NewTemplate("div", "uitempl", td)
-	if got := tpl.String(); !strings.Contains(got, `{"div", "uitempl", *ui.templateDot(`) {
-		t.Fatalf("unexpected template string %q", got)
+	// Dot is rendered with tag.TagString, whose exact form varies by build, so build
+	// the expectation the same way rather than hardcoding it.
+	if got, want := tpl.String(), `{"div", "uitempl", `+tag.TagString(td); !strings.Contains(got, want) {
+		t.Fatalf("template string %q does not contain %q", got, want)
 	}
 	elem := rq.NewElement(tpl)
 	tpl.JawsUpdate(elem)

--- a/lib/wire/message.go
+++ b/lib/wire/message.go
@@ -3,6 +3,7 @@ package wire
 import (
 	"fmt"
 
+	"github.com/linkdata/jaws/lib/tag"
 	"github.com/linkdata/jaws/lib/what"
 )
 
@@ -18,10 +19,15 @@ type Message struct {
 }
 
 // String returns the Message in a form suitable for debug output.
+//
+// Dest is rendered with [tag.TagString], so in the default build it shows only
+// its type (and, for a pointer, its address when it can be read safely) and a
+// malformed Dest cannot crash the caller; build with -tags debug or -race for
+// full-value rendering, which is more informative but not crash-safe.
 func (msg *Message) String() string {
 	return fmt.Sprintf(
-		"{%v, %v, %q}",
-		msg.Dest,
+		"{%s, %v, %q}",
+		tag.TagString(msg.Dest),
 		msg.What,
 		msg.Data,
 	)

--- a/lib/wire/message_release_test.go
+++ b/lib/wire/message_release_test.go
@@ -1,0 +1,25 @@
+//go:build !debug && !race
+
+package wire
+
+import (
+	"testing"
+
+	"github.com/linkdata/jaws/lib/what"
+)
+
+// Test_Message_String_CyclicDestBounded is a unit test for Message.String: a
+// self-referential Dest must render to a bounded string in the default build
+// rather than overflow the stack.
+//
+// The broadcast-overload path in serve.go formats a Message's Dest through this
+// same Message.String, so a bounded Message.String is what keeps that path safe;
+// this test exercises Message.String directly, not that path.
+func Test_Message_String_CyclicDestBounded(t *testing.T) {
+	dest := []any{nil}
+	dest[0] = dest
+	msg := Message{Dest: dest, What: what.Inner}
+	if s := msg.String(); len(s) > 1<<13 {
+		t.Errorf("Message.String() = %d bytes, want bounded", len(s))
+	}
+}

--- a/lib/wire/message_test.go
+++ b/lib/wire/message_test.go
@@ -1,23 +1,27 @@
 package wire
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/linkdata/jaws/lib/tag"
 	"github.com/linkdata/jaws/lib/what"
 )
 
 func Test_Message_String(t *testing.T) {
+	// Dest is rendered with tag.TagString, whose output depends on the build, so
+	// build the expectation the same way rather than hardcoding one build's form.
 	msg := Message{
 		Dest: "Elem",
 		What: what.Update,
 		Data: "Data\nText",
 	}
-	if s := msg.String(); s != "{Elem, Update, \"Data\\nText\"}" {
-		t.Error(s)
+	want := fmt.Sprintf("{%s, Update, %q}", tag.TagString("Elem"), "Data\nText")
+	if s := msg.String(); s != want {
+		t.Errorf("Message.String() = %q, want %q", s, want)
 	}
-	msg = Message{
-		What: what.Click,
-	}
+	// A nil Dest renders as <nil> in every build.
+	msg = Message{What: what.Click}
 	if s := msg.String(); s != "{<nil>, Click, \"\"}" {
 		t.Error(s)
 	}

--- a/request_test.go
+++ b/request_test.go
@@ -2063,7 +2063,9 @@ func TestRequest_renderDebugLocked(t *testing.T) {
 	}
 
 	txt := sb.String()
-	is.Equal(strings.Contains(txt, "zomg"), true)
+	// renderDebug renders each tag with tag.TagString, whose form depends on the
+	// build, so match on that rather than the raw tag value.
+	is.Equal(strings.Contains(txt, tag.TagString(tag.Tag("zomg"))), true)
 	is.Equal(strings.Contains(txt, "n/a"), false)
 
 	rq.mu.Lock()


### PR DESCRIPTION
Fixes #197.

## Problem

`tag.TagString` formatted tags with `fmt`'s `%#v`, and `wire.Message.String` / `jaws.Element.String` formatted their tag `Dest` / tag list with `%v`. `fmt` has no cycle or size bound, so a self-referential or oversized tag overflows the stack or exhausts memory.

This is **not** confined to opt-in debug logging. The trigger is on an always-on, process-critical path with no runtime guard:

- [serve.go](serve.go) `mustBroadcast` (documented as "critical" to keep running) eagerly evaluates `Message.String()` in the error it raises when a slow `Request`'s buffered channel fills, on any non-`Update` message. `Message.String()` renders `Dest`, an arbitrary application tag. No `jaws.Debug` guard, and the Serve goroutine has no `recover`.

So a malformed broadcast `Dest` can crash a **production** process.

## Approach

Rather than a bounded reimplementation of `fmt`, **gate the descend-into-value rendering behind a build tag**. Two implementations, both compiled in every build:

- **`TagStringRelease`** — renders the type and, for a pointer, its address. It never hands the tag to a formatting verb or invokes a `String`/`GoString`/`Format`/`Error` method; the address is read under a **recover** (`reflect.Value.Pointer` can panic on some cgo / not-in-heap pointers → falls back to type-only), and an over-long type name is truncated. It cannot recurse, overflow the stack, exhaust memory, or panic on any input — at the cost of not showing the tag's contents.
- **`TagStringDebug`** — full detail (type+address, `Stringer` text, or `%#v`): informative, not safe against pathological tags.

`TagString`/`TagsString` **forward** to the release variants by default and to the debug variants under **`-tags debug` or `-race`**. `const DebugRender` reports which is active. `Message.String`/`Element.String` route through `TagString`, so the **production build of every tag-render site — including the always-on broadcast path — is bounded**, while development/`-race` builds keep full detail. (`TagsStringDebug` renders lists in full — no aggregate cap — matching the debug contract; only the release list is size-capped.)

## Safety, measured

The release path is method-free (regression test uses `String`/`GoString`/`Format` methods that panic if called), reads a pointer's address only under recover (tested via the panic `reflect.Value.Pointer` raises on a non-pointer), and caps type-name/list size:

| input | before | after (release) |
|---|---|---|
| tag with a ~4 MiB dynamic type name | ~8.4 MiB | **4 KiB** |
| 1,000,000-element tag list | ~41.7 MiB | **17 KiB** |
| cyclic / cgo / not-in-heap pointer tag | crash risk | type (+ address when safe), never touches the value |

## Tests / CI

- `lib/tag`: both implementations tested directly (build-agnostic); release bounded on cyclic slice/map, huge type name, huge list; `pointerAddr` recover path covered; forwarding per build.
- Release-only reproduction of #197 on the `serve.go` path: `Message.String` with a self-referential `Dest` stays bounded.
- **`-race`/`-tags debug` select the debug renderer**, so `build.yml` gains a non-`-race` leg (`go test ./...`) exercising the crash-safe release path; `README.md` and the package doc document running both legs.
- **100% statement coverage** of `lib/tag` in both `go test ./...` and `go test -race ./...`; `vet`/`gofumpt`/`staticcheck` (default and `-tags debug`)/`golangci-lint` clean; full module suite green in all three build modes.