### PR TITLE
fix: expand aliased slice views with differing lengths in TagExpand

### DIFF
--- a/lib/tag/tag.go
+++ b/lib/tag/tag.go
@@ -85,11 +85,13 @@ func sameActiveNode(a, b any) bool {
 		return false
 	case reflect.Slice:
 		// Value.Pointer for a slice is the address of its first element, so two
-		// distinct views into the same backing array share it. Compare length too
-		// so aliased views of different lengths (e.g. s[:2] and s[:3]) are distinct
-		// nodes; a genuine self-referential slice re-enters with an identical
-		// pointer and length and is still detected as a cycle.
-		return va.Pointer() == vb.Pointer() && va.Len() == vb.Len()
+		// distinct views into the same backing array share it. A slice header is
+		// fully identified by its pointer, length and capacity, so compare all
+		// three: views differing in length or capacity are distinct nodes (a named
+		// slice TagGetter can observe its capacity via cap and yield different
+		// tags), while a genuine self-referential slice re-enters with an identical
+		// header and is still detected as a cycle.
+		return va.Pointer() == vb.Pointer() && va.Len() == vb.Len() && va.Cap() == vb.Cap()
 	case reflect.Pointer, reflect.Map, reflect.Chan, reflect.UnsafePointer:
 		return va.Pointer() == vb.Pointer()
 	default:

--- a/lib/tag/tag.go
+++ b/lib/tag/tag.go
@@ -83,12 +83,14 @@ func sameActiveNode(a, b any) bool {
 		// Value.Pointer identifies shared function code, not closure identity, so it
 		// cannot detect cycles. maxTagDepth still bounds recursive function getters.
 		return false
-	case reflect.Pointer, reflect.Slice, reflect.Map, reflect.Chan, reflect.UnsafePointer:
-		// For slices, Pointer() is the address of the first element, so two
-		// distinct slices aliasing the same backing array at the same start
-		// compare equal here. That can only over-detect a cycle and truncate
-		// expansion early, which maxTagCount/maxTagDepth already bound; real tag
-		// data does not take that shape.
+	case reflect.Slice:
+		// Value.Pointer for a slice is the address of its first element, so two
+		// distinct views into the same backing array share it. Compare length too
+		// so aliased views of different lengths (e.g. s[:2] and s[:3]) are distinct
+		// nodes; a genuine self-referential slice re-enters with an identical
+		// pointer and length and is still detected as a cycle.
+		return va.Pointer() == vb.Pointer() && va.Len() == vb.Len()
+	case reflect.Pointer, reflect.Map, reflect.Chan, reflect.UnsafePointer:
 		return va.Pointer() == vb.Pointer()
 	default:
 		return false

--- a/lib/tag/tag_test.go
+++ b/lib/tag/tag_test.go
@@ -60,6 +60,20 @@ func (tt *testMutualSliceTagger) JawsGetTag(Context) any {
 	return []any{tt.next}
 }
 
+// testCapTagger is a named slice type whose tag depends on its capacity: a view
+// with spare capacity yields Tag("outer") plus a capacity-trimmed view of
+// itself, which (having no spare capacity) yields Tag("inner"). The two views
+// share a first-element pointer and length but differ in capacity, so they must
+// be treated as distinct active nodes.
+type testCapTagger []int
+
+func (c testCapTagger) JawsGetTag(Context) any {
+	if cap(c) > len(c) {
+		return []any{Tag("outer"), c[:len(c):len(c)]}
+	}
+	return Tag("inner")
+}
+
 type testTagExpandNestedTagGetter struct {
 	Setter testNestedTagGetter
 	Vals   []int
@@ -395,6 +409,23 @@ func TestTagExpand_AliasedSliceViews(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("TagExpand() = %#v, want %#v", got, want)
 	}
+}
+
+// TestTagExpand_CapacityDependentSliceGetter guards against conflating two
+// aliased slice-typed TagGetters that share a first-element pointer and length
+// but differ in capacity. Identifying active nodes by pointer and length alone
+// would treat the capacity-trimmed inner view as a cycle back to the outer view
+// and, because a non-comparable slice getter cannot itself be a tag key, fail
+// with ErrNotUsableAsTag instead of invoking the inner getter.
+func TestTagExpand_CapacityDependentSliceGetter(t *testing.T) {
+	backing := make(testCapTagger, 2)
+	outer := backing[:1] // len 1, cap 2: yields Tag("outer") and a cap-1 inner view
+
+	got, err := TagExpand(nil, outer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertTagSetEqual(t, got, []any{Tag("outer"), Tag("inner")})
 }
 
 func TestTagExpand_TooManyTagsPanic(t *testing.T) {
@@ -751,7 +782,12 @@ func TestSameActiveNode_AliasedSliceViews(t *testing.T) {
 	if sameActiveNode(short, backing) {
 		t.Fatal("expected aliased slice views of different lengths not to match")
 	}
-	// Identical start pointer and length: the same node, so a genuine
+	// Same start pointer and length, different capacities: also distinct nodes,
+	// since a named slice getter can observe capacity and produce different tags.
+	if sameActiveNode(backing[:2], backing[:2:2]) {
+		t.Fatal("expected aliased slice views of different capacities not to match")
+	}
+	// Identical start pointer, length and capacity: the same node, so a genuine
 	// self-referential slice is still detected as a cycle.
 	if !sameActiveNode(backing, backing) {
 		t.Fatal("expected a slice to match itself")

--- a/lib/tag/tag_test.go
+++ b/lib/tag/tag_test.go
@@ -375,6 +375,28 @@ func TestTagExpand_SelfReferentialSliceStopsRecursing(t *testing.T) {
 	}
 }
 
+// TestTagExpand_AliasedSliceViews reproduces #203: two slices sharing a backing
+// array at the same start but with different lengths must not be conflated as a
+// cycle. Expanding the shorter view whose element references the longer backing
+// slice must still visit every tag reachable through the longer slice.
+func TestTagExpand_AliasedSliceViews(t *testing.T) {
+	all := make([]any, 3)
+	outer := all[:2]
+
+	all[0] = Tag("first")
+	all[1] = all
+	all[2] = Tag("last")
+
+	got, err := TagExpand(nil, outer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []any{Tag("first"), Tag("last")}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("TagExpand() = %#v, want %#v", got, want)
+	}
+}
+
 func TestTagExpand_TooManyTagsPanic(t *testing.T) {
 	tags := make([]any, 101)
 	for i := range tags {
@@ -719,6 +741,20 @@ func TestSameActiveNode_NilAndDefaultCases(t *testing.T) {
 	b := testNonComparableActiveNode{Values: []int{1}}
 	if sameActiveNode(a, b) {
 		t.Fatal("expected non-comparable structs to compare by identity, not contents")
+	}
+}
+
+func TestSameActiveNode_AliasedSliceViews(t *testing.T) {
+	backing := []any{Tag("a"), Tag("b"), Tag("c")}
+	short := backing[:2]
+	// Same start pointer, different lengths: distinct traversal nodes (#203).
+	if sameActiveNode(short, backing) {
+		t.Fatal("expected aliased slice views of different lengths not to match")
+	}
+	// Identical start pointer and length: the same node, so a genuine
+	// self-referential slice is still detected as a cycle.
+	if !sameActiveNode(backing, backing) {
+		t.Fatal("expected a slice to match itself")
 	}
 }
 


### PR DESCRIPTION
Fixes #203.

## Problem

`TagExpand`'s cycle detector (`sameActiveNode`) identified an active `[]any`
node by its first-element pointer alone. For a slice, `reflect.Value.Pointer()`
is the address of the first element, so two distinct slice headers viewing the
same backing array at the same start compared equal even with different lengths.

Expanding a short view whose element references the longer backing slice then
mistook the longer slice for a cycle back to the short view, skipped its
expansion, and silently dropped every later tag:

```go
all := make([]any, 3)
outer := all[:2]
all[0] = tag.Tag("first")
all[1] = all
all[2] = tag.Tag("last")
tag.TagExpand(nil, outer) // returned {"first"}; "last" dropped with no error
```

Downstream `Dirty`/broadcast/lookup on the dropped tag then silently miss those
Elements.

## Fix

Give `reflect.Slice` its own case in `sameActiveNode` that also compares length:

- Views of differing lengths iterate different elements, so they are distinct
  traversal nodes.
- A genuine self-referential slice re-enters with an identical pointer **and**
  length and is still detected as a cycle.

Capacity is intentionally not compared — two views with the same start and
length iterate identical elements, so they are correctly the same node. The
change only makes detection more precise (removes a false positive); even a
hypothetical missed cycle stays bounded by `maxTagDepth`/`maxTagCount`.

## Tests

- `TestTagExpand_AliasedSliceViews` — the issue's exact reproduction.
- `TestSameActiveNode_AliasedSliceViews` — direct helper coverage of the
  differing-length (distinct) and self (same-node) cases.

Both fail without the fix and pass with it. Existing cycle tests
(`TestTagExpand_SelfReferentialSliceStopsRecursing`, the TagGetter self/mutual
cycle tests) stay green.

Verified with `gofmt -l`, `go vet ./lib/tag/`, and `go test -race ./...`
(all packages green, no races).

## Known follow-up (out of scope)

`FindTagGetter` in `lib/tag/errnotusableastag.go` has an analogous
`seenPtr{t, ptr}` slice-aliasing collision, but it only powers a best-effort
error-message hint — over-detection there degrades a hint string, never drops
real tags. Left untouched to keep this change focused on the reported bug.