### PR TITLE
fix: encode carriage returns so HTML helpers round-trip them

### DIFF
--- a/lib/htmlio/writehtml.go
+++ b/lib/htmlio/writehtml.go
@@ -46,6 +46,25 @@ func isNewlineSensitive(tag string) bool {
 	return false
 }
 
+// appendEscapeCR appends s to b, replacing every carriage return with the
+// numeric character reference &#13;.
+//
+// Browser input-stream preprocessing rewrites a raw CR (and a CRLF pair) to a
+// single LF before tokenization, so a raw carriage return never reaches the DOM.
+// The reference is decoded back to CR after preprocessing, so encoding it lets
+// logical values that contain carriage returns round-trip through HTML parsing.
+func appendEscapeCR(b []byte, s string) []byte {
+	for {
+		i := strings.IndexByte(s, '\r')
+		if i < 0 {
+			return append(b, s...)
+		}
+		b = append(b, s[:i]...)
+		b = append(b, "&#13;"...)
+		s = s[i+1:]
+	}
+}
+
 // AppendAttrs appends each non-empty attribute fragment in attrs to b, each
 // prefixed with a single space so the result can be concatenated directly after a
 // tag name.
@@ -68,9 +87,13 @@ func AppendAttrs(b []byte, attrs []template.HTMLAttr) []byte {
 // The value parameter must be the unescaped logical attribute value. It is
 // escaped for HTML source output by this function. Use [Attr] or [AppendAttr]
 // to build a complete name=value fragment.
+//
+// Carriage returns are emitted as the numeric character reference &#13;, because
+// browser input-stream preprocessing would otherwise rewrite a raw CR to LF
+// before parsing and change the value the DOM reports.
 func AppendAttrValue(b []byte, value string) []byte {
 	b = append(b, '"')
-	b = append(b, html.EscapeString(value)...)
+	b = appendEscapeCR(b, html.EscapeString(value))
 	b = append(b, '"')
 	return b
 }
@@ -154,7 +177,10 @@ func WriteHTMLInput(w io.Writer, jid jid.Jid, typeAttr, valueAttr string, attrs 
 //
 // For textarea and pre elements, the HTML source includes one LF immediately
 // after the start tag. The parser consumes that prefix, so it adds no DOM content
-// while preserving a leading LF or CR from innerHTML.
+// while preserving a leading LF or CR from innerHTML. Because browser input-stream
+// preprocessing rewrites a raw carriage return to LF before parsing, each CR in
+// innerHTML is emitted as the numeric character reference &#13; so carriage
+// returns survive parsing unchanged.
 //
 // The htmlTag parameter is trusted and written verbatim with no escaping or
 // validation; it MUST NOT be derived from untrusted data. The typeAttr parameter
@@ -165,13 +191,17 @@ func WriteHTMLInput(w io.Writer, jid jid.Jid, typeAttr, valueAttr string, attrs 
 func WriteHTMLInner(w io.Writer, jid jid.Jid, htmlTag, typeAttr string, innerHTML template.HTML, attrs ...template.HTMLAttr) (err error) {
 	b := appendHTMLTag(nil, jid, htmlTag, typeAttr, "", attrs)
 	if needClosingTag(htmlTag) {
-		// The HTML parser strips one LF right after a textarea/pre start tag.
-		// Always provide that parser-consumed prefix so innerHTML is preserved
-		// regardless of whether its first character is LF, CR, or ordinary text.
 		if isNewlineSensitive(htmlTag) {
+			// The HTML parser strips one LF right after a textarea/pre start
+			// tag. Always provide that parser-consumed prefix so innerHTML is
+			// preserved regardless of whether its first character is LF, CR, or
+			// ordinary text. Encode each CR as &#13; because browser input-stream
+			// preprocessing would otherwise rewrite a raw CR to LF before parsing.
 			b = append(b, '\n')
+			b = appendEscapeCR(b, string(innerHTML))
+		} else {
+			b = append(b, innerHTML...)
 		}
-		b = append(b, innerHTML...)
 		b = append(b, "</"...)
 		b = append(b, htmlTag...)
 		b = append(b, '>')

--- a/lib/htmlio/writehtml.go
+++ b/lib/htmlio/writehtml.go
@@ -176,11 +176,16 @@ func WriteHTMLInput(w io.Writer, jid jid.Jid, typeAttr, valueAttr string, attrs 
 // example Attr("value", v)) when a value="..." is needed.
 //
 // For textarea and pre elements, the HTML source includes one LF immediately
-// after the start tag. The parser consumes that prefix, so it adds no DOM content
-// while preserving a leading LF or CR from innerHTML. Because browser input-stream
-// preprocessing rewrites a raw carriage return to LF before parsing, each CR in
-// innerHTML is emitted as the numeric character reference &#13; so carriage
-// returns survive parsing unchanged.
+// after the start tag. The parser strips that one LF, so a leading LF in
+// innerHTML is preserved instead of being consumed.
+//
+// Carriage returns in innerHTML are written verbatim, not encoded. A textarea
+// reports its value with every CR and CRLF normalized to LF (the HTML standard's
+// textarea value normalization), so carriage returns in textarea content cannot
+// round-trip through the value the browser sends back. Encoding them would also
+// be unsafe for pre, whose trusted markup may include script, comment, or other
+// contexts where character references are not decoded. Use [AppendAttrValue] for
+// logical values that must retain carriage returns.
 //
 // The htmlTag parameter is trusted and written verbatim with no escaping or
 // validation; it MUST NOT be derived from untrusted data. The typeAttr parameter
@@ -191,17 +196,14 @@ func WriteHTMLInput(w io.Writer, jid jid.Jid, typeAttr, valueAttr string, attrs 
 func WriteHTMLInner(w io.Writer, jid jid.Jid, htmlTag, typeAttr string, innerHTML template.HTML, attrs ...template.HTMLAttr) (err error) {
 	b := appendHTMLTag(nil, jid, htmlTag, typeAttr, "", attrs)
 	if needClosingTag(htmlTag) {
+		// The HTML parser strips one LF right after a textarea/pre start tag.
+		// Provide that parser-consumed prefix so a leading LF in innerHTML is
+		// preserved instead of being consumed. Carriage returns are written
+		// verbatim; the doc comment explains why they are not encoded here.
 		if isNewlineSensitive(htmlTag) {
-			// The HTML parser strips one LF right after a textarea/pre start
-			// tag. Always provide that parser-consumed prefix so innerHTML is
-			// preserved regardless of whether its first character is LF, CR, or
-			// ordinary text. Encode each CR as &#13; because browser input-stream
-			// preprocessing would otherwise rewrite a raw CR to LF before parsing.
 			b = append(b, '\n')
-			b = appendEscapeCR(b, string(innerHTML))
-		} else {
-			b = append(b, innerHTML...)
 		}
+		b = append(b, innerHTML...)
 		b = append(b, "</"...)
 		b = append(b, htmlTag...)
 		b = append(b, '>')

--- a/lib/htmlio/writehtml_test.go
+++ b/lib/htmlio/writehtml_test.go
@@ -1,6 +1,7 @@
 package htmlio_test
 
 import (
+	"html"
 	"html/template"
 	"io"
 	"strings"
@@ -144,10 +145,22 @@ func Test_WriteHTMLInner_NewlineSensitivePrefix(t *testing.T) {
 			want:  "<textarea id=\"Jid.1\">\n\nhello</textarea>",
 		},
 		{
-			name:  "textarea leading CR is prefixed with LF",
+			name:  "textarea leading CR is encoded as a character reference",
 			tag:   "textarea",
 			inner: "\rhello",
-			want:  "<textarea id=\"Jid.1\">\n\rhello</textarea>",
+			want:  "<textarea id=\"Jid.1\">\n&#13;hello</textarea>",
+		},
+		{
+			name:  "textarea interior and CRLF carriage returns are encoded",
+			tag:   "textarea",
+			inner: "a\rb\r\nc",
+			want:  "<textarea id=\"Jid.1\">\na&#13;b&#13;\nc</textarea>",
+		},
+		{
+			name:  "pre leading CR is encoded as a character reference",
+			tag:   "pre",
+			inner: "\rhello",
+			want:  "<pre id=\"Jid.1\">\n&#13;hello</pre>",
 		},
 		{
 			name:  "uppercase TEXTAREA is newline-sensitive",
@@ -177,6 +190,14 @@ func Test_WriteHTMLInner_NewlineSensitivePrefix(t *testing.T) {
 			tag:   "div",
 			inner: "\nx",
 			want:  "<div id=\"Jid.1\">\nx</div>",
+		},
+		{
+			// Only textarea/pre content is CR-encoded; a non-newline-sensitive
+			// element carries the trusted innerHTML markup through verbatim.
+			name:  "div carriage return is left verbatim",
+			tag:   "div",
+			inner: "a\rb",
+			want:  "<div id=\"Jid.1\">a\rb</div>",
 		},
 	}
 	for _, tt := range tests {
@@ -326,11 +347,35 @@ func TestWriteHTMLTag(t *testing.T) {
 }
 
 func TestAppendAttrValue(t *testing.T) {
-	value := `"&<>'`
-	got := string(htmlio.AppendAttrValue(nil, value))
-	want := `"&#34;&amp;&lt;&gt;&#39;"`
-	if got != want {
-		t.Fatalf("AppendAttrValue() = %q, want %q", got, want)
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{
+			name:  "html metacharacters",
+			value: `"&<>'`,
+			want:  `"&#34;&amp;&lt;&gt;&#39;"`,
+		},
+		{
+			// html.EscapeString leaves CR raw, but browser preprocessing would
+			// rewrite it to LF; it must be a numeric character reference instead.
+			name:  "carriage return is encoded",
+			value: "a\rb",
+			want:  `"a&#13;b"`,
+		},
+		{
+			name:  "CRLF encodes only the CR",
+			value: "a\r\nb",
+			want:  "\"a&#13;\nb\"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := string(htmlio.AppendAttrValue(nil, tt.value)); got != tt.want {
+				t.Fatalf("AppendAttrValue(%q) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -358,5 +403,64 @@ func TestWriteHTML_WriterErrorPropagates(t *testing.T) {
 	}
 	if err := htmlio.WriteHTMLInner(errWriter{}, jid.Jid(1), "span", "", "x"); err != io.ErrShortWrite {
 		t.Errorf("WriteHTMLInner error = %v, want %v", err, io.ErrShortWrite)
+	}
+}
+
+// normalizeCR models the browser HTML input-stream preprocessing step that
+// rewrites every CRLF pair and every standalone CR to a single LF before
+// tokenization. This is why a raw carriage return never survives HTML parsing.
+func normalizeCR(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	return strings.ReplaceAll(s, "\r", "\n")
+}
+
+// TestAppendAttrValue_DOMRoundTrip verifies that a logical attribute value with
+// carriage returns survives a browser parse unchanged. It models the two browser
+// steps that would otherwise corrupt a raw CR: input-stream preprocessing
+// (CR/CRLF to LF) followed by tokenizer character-reference decoding, the latter
+// using the standard library html.UnescapeString.
+func TestAppendAttrValue_DOMRoundTrip(t *testing.T) {
+	values := []string{"", "plain", "a\rb", "a\r\nb", "\rlead", "trail\r", "x\ry\rz", `"&<>'` + "\r"}
+	for _, value := range values {
+		src := string(htmlio.AppendAttrValue(nil, value))
+		inner := src[1 : len(src)-1] // strip the bounding double quotes
+		if got := html.UnescapeString(normalizeCR(inner)); got != value {
+			t.Errorf("attribute value %q round-tripped to %q via source %q", value, got, src)
+		}
+	}
+}
+
+// innerContent returns the HTML source between an element's start tag and its
+// matching end tag.
+func innerContent(t *testing.T, source, tag string) string {
+	t.Helper()
+	start := strings.IndexByte(source, '>')
+	end := strings.LastIndex(source, "</"+tag+">")
+	if start < 0 || end < start {
+		t.Fatalf("cannot locate <%s> content in %q", tag, source)
+	}
+	return source[start+1 : end]
+}
+
+// TestWriteHTMLInner_DOMRoundTrip verifies that carriage returns in textarea/pre
+// content survive a browser parse. It mirrors the ui.Textarea pipeline (the
+// value is HTML-escaped before WriteHTMLInner) and models the browser: input-
+// stream preprocessing (CR/CRLF to LF), character-reference decoding, then the
+// single leading LF the parser strips after a textarea/pre start tag.
+func TestWriteHTMLInner_DOMRoundTrip(t *testing.T) {
+	values := []string{"", "plain", "\rhello", "\nhello", "a\rb", "a\r\nb\rc", "\r\r", "<kept>&amp;"}
+	for _, tag := range []string{"textarea", "pre"} {
+		for _, value := range values {
+			inner := template.HTML(template.HTMLEscapeString(value)) // #nosec G203
+			var sb strings.Builder
+			if err := htmlio.WriteHTMLInner(&sb, jid.Jid(1), tag, "", inner); err != nil {
+				t.Fatal(err)
+			}
+			content := innerContent(t, sb.String(), tag)
+			decoded := html.UnescapeString(normalizeCR(content))
+			if got := strings.TrimPrefix(decoded, "\n"); got != value {
+				t.Errorf("%s value %q round-tripped to %q via source %q", tag, value, got, sb.String())
+			}
+		}
 	}
 }

--- a/lib/htmlio/writehtml_test.go
+++ b/lib/htmlio/writehtml_test.go
@@ -145,22 +145,21 @@ func Test_WriteHTMLInner_NewlineSensitivePrefix(t *testing.T) {
 			want:  "<textarea id=\"Jid.1\">\n\nhello</textarea>",
 		},
 		{
-			name:  "textarea leading CR is encoded as a character reference",
+			// A carriage return is written verbatim: the textarea value API
+			// normalizes it to LF (see TestWriteHTMLInner_TextareaValueNormalization),
+			// so encoding it would not round-trip anyway.
+			name:  "textarea carriage returns are written verbatim",
 			tag:   "textarea",
-			inner: "\rhello",
-			want:  "<textarea id=\"Jid.1\">\n&#13;hello</textarea>",
+			inner: "\ra\r\nb",
+			want:  "<textarea id=\"Jid.1\">\n\ra\r\nb</textarea>",
 		},
 		{
-			name:  "textarea interior and CRLF carriage returns are encoded",
-			tag:   "textarea",
-			inner: "a\rb\r\nc",
-			want:  "<textarea id=\"Jid.1\">\na&#13;b&#13;\nc</textarea>",
-		},
-		{
-			name:  "pre leading CR is encoded as a character reference",
+			// pre content is trusted markup written verbatim; encoding CR would
+			// corrupt nested script/comment contexts that do not decode &#13;.
+			name:  "pre carriage returns are written verbatim",
 			tag:   "pre",
-			inner: "\rhello",
-			want:  "<pre id=\"Jid.1\">\n&#13;hello</pre>",
+			inner: "<script>//x\rdoThing()</script>",
+			want:  "<pre id=\"Jid.1\">\n<script>//x\rdoThing()</script></pre>",
 		},
 		{
 			name:  "uppercase TEXTAREA is newline-sensitive",
@@ -192,8 +191,8 @@ func Test_WriteHTMLInner_NewlineSensitivePrefix(t *testing.T) {
 			want:  "<div id=\"Jid.1\">\nx</div>",
 		},
 		{
-			// Only textarea/pre content is CR-encoded; a non-newline-sensitive
-			// element carries the trusted innerHTML markup through verbatim.
+			// WriteHTMLInner never rewrites innerHTML; the trusted markup,
+			// including any carriage return, is carried through verbatim.
 			name:  "div carriage return is left verbatim",
 			tag:   "div",
 			inner: "a\rb",
@@ -415,10 +414,11 @@ func normalizeCR(s string) string {
 }
 
 // TestAppendAttrValue_DOMRoundTrip verifies that a logical attribute value with
-// carriage returns survives a browser parse unchanged. It models the two browser
-// steps that would otherwise corrupt a raw CR: input-stream preprocessing
-// (CR/CRLF to LF) followed by tokenizer character-reference decoding, the latter
-// using the standard library html.UnescapeString.
+// carriage returns survives a browser parse unchanged, as getAttribute reports
+// it. It models the two browser steps that would otherwise corrupt a raw CR:
+// input-stream preprocessing (CR/CRLF to LF) followed by tokenizer
+// character-reference decoding, the latter using the standard library
+// html.UnescapeString.
 func TestAppendAttrValue_DOMRoundTrip(t *testing.T) {
 	values := []string{"", "plain", "a\rb", "a\r\nb", "\rlead", "trail\r", "x\ry\rz", `"&<>'` + "\r"}
 	for _, value := range values {
@@ -442,25 +442,27 @@ func innerContent(t *testing.T, source, tag string) string {
 	return source[start+1 : end]
 }
 
-// TestWriteHTMLInner_DOMRoundTrip verifies that carriage returns in textarea/pre
-// content survive a browser parse. It mirrors the ui.Textarea pipeline (the
-// value is HTML-escaped before WriteHTMLInner) and models the browser: input-
-// stream preprocessing (CR/CRLF to LF), character-reference decoding, then the
-// single leading LF the parser strips after a textarea/pre start tag.
-func TestWriteHTMLInner_DOMRoundTrip(t *testing.T) {
+// TestWriteHTMLInner_TextareaValueNormalization documents that a textarea cannot
+// round-trip carriage returns: the value the browser reports (and jaws.js sends
+// back) collapses every CR and CRLF to LF. It mirrors the ui.Textarea pipeline
+// (the value is HTML-escaped before WriteHTMLInner) and models
+// HTMLTextAreaElement.value: input-stream preprocessing, character-reference
+// decoding, dropping the single leading LF the parser strips after the start
+// tag to obtain the raw value, then the textarea value normalization the HTML
+// standard applies (CR and CRLF become LF).
+func TestWriteHTMLInner_TextareaValueNormalization(t *testing.T) {
 	values := []string{"", "plain", "\rhello", "\nhello", "a\rb", "a\r\nb\rc", "\r\r", "<kept>&amp;"}
-	for _, tag := range []string{"textarea", "pre"} {
-		for _, value := range values {
-			inner := template.HTML(template.HTMLEscapeString(value)) // #nosec G203
-			var sb strings.Builder
-			if err := htmlio.WriteHTMLInner(&sb, jid.Jid(1), tag, "", inner); err != nil {
-				t.Fatal(err)
-			}
-			content := innerContent(t, sb.String(), tag)
-			decoded := html.UnescapeString(normalizeCR(content))
-			if got := strings.TrimPrefix(decoded, "\n"); got != value {
-				t.Errorf("%s value %q round-tripped to %q via source %q", tag, value, got, sb.String())
-			}
+	for _, value := range values {
+		inner := template.HTML(template.HTMLEscapeString(value)) // #nosec G203
+		var sb strings.Builder
+		if err := htmlio.WriteHTMLInner(&sb, jid.Jid(1), "textarea", "", inner); err != nil {
+			t.Fatal(err)
+		}
+		content := innerContent(t, sb.String(), "textarea")
+		rawValue := strings.TrimPrefix(html.UnescapeString(normalizeCR(content)), "\n")
+		apiValue := normalizeCR(rawValue) // textarea value normalization: CR/CRLF -> LF
+		if want := normalizeCR(value); apiValue != want {
+			t.Errorf("textarea value %q reported as %q, want %q (source %q)", value, apiValue, want, sb.String())
 		}
 	}
 }


### PR DESCRIPTION
Fixes #202

## Problem

`AppendAttrValue` delegates to `html.EscapeString`, which does **not** escape a carriage return, so a multiline attribute value read back from the DOM has its `\r` turned into `\n` (browser input-stream preprocessing rewrites raw `CR`/`CRLF` to `LF` before tokenization). Encoding the `CR` as `&#13;` makes `getAttribute` report it unchanged.

## Fix

`AppendAttrValue` now encodes each `\r` as the numeric character reference `&#13;` (via a small shared `appendEscapeCR` helper). The parser decodes it back to `CR` *after* preprocessing, so the value round-trips through `getAttribute`. `Attr`, `AppendAttr`, `WriteHTMLTag`, and `WriteHTMLInput` inherit the fix.

## Why `WriteHTMLInner` (textarea/pre) is *not* changed

The issue also asked to encode `CR` in `textarea`/`pre` inner content, but that turns out to be wrong for both:

- **textarea** — `HTMLTextAreaElement.value` normalizes every `CR` and `CRLF` to `LF` ([WHATWG textarea value normalization](https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element:concept-textarea-api-value)), and jaws.js sends `elem.value` back to the server ([jaws.js#L157](../blob/main/lib/assets/jaws.js#L157)). So a carriage return in textarea content can **never** round-trip through the value the browser reports, regardless of `&#13;` encoding — `<textarea>\n&#13;hello</textarea>` gives `textContent == "\rhello"` but `value == "\nhello"`.
- **pre** — `pre` permits phrasing content including `<script>` and comments, where character references are **not** decoded ([script-data / comment parsing](https://html.spec.whatwg.org/multipage/parsing.html#script-data-state)). Rewriting every `CR` would corrupt trusted markup, e.g. `//x\rdoThing()` would become the literal `//x&#13;doThing()`, commenting out `doThing()`.

So `WriteHTMLInner` writes `innerHTML` verbatim (unchanged behavior); the doc comment now explains the textarea/pre `CR` semantics and points callers who need `CR` retention to `AppendAttrValue`.

## Tests

- Exact-output assertions for the new `&#13;` attribute encoding (single `CR` and `CRLF`).
- `TestAppendAttrValue_DOMRoundTrip` — models `getAttribute` (input-stream preprocessing + character-reference decoding via stdlib `html.UnescapeString`) and confirms the logical value is recovered.
- `TestWriteHTMLInner_TextareaValueNormalization` — models `HTMLTextAreaElement.value` and pins the true contract: textarea content round-trips with `CR`/`CRLF` collapsed to `LF`.
- Newline-sensitive table now asserts `textarea`/`pre` content is written verbatim, including a `pre`+`<script>` regression case guarding against `CR` encoding inside nested markup.

Dependency surface stays stdlib-only. Package coverage remains 100% under `-race`; `go vet`, `gofumpt`, `staticcheck`, `golangci-lint`, and `gosec` are clean.