### PR TITLE
fix: reject the framework-owned "id" attribute in attribute helpers

### DIFF
--- a/broadcast.go
+++ b/broadcast.go
@@ -273,13 +273,29 @@ func (jw *Jaws) SetInner(target any, innerHTML template.HTML) {
 //
 // The value parameter must be the unescaped logical attribute value. It is sent
 // to the browser DOM and used as the value argument to setAttribute().
+//
+// The framework-owned "id" attribute is rejected (ASCII case-insensitively):
+// attempting to set it is reported as [ErrReservedAttribute] via reportMisuse and
+// nothing is sent, since it carries an [Element]'s JaWS identity.
 func (jw *Jaws) SetAttr(target any, attr, value string) {
+	if isReservedAttr(attr) {
+		jw.reportMisuse(fmt.Errorf("jaws: SetAttr: %q: %w", attr, ErrReservedAttribute))
+		return
+	}
 	jw.broadcastTo(target, what.SAttr, attr+"\n"+value)
 }
 
 // RemoveAttr sends a request to remove the given attribute from
 // all HTML elements matching target.
+//
+// The framework-owned "id" attribute is rejected (ASCII case-insensitively):
+// attempting to remove it is reported as [ErrReservedAttribute] via reportMisuse and
+// nothing is sent, since it carries an [Element]'s JaWS identity.
 func (jw *Jaws) RemoveAttr(target any, attr string) {
+	if isReservedAttr(attr) {
+		jw.reportMisuse(fmt.Errorf("jaws: RemoveAttr: %q: %w", attr, ErrReservedAttribute))
+		return
+	}
 	jw.broadcastTo(target, what.RAttr, attr)
 }
 

--- a/element.go
+++ b/element.go
@@ -214,11 +214,22 @@ func (elem *Element) queue(wht what.What, data string) (queued bool) {
 	return
 }
 
+// isReservedAttr reports whether attr names a framework-owned attribute that must
+// not be set or removed through the public helpers. The match is ASCII
+// case-insensitive because browsers lower-case HTML attribute names in setAttribute.
+func isReservedAttr(attr string) bool {
+	return strings.EqualFold(attr, "id")
+}
+
 // SetAttr queues sending a new attribute value
 // to the browser for the [Element].
 //
 // The value parameter must be the unescaped logical attribute value. It is sent
 // to the browser DOM and used as the value argument to setAttribute().
+//
+// The framework-owned "id" attribute is rejected (ASCII case-insensitively):
+// attempting to set it is reported as [ErrReservedAttribute] via reportMisuse and
+// nothing is sent, since it carries the [Element]'s JaWS identity.
 //
 // Call this while the [Element] is rendering or updating, when a send pass is
 // imminent. To change the [Element] in response to a browser event, mark it dirty
@@ -226,11 +237,19 @@ func (elem *Element) queue(wht what.What, data string) (queued bool) {
 // flushed only when the processing loop is next woken, which on an otherwise-idle
 // request is not guaranteed to be prompt (see [Element.queue]).
 func (elem *Element) SetAttr(attr, value string) {
+	if isReservedAttr(attr) {
+		elem.Jaws.reportMisuse(fmt.Errorf("jaws: Element.SetAttr: %q: %w", attr, ErrReservedAttribute))
+		return
+	}
 	elem.queue(what.SAttr, attr+"\n"+value)
 }
 
 // RemoveAttr queues sending a request to remove an attribute
 // to the browser for the [Element].
+//
+// The framework-owned "id" attribute is rejected (ASCII case-insensitively):
+// attempting to remove it is reported as [ErrReservedAttribute] via reportMisuse and
+// nothing is sent, since it carries the [Element]'s JaWS identity.
 //
 // Call this while the [Element] is rendering or updating, when a send pass is
 // imminent. To change the [Element] in response to a browser event, mark it dirty
@@ -238,6 +257,10 @@ func (elem *Element) SetAttr(attr, value string) {
 // flushed only when the processing loop is next woken, which on an otherwise-idle
 // request is not guaranteed to be prompt (see [Element.queue]).
 func (elem *Element) RemoveAttr(attr string) {
+	if isReservedAttr(attr) {
+		elem.Jaws.reportMisuse(fmt.Errorf("jaws: Element.RemoveAttr: %q: %w", attr, ErrReservedAttribute))
+		return
+	}
 	elem.queue(what.RAttr, attr)
 }
 

--- a/element_test.go
+++ b/element_test.go
@@ -473,23 +473,29 @@ func TestElement_AttrHelpersRejectReservedId(t *testing.T) {
 			defer jw.Close()
 			logger := &captureErrorLogger{}
 			jw.Logger = logger
-			rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+			// A plain NewRequest has no running process loop, so nothing drains
+			// wsQueue underneath the assertion (unlike newTestRequest).
+			rq := jw.NewRequest(nil)
+			defer jw.recycle(rq)
 			e := rq.NewElement(&testUi{})
 
+			// Wrap only the call so that in a debug build the fail-fast panic is
+			// recovered here and the identity/queue assertions below still run.
+			call := func() { tt.call(e) }
 			if deadlock.Debug {
-				// Debug builds fail fast with a panic (after logging the misuse).
-				defer func() {
-					if recover() == nil {
-						t.Fatal("reserved attribute did not panic in a debug build")
-					}
+				func() {
+					defer func() {
+						if recover() == nil {
+							t.Fatal("reserved attribute did not panic in a debug build")
+						}
+					}()
+					call()
 				}()
-			}
-			tt.call(e)
-			if deadlock.Debug {
-				t.Fatal("reserved attribute should have panicked in debug build")
+			} else {
+				call()
 			}
 
-			// Production builds (with a Logger) report it and send nothing.
+			// Both builds report the misuse (after logging) and send nothing.
 			if !errors.Is(logger.err, ErrReservedAttribute) {
 				t.Fatalf("error = %v, want ErrReservedAttribute", logger.err)
 			}
@@ -505,8 +511,15 @@ func TestElement_AttrHelpersRejectReservedId(t *testing.T) {
 }
 
 func TestElement_AttrHelpersAllowNormalAttr(t *testing.T) {
-	rq := newTestRequest(t)
-	defer rq.Close()
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+	// A plain NewRequest has no running process loop, so nothing drains wsQueue
+	// underneath the assertion (unlike newTestRequest).
+	rq := jw.NewRequest(nil)
+	defer jw.recycle(rq)
 	e := rq.NewElement(&testUi{})
 	e.SetAttr("hidden", "yes")
 	e.RemoveAttr("hidden")

--- a/element_test.go
+++ b/element_test.go
@@ -453,6 +453,79 @@ func TestElement_ReplaceRejectsMissingId(t *testing.T) {
 	}
 }
 
+func TestElement_AttrHelpersRejectReservedId(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(e *Element)
+	}{
+		{"SetAttr id", func(e *Element) { e.SetAttr("id", "changed") }},
+		{"SetAttr ID", func(e *Element) { e.SetAttr("ID", "changed") }},
+		{"SetAttr Id", func(e *Element) { e.SetAttr("Id", "changed") }},
+		{"RemoveAttr id", func(e *Element) { e.RemoveAttr("id") }},
+		{"RemoveAttr iD", func(e *Element) { e.RemoveAttr("iD") }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jw, err := New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer jw.Close()
+			logger := &captureErrorLogger{}
+			jw.Logger = logger
+			rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+			e := rq.NewElement(&testUi{})
+
+			if deadlock.Debug {
+				// Debug builds fail fast with a panic (after logging the misuse).
+				defer func() {
+					if recover() == nil {
+						t.Fatal("reserved attribute did not panic in a debug build")
+					}
+				}()
+			}
+			tt.call(e)
+			if deadlock.Debug {
+				t.Fatal("reserved attribute should have panicked in debug build")
+			}
+
+			// Production builds (with a Logger) report it and send nothing.
+			if !errors.Is(logger.err, ErrReservedAttribute) {
+				t.Fatalf("error = %v, want ErrReservedAttribute", logger.err)
+			}
+			rq.muQueue.Lock()
+			defer rq.muQueue.Unlock()
+			for _, msg := range rq.wsQueue {
+				if msg.What == what.SAttr || msg.What == what.RAttr {
+					t.Fatalf("reserved attribute was enqueued: %+v", msg)
+				}
+			}
+		})
+	}
+}
+
+func TestElement_AttrHelpersAllowNormalAttr(t *testing.T) {
+	rq := newTestRequest(t)
+	defer rq.Close()
+	e := rq.NewElement(&testUi{})
+	e.SetAttr("hidden", "yes")
+	e.RemoveAttr("hidden")
+	rq.muQueue.Lock()
+	defer rq.muQueue.Unlock()
+	var sattr, rattr int
+	for _, msg := range rq.wsQueue {
+		switch msg.What {
+		case what.SAttr:
+			sattr++
+		case what.RAttr:
+			rattr++
+		}
+	}
+	if sattr != 1 || rattr != 1 {
+		t.Fatalf("want 1 SAttr and 1 RAttr queued, got %d and %d", sattr, rattr)
+	}
+}
+
 func TestElement_ReplaceMessageTargetsElementHTML(t *testing.T) {
 	rq := newTestRequest(t)
 	defer rq.Close()

--- a/errors.go
+++ b/errors.go
@@ -58,6 +58,16 @@ var ErrInvalidChildElement = errors.New("invalid child element")
 // insert at the end.
 var ErrInvalidChildIndex = errors.New("invalid child index")
 
+// ErrReservedAttribute indicates an attempt to set or remove a framework-owned
+// attribute through a public attribute helper.
+//
+// The "id" attribute carries an [Element]'s JaWS identity: every wire command
+// resolves its target node with document.getElementById, so changing or removing
+// it would strand the server-side [Element] with an unreachable DOM node. The
+// [Element.SetAttr], [Element.RemoveAttr], [Jaws.SetAttr] and [Jaws.RemoveAttr]
+// helpers report this via reportMisuse and send nothing.
+var ErrReservedAttribute = errors.New("reserved attribute")
+
 // ErrJavascriptDisabled is returned when the noscript probe indicates JavaScript is disabled.
 var ErrJavascriptDisabled = errors.New("javascript is disabled")
 

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -1515,6 +1515,51 @@ func TestJaws_InsertRejectsNegativeIndex(t *testing.T) {
 	}
 }
 
+func TestJaws_AttrHelpersRejectReservedId(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(jw *Jaws)
+	}{
+		{"SetAttr id", func(jw *Jaws) { jw.SetAttr(tag.Tag("t"), "id", "changed") }},
+		{"SetAttr ID", func(jw *Jaws) { jw.SetAttr(tag.Tag("t"), "ID", "changed") }},
+		{"RemoveAttr id", func(jw *Jaws) { jw.RemoveAttr(tag.Tag("t"), "id") }},
+		{"RemoveAttr Id", func(jw *Jaws) { jw.RemoveAttr(tag.Tag("t"), "Id") }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jw, err := New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer jw.Close()
+			logger := &captureErrorLogger{}
+			jw.Logger = logger
+
+			call := func() { tt.call(jw) }
+			if deadlock.Debug {
+				func() {
+					defer func() {
+						if recover() == nil {
+							t.Fatal("reserved attribute did not panic in a debug build")
+						}
+					}()
+					call()
+				}()
+			} else {
+				call()
+			}
+			if !errors.Is(logger.err, ErrReservedAttribute) {
+				t.Fatalf("error = %v, want ErrReservedAttribute", logger.err)
+			}
+			select {
+			case msg := <-jw.bcastCh:
+				t.Fatalf("reserved attribute queued broadcast %#v", msg)
+			default:
+			}
+		})
+	}
+}
+
 func TestBroadcast_NoneDestination(t *testing.T) {
 	jw, err := New()
 	if err != nil {

--- a/lib/assets/jaws.js
+++ b/lib/assets/jaws.js
@@ -438,6 +438,9 @@ function jawsSetAttr(elem, data) {
 	const idx = data.indexOf('\n');
 	const attr = data.substring(0, idx);
 	const val = data.substring(idx + 1);
+	if (attr.toLowerCase() === 'id') {
+		throw "jaws: refusing to change reserved attribute 'id'";
+	}
 	if (elem.getAttribute(attr) !== val) {
 		elem.setAttribute(attr, val);
 	}
@@ -598,6 +601,9 @@ function jawsPerform(what, id, data) {
 			jawsSetAttr(elem, data);
 			return;
 		case 'RAttr':
+			if (data.toLowerCase() === 'id') {
+				throw "jaws: refusing to remove reserved attribute 'id'";
+			}
 			elem.removeAttribute(data);
 			return;
 		case 'SClass':

--- a/lib/assets/js_test.go
+++ b/lib/assets/js_test.go
@@ -2566,3 +2566,116 @@ process.stdout.write(JSON.stringify({ warnings: warnings, replaceCalls: replaceC
 		t.Fatalf("replace calls = %d, want 0", got.ReplaceCalls)
 	}
 }
+
+func TestJawsJS_AttrGuardsRejectReservedId(t *testing.T) {
+	raw := runJawsJSSnippet(t, `
+function FakeSocket() { this.readyState = 1; this.sent = []; }
+FakeSocket.prototype.send = function(msg) { this.sent.push(msg); };
+WebSocket = FakeSocket;
+jaws = new FakeSocket();
+
+// Keep the Inner order in the frame test focused on "did it run at all".
+jawsRemoving = function() {};
+jawsAttachChildren = function(node) { return node; };
+
+const elem1 = {
+	id: "Jid.1",
+	attrs: { id: "Jid.1" },
+	getAttribute: function(a) { return Object.prototype.hasOwnProperty.call(this.attrs, a) ? this.attrs[a] : null; },
+	setAttribute: function(a, v) { this.attrs[a] = v; },
+	removeAttribute: function(a) { delete this.attrs[a]; },
+	innerHTML: "",
+	querySelectorAll: function() { return []; },
+};
+const elem2 = {
+	id: "Jid.2",
+	innerHTML: "old",
+	querySelectorAll: function() { return []; },
+};
+const elems = { "Jid.1": elem1, "Jid.2": elem2 };
+document.getElementById = function(id) { return elems[id] || null; };
+
+const errors = [];
+console.error = function(msg) { errors.push(String(msg)); };
+
+// SAttr rejects "id" ASCII case-insensitively without touching setAttribute.
+const sattrThrows = {};
+["id", "ID", "Id", "iD"].forEach(function(name) {
+	try {
+		jawsSetAttr(elem1, name + "\nhacked");
+		sattrThrows[name] = false;
+	} catch (err) {
+		sattrThrows[name] = true;
+	}
+});
+// A normal attribute is still applied.
+jawsSetAttr(elem1, "title\nhello");
+const normalAttr = elem1.getAttribute("title");
+
+// RAttr rejects "id" ASCII case-insensitively without touching removeAttribute.
+const rattrThrows = {};
+["id", "ID", "Id", "iD"].forEach(function(name) {
+	try {
+		jawsPerform("RAttr", "Jid.1", JSON.stringify(name));
+		rattrThrows[name] = false;
+	} catch (err) {
+		rattrThrows[name] = true;
+	}
+});
+const idAfterRemove = elem1.getAttribute("id");
+
+// A frame whose first order tries to change "id" throws, but jawsMessage isolates
+// it so later orders in the same frame still apply.
+const frame = [
+	"SAttr\tJid.1\t" + JSON.stringify("id\nhacked"),
+	"Inner\tJid.2\t" + JSON.stringify("<b>ok</b>")
+].join("\n");
+jawsMessage({ data: frame });
+
+process.stdout.write(JSON.stringify({
+	sattrThrows: sattrThrows,
+	rattrThrows: rattrThrows,
+	normalAttr: normalAttr,
+	idAfterRemove: idAfterRemove,
+	idAfterFrame: elem1.getAttribute("id"),
+	laterOrderInner: elem2.innerHTML,
+	frameErrors: errors.length
+}));
+`)
+
+	var got struct {
+		SattrThrows     map[string]bool `json:"sattrThrows"`
+		RattrThrows     map[string]bool `json:"rattrThrows"`
+		NormalAttr      string          `json:"normalAttr"`
+		IDAfterRemove   string          `json:"idAfterRemove"`
+		IDAfterFrame    string          `json:"idAfterFrame"`
+		LaterOrderInner string          `json:"laterOrderInner"`
+		FrameErrors     int             `json:"frameErrors"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &got); err != nil {
+		t.Fatalf("failed to parse snippet output %q: %v", raw, err)
+	}
+	for _, name := range []string{"id", "ID", "Id", "iD"} {
+		if !got.SattrThrows[name] {
+			t.Errorf("jawsSetAttr(%q) did not reject the reserved attribute", name)
+		}
+		if !got.RattrThrows[name] {
+			t.Errorf("RAttr %q did not reject the reserved attribute", name)
+		}
+	}
+	if got.NormalAttr != "hello" {
+		t.Errorf("normal attribute = %q, want %q", got.NormalAttr, "hello")
+	}
+	if got.IDAfterRemove != "Jid.1" {
+		t.Errorf("id after rejected RemoveAttr = %q, want it untouched", got.IDAfterRemove)
+	}
+	if got.IDAfterFrame != "Jid.1" {
+		t.Errorf("id after rejected SAttr in frame = %q, want it untouched", got.IDAfterFrame)
+	}
+	if got.LaterOrderInner != "<b>ok</b>" {
+		t.Errorf("later order in frame = %q, want it applied despite the earlier throw", got.LaterOrderInner)
+	}
+	if got.FrameErrors == 0 {
+		t.Error("rejected SAttr in frame was not surfaced via console.error")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #198.

`Element.SetAttr`/`RemoveAttr` and `Jaws.SetAttr`/`RemoveAttr` accepted any attribute name, including `"id"`. A JaWS-managed DOM node is addressable only by its JaWS `Jid`, and every wire command resolves its target via `document.getElementById(id)`. Setting or removing `id` through these helpers changed/removed that identity in the browser while the server kept targeting the original `Jid`, so all later commands failed with `jaws: element not found`, event routing could no longer find the Element, and a duplicate `id` could route commands to the wrong node.

## Changes

- **New sentinel `ErrReservedAttribute`** (`errors.go`) for a stable, matchable misuse identity.
- **Guard all four helpers** (`element.go`, `broadcast.go`): reject `"id"` ASCII case-insensitively via a shared `isReservedAttr` helper, report through `reportMisuse`, and send/queue nothing — mirroring how `Jaws.Insert` guards a negative child index (`ErrInvalidChildIndex`). In production (Logger configured) the misuse is logged and the call is a no-op; debug/race builds panic to fail fast.
- **Client-side guard** (`lib/assets/jaws.js`): defense in depth — `jawsSetAttr` and the `RAttr` case throw on `id`, caught by `jawsMessage`'s per-order `try/catch` so the rest of the frame still applies.
- The initial-render tail-script path only *consumes* the queue, so blocking the enqueue at the source protects it too — no change needed there.

## Tests

- `TestElement_AttrHelpersRejectReservedId` / `TestJaws_AttrHelpersRejectReservedId`: table-driven, including case variants (`ID`, `Id`, `iD`) to lock in ASCII case-insensitivity; assert `errors.Is(err, ErrReservedAttribute)`, panic under debug builds, and that nothing is queued/broadcast.
- `TestElement_AttrHelpersAllowNormalAttr`: control case confirming a normal attribute (`hidden`) still queues.

The repo has no JS unit-test harness, so the client guard is verified by review + `node --check`.

## Verification

- `gofmt -l`, `go vet ./...` — clean
- `go test -race ./...` — all pass (debug/panic path)
- `go test ./...` — pass (production log-and-continue path)
- `node --check lib/assets/jaws.js` — OK