### PR TITLE
fix: close #199 — remove Jaws.Replace and reject Replace/Remove broadcasts

### DIFF
--- a/broadcast.go
+++ b/broadcast.go
@@ -28,8 +28,8 @@ import (
 // A [wire.Message.What] of [what.Replace] or [what.Remove] is rejected (as
 // [ErrReplaceNotBroadcastable] or [ErrRemoveNotBroadcastable]) via reportMisuse and
 // nothing is sent: each mutates a specific element's node in a way the broadcast path
-// cannot keep in sync with the server-side registry, stranding the matched [Element]s
-// with no reachable DOM node. Use [Element.Replace], or [Jaws.Delete] / [Element.Remove],
+// cannot keep in sync with the server-side registry, stranding the matched [Element]
+// values with no reachable DOM node. Use [Element.Replace], or [Jaws.Delete] / [Element.Remove],
 // for the identity-preserving forms.
 //
 // A nil [wire.Message.Dest] targets every active Request; a [key.Key] Dest targets

--- a/broadcast.go
+++ b/broadcast.go
@@ -25,6 +25,13 @@ import (
 //
 // All convenience helpers on [Jaws] that call Broadcast inherit this requirement.
 //
+// A [wire.Message.What] of [what.Replace] or [what.Remove] is rejected (as
+// [ErrReplaceNotBroadcastable] or [ErrRemoveNotBroadcastable]) via reportMisuse and
+// nothing is sent: each mutates a specific element's node in a way the broadcast path
+// cannot keep in sync with the server-side registry, stranding the matched [Element]s
+// with no reachable DOM node. Use [Element.Replace], or [Jaws.Delete] / [Element.Remove],
+// for the identity-preserving forms.
+//
 // A nil [wire.Message.Dest] targets every active Request; a [key.Key] Dest targets
 // the active Request with that identity key, and a zero key is dropped. Any other
 // Dest is expanded into tags. Plain strings and [Jid] values are illegal tag
@@ -35,6 +42,14 @@ import (
 // set; with a Logger the error is logged and the message is sent to the
 // destinations that did expand.
 func (jw *Jaws) Broadcast(msg wire.Message) {
+	switch msg.What {
+	case what.Replace:
+		jw.reportMisuse(fmt.Errorf("jaws: Broadcast: %w; use Element.Replace", ErrReplaceNotBroadcastable))
+		return
+	case what.Remove:
+		jw.reportMisuse(fmt.Errorf("jaws: Broadcast: %w; use Jaws.Delete or Element.Remove", ErrRemoveNotBroadcastable))
+		return
+	}
 	switch dest := msg.Dest.(type) {
 	case nil: // send to all active requests
 	case key.Key: // send to the active request with this identity key

--- a/broadcast.go
+++ b/broadcast.go
@@ -335,13 +335,6 @@ func (jw *Jaws) Insert(target any, childIndex int, html template.HTML) {
 	jw.broadcastTo(target, what.Insert, strconv.Itoa(childIndex)+"\n"+string(html))
 }
 
-// Replace replaces HTML on all HTML elements matching target.
-//
-// html is trusted HTML, matching [Jaws.SetInner] and [Jaws.Append].
-func (jw *Jaws) Replace(target any, html template.HTML) {
-	jw.broadcastTo(target, what.Replace, string(html))
-}
-
 // Delete removes the HTML element(s) matching target.
 func (jw *Jaws) Delete(target any) {
 	jw.broadcastTo(target, what.Delete, "")

--- a/errors.go
+++ b/errors.go
@@ -68,6 +68,29 @@ var ErrInvalidChildIndex = errors.New("invalid child index")
 // helpers report this via reportMisuse and send nothing.
 var ErrReservedAttribute = errors.New("reserved attribute")
 
+// ErrReplaceNotBroadcastable indicates an attempt to broadcast a [what.Replace] command.
+//
+// Replace swaps the whole target node for new HTML, which must carry the
+// [Element]'s own "id" so the server-side [Element] keeps a reachable DOM node
+// (see [Element.Replace], which validates exactly that). A broadcast delivers one
+// payload to every element matching [wire.Message.Dest], so no single payload can
+// preserve each element's distinct id and the matched Elements would be stranded
+// with no matching DOM node. [Jaws.Broadcast] reports this via reportMisuse and
+// sends nothing; use [Element.Replace] for the per-element form.
+var ErrReplaceNotBroadcastable = errors.New("what.Replace cannot be broadcast")
+
+// ErrRemoveNotBroadcastable indicates an attempt to broadcast a [what.Remove] command.
+//
+// Remove deletes the child node named by Data from the matched element and requires
+// the child's server-side [Element] to be unregistered too (see [Element.Remove],
+// which calls [Request.DeleteElement]; the client acknowledges only the removal of
+// the child's descendants, never the child itself). A broadcast forwards the command
+// verbatim without that registry cleanup, and its Data names one request's child, so
+// matched child Elements would be stranded with no reachable DOM node. [Jaws.Broadcast]
+// reports this via reportMisuse and sends nothing; use [Jaws.Delete] to remove matched
+// elements, or [Element.Remove] for the per-element child form.
+var ErrRemoveNotBroadcastable = errors.New("what.Remove cannot be broadcast")
+
 // ErrJavascriptDisabled is returned when the noscript probe indicates JavaScript is disabled.
 var ErrJavascriptDisabled = errors.New("javascript is disabled")
 

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -1366,10 +1366,6 @@ func TestCoverage_GenerateHeadAndConvenienceBroadcasts(t *testing.T) {
 	if msg := nextBroadcast(t, jw); msg.What != what.Insert || msg.Data != "0\n<i>a</i>" {
 		t.Fatalf("unexpected insert msg %#v", msg)
 	}
-	jw.Replace(target, "<i>b</i>")
-	if msg := nextBroadcast(t, jw); msg.What != what.Replace || msg.Data != "<i>b</i>" {
-		t.Fatalf("unexpected replace msg %#v", msg)
-	}
 	jw.Delete(target)
 	if msg := nextBroadcast(t, jw); msg.What != what.Delete {
 		t.Fatalf("unexpected delete msg %#v", msg)

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -1556,6 +1556,61 @@ func TestJaws_AttrHelpersRejectReservedId(t *testing.T) {
 	}
 }
 
+func TestBroadcast_RejectsElementMutatingCommands(t *testing.T) {
+	// Replace and Remove mutate a specific element's node in a way the broadcast path
+	// cannot keep in sync with the server-side registry: a raw broadcast forwards the
+	// command verbatim to every matching element, stranding the server-side Element
+	// with no reachable DOM node (the #199 identity desync). Both must be rejected
+	// before reaching bcastCh, regardless of Data.
+	tests := []struct {
+		name    string
+		what    what.What
+		wantErr error
+	}{
+		{"Replace", what.Replace, ErrReplaceNotBroadcastable},
+		{"Remove", what.Remove, ErrRemoveNotBroadcastable},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jw, err := New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer jw.Close()
+			logger := &captureErrorLogger{}
+			jw.Logger = logger
+
+			call := func() {
+				jw.Broadcast(wire.Message{
+					Dest: tag.Tag("t"),
+					What: tt.what,
+					Data: "whatever",
+				})
+			}
+			if deadlock.Debug {
+				func() {
+					defer func() {
+						if recover() == nil {
+							t.Fatalf("broadcast of %v did not panic in a debug build", tt.what)
+						}
+					}()
+					call()
+				}()
+			} else {
+				call()
+			}
+			if !errors.Is(logger.err, tt.wantErr) {
+				t.Fatalf("error = %v, want %v", logger.err, tt.wantErr)
+			}
+			select {
+			case msg := <-jw.bcastCh:
+				t.Fatalf("%v queued broadcast %#v", tt.what, msg)
+			default:
+			}
+		})
+	}
+}
+
 func TestBroadcast_NoneDestination(t *testing.T) {
 	jw, err := New()
 	if err != nil {

--- a/request_test.go
+++ b/request_test.go
@@ -2540,25 +2540,6 @@ func TestRequest_IncomingRemoveDoesNotDeleteMessageJidListedInData(t *testing.T)
 	})
 }
 
-func TestRequest_ReplaceMessageTargetsElementHTML(t *testing.T) {
-	rq := newTestRequest(t)
-	defer rq.Close()
-
-	tagValue := &testUi{}
-	jid := rq.Register(tagValue)
-	html := template.HTML(`<div id="` + jid.String() + `">replaced</div>`)
-
-	rq.Jaws.Replace(tagValue, html)
-	msg := nextOutboundMsg(t, rq)
-
-	if msg.What != what.Replace {
-		t.Fatalf("unexpected message type %v", msg.What)
-	}
-	if msg.Data != string(html) {
-		t.Fatalf("replace payload mismatch: got %q want %q", msg.Data, html)
-	}
-}
-
 func TestRequest_JsCallProducesJawsJSFrameSafeWireData(t *testing.T) {
 	rq := newTestRequest(t)
 	defer rq.Close()


### PR DESCRIPTION
## What

Closes the #199 DOM/server identity desync at the source, in two commits:

1. **Remove the `Jaws.Replace(target, html)` convenience helper** and its two test callers.
2. **Reject `what.Replace` *and* `what.Remove` in `Jaws.Broadcast`** — the public broadcast entry point — reporting the new sentinels `ErrReplaceNotBroadcastable` / `ErrRemoveNotBroadcastable` via `reportMisuse` and sending nothing.

## Why

`Jaws.Broadcast` is public and `handleBroadcast` forwards unrecognized commands verbatim to every matching element. So removing the `Jaws.Replace` helper alone was not enough — a caller could still send `wire.Message{What: what.Replace, ...}` (or `what.Remove`) through raw `Broadcast` and reproduce the same strand: the DOM node is mutated/removed while the server-side `Element` stays registered with no reachable DOM node.

Both commands mutate a *specific* element's node in a way a broadcast cannot keep in sync with the server-side registry:

- **Replace** swaps the whole node for HTML that must carry the element's own `id`; one broadcast payload cannot preserve the distinct `id` of every matched element.
- **Remove** deletes a child node and requires the child's `Element` to be unregistered server-side. The broadcast default path never calls `DeleteElement`, and the client acks only the child's *descendants*, never the child itself (`jawsRemoving` uses `querySelectorAll`, which excludes the node being removed) — so the child `Element` is stranded. This is precisely why the safe per-element `Element.Remove` calls `Request.DeleteElement(child)` itself.

## Safe forms (unaffected)

- `Element.Replace` — per-element, validates the replacement carries the element's `id`.
- `Element.Remove` — per-element child removal, unregisters the child server-side.
- `Jaws.Delete` — broadcast-level element removal that stays in sync (its `handleBroadcast` case calls `DeleteElement`).
- The `what.Replace` / `what.Remove` wire commands and all client-side handling are untouched.

## Breaking change

Removes the exported `Jaws.Replace` method (API break for any external caller; nothing in-repo used it outside tests). `Jaws.Broadcast` now rejects `what.Replace` / `what.Remove` messages instead of forwarding them — these were never emitted by any in-repo helper.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test -race ./...` — all packages pass
- `gofumpt` (touched files), `staticcheck ./...`, `golangci-lint run ./...` — clean / 0 issues
- `TestBroadcast_RejectsElementMutatingCommands` — table-driven regression test exercising raw `Jaws.Broadcast` for both `Replace` and `Remove`, asserting the sentinel is reported and nothing reaches `bcastCh` (covers both the debug-panic and production-log branches).

## Noted, deliberately out of scope

- Broadcasting `what.SAttr`/`what.RAttr` with `id` is refused only client-side on the raw-broadcast path (the server-side `ErrReservedAttribute` guard lives in the attribute helpers). This does **not** strand — the id-bearing node survives — so it is not a #199-class defect. Happy to follow up separately if you want the server-side guard extended to the broadcast path.
