### PR TITLE
fix: close #216 — track and unregister Elements owned by ui.Template

### DIFF
--- a/.agents/skills/jaws/SKILL.md
+++ b/.agents/skills/jaws/SKILL.md
@@ -159,10 +159,15 @@ For clickable content rendering:
 - `ui.NewTemplate` returns a `*ui.Template`, which tracks the Elements its execution
   creates and therefore backs one live Element; construct a fresh one per render
   (`$.Template` already does). A successful update unregisters the Elements the
-  previous execution created through the `RequestWriter` widget helpers, since
-  `SetInner` replaces the DOM holding them. Elements created by `$.Register` and
-  `$.RadioGroup` are not tracked and stay registered for the Request's lifetime, so
-  prefer the widget helpers inside a template that updates.
+  previous execution created through `rw.NewUI` — the path every `RequestWriter`
+  widget helper except `$.Register` and `$.RadioGroup` takes — since `SetInner`
+  replaces the DOM holding them.
+- Those two helpers create Elements with `Request.NewElement`, so no template owns
+  them and their cleanup falls to the browser, which reports the ids it removed from
+  the DOM as the wrapper's new content is applied. An Element whose id never reaches
+  the DOM stays registered until the request ends (a discarded `$.Register` Jid, or an
+  execution that failed before delivering its markup), so prefer the `rw.NewUI`-backed
+  helpers inside a template that updates.
 - HTML getter paths must not mutate domain state, but they may call element update methods (`SetClass`, `RemoveClass`, `SetAttr`, `RemoveAttr`, etc.) on the passed-in `*Element` to co-ordinate wrapper class/attribute changes with the inner-HTML refresh. No custom `JawsUpdate` is needed for that case — the queued wrapper updates flush alongside the `SetInner` from `HTMLInner.JawsUpdate`.
 - Use a custom `JawsUpdate` only when the widget's update logic diverges from "render the getter again" — e.g. to compare against a stored last-value and skip the update (as the input widgets do).
 - `Element.SetAttr/RemoveAttr/SetClass/RemoveClass/SetInner/SetValue/Append/Order/Remove/Replace` are update-time operations; call them only from render/update processing.

--- a/.agents/skills/jaws/SKILL.md
+++ b/.agents/skills/jaws/SKILL.md
@@ -41,8 +41,12 @@ JaWS is an immediate-mode, server-driven UI framework, not an MVC framework.
   holds a `NaN` (so `v != v`) is rejected: the container widgets — the only place a raw
   `UI` value is used as a map key — cancel the `Request` in all builds (cause matches
   `tag.ErrNotUsableAsTag`), and `Request.NewElement` asserts runtime comparability in
-  debug builds. A typed nil (e.g. `(*Widget)(nil)`) is accepted as usable; its methods
-  must tolerate a nil receiver.
+  debug builds. A typed nil (e.g. `(*Widget)(nil)`) is comparable and equal to itself,
+  so it counts as usable and JaWS dispatches render/update/event calls to it; only a
+  nil `UI` interface is a no-op. Surviving such a call is up to the concrete type, not
+  a requirement: a widget that dereferences its fields panics, and none of the
+  standard `lib/ui` widgets document nil-receiver tolerance. Do not pass a nil pointer
+  of a type that does not; use its zero value (e.g. `&ui.Template{}`) instead.
 - Every JaWS `UI` value is request-scoped. Once used by one Request, never use
   that value with another Request; construct fresh widgets per request. The
   widgets may still refer to shared, synchronized application state, binders,
@@ -152,6 +156,13 @@ For clickable content rendering:
 
 - Keep HTML structure in templates; avoid manual HTML string assembly in Go.
 - `ui.Template.JawsUpdate` re-renders the template data into the generated wrapper.
+- `ui.NewTemplate` returns a `*ui.Template`, which tracks the Elements its execution
+  creates and therefore backs one live Element; construct a fresh one per render
+  (`$.Template` already does). A successful update unregisters the Elements the
+  previous execution created through the `RequestWriter` widget helpers, since
+  `SetInner` replaces the DOM holding them. Elements created by `$.Register` and
+  `$.RadioGroup` are not tracked and stay registered for the Request's lifetime, so
+  prefer the widget helpers inside a template that updates.
 - HTML getter paths must not mutate domain state, but they may call element update methods (`SetClass`, `RemoveClass`, `SetAttr`, `RemoveAttr`, etc.) on the passed-in `*Element` to co-ordinate wrapper class/attribute changes with the inner-HTML refresh. No custom `JawsUpdate` is needed for that case — the queued wrapper updates flush alongside the `SetInner` from `HTMLInner.JawsUpdate`.
 - Use a custom `JawsUpdate` only when the widget's update logic diverges from "render the getter again" — e.g. to compare against a stored last-value and skip the update (as the input widgets do).
 - `Element.SetAttr/RemoveAttr/SetClass/RemoveClass/SetInner/SetValue/Append/Order/Remove/Replace` are update-time operations; call them only from render/update processing.

--- a/contracts.go
+++ b/contracts.go
@@ -77,10 +77,19 @@ type TemplateLookuper interface {
 // value holding NaN), with a cause matching
 // [github.com/linkdata/jaws/lib/tag.ErrNotUsableAsTag] under errors.Is. That is the
 // only place a raw UI value is used as a map key; outside a container
-// [Request.NewElement] asserts runtime comparability in debug builds. A typed nil (a
-// non-nil interface holding a nil pointer) is usable, and tolerating a nil receiver
-// is the concrete type's responsibility. Callers must ensure UI values are genuinely
-// comparable and reflexive.
+// [Request.NewElement] asserts runtime comparability in debug builds. Callers must
+// ensure UI values are genuinely comparable and reflexive.
+//
+// A typed nil (a non-nil interface holding a nil pointer) meets those key
+// requirements, being comparable and equal to itself, so JaWS accepts one and
+// dispatches render, update and event calls to it like any other value; only a nil
+// UI interface is treated as a no-op. Surviving those calls with a nil receiver is a
+// property of the concrete type rather than a requirement of this contract: a type
+// may document that it tolerates one, and a type that does not will panic when
+// dereferencing its fields. Passing a nil pointer of such a type is therefore a
+// caller error, not a framework-handled case. The widgets in
+// [github.com/linkdata/jaws/lib/ui] are pointer types that dereference their fields,
+// and none of them document nil-receiver tolerance.
 type UI interface {
 	Renderer
 	Updater

--- a/contracts.go
+++ b/contracts.go
@@ -87,9 +87,9 @@ type TemplateLookuper interface {
 // property of the concrete type rather than a requirement of this contract: a type
 // may document that it tolerates one, and a type that does not will panic when
 // dereferencing its fields. Passing a nil pointer of such a type is therefore a
-// caller error, not a framework-handled case. The widgets in
-// [github.com/linkdata/jaws/lib/ui] are pointer types that dereference their fields,
-// and none of them document nil-receiver tolerance.
+// caller error, not a framework-handled case. The pointer-valued widgets in
+// [github.com/linkdata/jaws/lib/ui] dereference their fields, and no widget there
+// documents nil-receiver tolerance.
 type UI interface {
 	Renderer
 	Updater

--- a/element.go
+++ b/element.go
@@ -160,8 +160,9 @@ var debugCommentSanitizer = strings.NewReplacer("-->", "==>", "--!>", "==>")
 // Do not call this yourself unless it is from within another JawsRender implementation.
 //
 // A nil [UI] interface renders as a no-op; this arises only from [Request.NewElement]
-// given a nil interface. A typed nil (a non-nil interface holding a nil pointer) still
-// dispatches to its [Renderer], which is responsible for tolerating a nil receiver.
+// given a nil interface. A typed nil (a non-nil interface holding a nil pointer) is
+// still dispatched to its [Renderer], so the call panics unless that concrete type
+// documents nil-receiver tolerance; see [UI].
 func (elem *Element) JawsRender(w io.Writer, params []any) (err error) {
 	if ui := elem.UI(); ui != nil && !elem.deleted.Load() {
 		if err = ui.JawsRender(elem, w, params); err == nil {

--- a/errunusableui.go
+++ b/errunusableui.go
@@ -39,9 +39,10 @@ func (errUnusableUI) Is(target error) bool {
 // to render children: a non-comparable value panics when hashed and a NaN-bearing one
 // never matches itself, while a nil interface is a legal map key but has no methods to
 // render. A typed nil — a non-nil interface holding a nil pointer whose type
-// implements [UI] — is comparable and equal to itself, so it is reported usable;
-// whether its [Renderer] tolerates a nil receiver is the concrete type's
-// responsibility.
+// implements [UI] — is comparable and equal to itself, so it is reported usable.
+// Usable here means only that it can key a container and be dispatched to: whether
+// its [Renderer] survives a nil receiver depends on the concrete type, and most do
+// not (see [UI]).
 //
 // The returned error matches both [tag.ErrNotUsableAsTag] and [tag.ErrNotComparable]
 // under errors.Is. The container widgets use it to terminate a Request handed such a

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -26,17 +26,26 @@ such as `{{$.Span ...}}` register elements as the template runs, and custom
 template actions may queue updates or mutate application state. If execution
 later returns an error, JaWS returns or logs that error and preserves whatever
 already happened; it does not roll back partial output, queued messages, or
-application side effects. The elements the failed execution registered are
+application side effects. The tracked elements the failed execution registered are
 unregistered, since nothing will update them.
 
-A template owns the elements its nested UI helpers register, so a successful
-update unregisters the ones the previous render left behind along with the DOM
-that `SetInner` replaces. On updates that `SetInner` is queued only after a
-complete successful render, so a failed update leaves the browser DOM unchanged —
-and with it the previous render's elements — while earlier server-side side
-effects from that attempted render may remain. Treat template execution errors as
-application bugs: validate data before rendering and keep template actions
-infallible once they start emitting output or nested UI.
+A template owns the elements created through `rw.NewUI(...)`, which every
+`RequestWriter` widget helper — `{{$.Span ...}}`, `{{$.Button ...}}`, a nested
+`{{$.Template ...}}`, and so on — goes through. A successful update unregisters
+the ones the previous render left behind, along with the DOM that `SetInner`
+replaces. On updates that `SetInner` is queued only after a complete successful
+render, so a failed update leaves the browser DOM unchanged — and with it the
+previous render's elements — while earlier server-side side effects from that
+attempted render may remain. Treat template execution errors as application bugs:
+validate data before rendering and keep template actions infallible once they
+start emitting output or nested UI.
+
+`{{$.Register ...}}` and `{{$.RadioGroup ...}}` are the exceptions: they create
+elements through `Request.NewElement` directly rather than `rw.NewUI`, so a
+template does not own them. One created inside a template stays registered for the
+request's lifetime and re-rendering the template adds another, though the browser
+still reports the removal of any whose generated JaWS id reached the DOM. Prefer
+the widget helpers inside a template that updates.
 
 You can also use explicit constructors through:
 

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -29,23 +29,26 @@ already happened; it does not roll back partial output, queued messages, or
 application side effects. The tracked elements the failed execution registered are
 unregistered, since nothing will update them.
 
-A template owns the elements created through `rw.NewUI(...)`, which every
-`RequestWriter` widget helper — `{{$.Span ...}}`, `{{$.Button ...}}`, a nested
-`{{$.Template ...}}`, and so on — goes through. A successful update unregisters
-the ones the previous render left behind, along with the DOM that `SetInner`
-replaces. On updates that `SetInner` is queued only after a complete successful
-render, so a failed update leaves the browser DOM unchanged — and with it the
-previous render's elements — while earlier server-side side effects from that
-attempted render may remain. Treat template execution errors as application bugs:
-validate data before rendering and keep template actions infallible once they
+A template owns the elements created through `rw.NewUI(...)`, the path taken by
+every `RequestWriter` widget helper except the two below — `{{$.Span ...}}`,
+`{{$.Button ...}}`, a nested `{{$.Template ...}}`, and so on. A successful update
+unregisters the ones the previous render left behind, along with the DOM that
+`SetInner` replaces. On updates that `SetInner` is queued only after a complete
+successful render, so a failed update leaves the browser DOM unchanged — and with
+it the previous render's elements — while earlier server-side side effects from
+that attempted render may remain. Treat template execution errors as application
+bugs: validate data before rendering and keep template actions infallible once they
 start emitting output or nested UI.
 
 `{{$.Register ...}}` and `{{$.RadioGroup ...}}` are the exceptions: they create
-elements through `Request.NewElement` directly rather than `rw.NewUI`, so a
-template does not own them. One created inside a template stays registered for the
-request's lifetime and re-rendering the template adds another, though the browser
-still reports the removal of any whose generated JaWS id reached the DOM. Prefer
-the widget helpers inside a template that updates.
+elements through `Request.NewElement` directly rather than `rw.NewUI`, so the
+template neither owns nor unregisters them. Their cleanup falls to the browser,
+which reports the JaWS ids it removed from the DOM as the wrapper's new content is
+applied, and the request unregisters those elements. An element whose id never
+reaches the DOM has nothing to report it and stays registered until the request
+ends — one from an execution that failed before its markup was delivered, or a
+`$.Register` whose returned Jid the template discards. Prefer the `rw.NewUI`-backed
+helpers inside a template that updates.
 
 You can also use explicit constructors through:
 

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -25,13 +25,18 @@ Template execution is best-effort rather than transactional. Nested UI helpers
 such as `{{$.Span ...}}` register elements as the template runs, and custom
 template actions may queue updates or mutate application state. If execution
 later returns an error, JaWS returns or logs that error and preserves whatever
-already happened; it does not roll back partial output, nested elements, queued
-messages, or application side effects. On updates, the wrapper's `SetInner` is
-queued only after a complete successful render, so a failed update leaves the
-browser DOM unchanged while earlier server-side side effects from that attempted
-render may remain. Treat template execution errors as application bugs: validate
-data before rendering and keep template actions infallible once they start
-emitting output or nested UI.
+already happened; it does not roll back partial output, queued messages, or
+application side effects. The elements the failed execution registered are
+unregistered, since nothing will update them.
+
+A template owns the elements its nested UI helpers register, so a successful
+update unregisters the ones the previous render left behind along with the DOM
+that `SetInner` replaces. On updates that `SetInner` is queued only after a
+complete successful render, so a failed update leaves the browser DOM unchanged —
+and with it the previous render's elements — while earlier server-side side
+effects from that attempted render may remain. Treat template execution errors as
+application bugs: validate data before rendering and keep template actions
+infallible once they start emitting output or nested UI.
 
 You can also use explicit constructors through:
 

--- a/lib/ui/containerhelper.go
+++ b/lib/ui/containerhelper.go
@@ -100,9 +100,7 @@ func (u *ContainerHelper) RenderContainer(elem *jaws.Element, w io.Writer, outer
 				u.contents = contents
 				u.mu.Unlock()
 			} else {
-				for _, childElem := range contents {
-					elem.Request.DeleteElement(childElem)
-				}
+				deleteOwnedElements(elem.Request, contents)
 			}
 		}
 	}
@@ -117,15 +115,25 @@ func (u *ContainerHelper) UpdateContainer(elem *jaws.Element) {
 	wantContents := u.Container.JawsContains(elem)
 	toAppend, toRemove, oldOrder, newOrder := u.reconcile(elem, wantContents)
 
-	// Remove leftover Elements from both the browser DOM and the Request registry.
+	// Remove leftover Elements from both the browser DOM and the Request registry,
+	// then unregister what they owned in one pass. Element.Remove can reject the
+	// operation (leaving the DOM untouched), so a child's descendants are collected
+	// only once its removal actually happened.
+	var owned []*jaws.Element
 	for _, childElem := range toRemove {
 		elem.Remove(childElem)
+		if childElem.Deleted() {
+			owned = appendOwnedBy(owned, childElem)
+		}
 	}
+	elem.Request.DeleteElements(owned)
 
 	for _, childElem := range toAppend {
 		var sb strings.Builder
 		if err := childElem.JawsRender(&sb, nil); err != nil {
-			elem.Request.DeleteElement(childElem)
+			// Unregister the child and its nested UI before MustLog, which panics when
+			// no logger is configured; deferring it would strand the subtree.
+			deleteOwnedElements(elem.Request, []*jaws.Element{childElem})
 			u.deleteContent(childElem)
 			newOrder = slices.DeleteFunc(newOrder, func(id jaws.Jid) bool { return id == childElem.Jid() })
 			elem.Jaws.MustLog(err)
@@ -137,6 +145,17 @@ func (u *ContainerHelper) UpdateContainer(elem *jaws.Element) {
 	if !slices.Equal(oldOrder, newOrder) {
 		elem.Order(newOrder)
 	}
+}
+
+// takeOwnedElements returns the child Elements and clears the reconciliation state,
+// transferring responsibility for unregistering them to the caller. It implements
+// elementOwner, so a container whose own Element leaves the DOM as part of a larger
+// subtree takes its children with it.
+func (u *ContainerHelper) takeOwnedElements() (owned []*jaws.Element) {
+	u.mu.Lock()
+	owned, u.contents = u.contents, nil
+	u.mu.Unlock()
+	return
 }
 
 func (u *ContainerHelper) deleteContent(elem *jaws.Element) {

--- a/lib/ui/doc.go
+++ b/lib/ui/doc.go
@@ -18,14 +18,14 @@
 // synchronized as required.
 //
 // Within one request, a widget normally backs at most one live [jaws.Element].
-// The HTML-inner widgets, [Img], [Option] and [Template] document support for
-// backing multiple live Elements because they retain no Element-specific state;
-// their shared getters, handlers and template data must also be safe for those
-// calls. Input widgets, [ContainerHelper]-based widgets and [JsVar] require a
-// distinct widget value for each live Element. [Register] supports multiple live
-// Elements only when its Updater does. Distinct widgets may still share
-// synchronized application state. This is the canonical package-wide
-// classification; each concrete type's documentation states its conditions.
+// The HTML-inner widgets, [Img] and [Option] document support for backing
+// multiple live Elements because they retain no Element-specific state; their
+// shared getters and handlers must also be safe for those calls. Input widgets,
+// [ContainerHelper]-based widgets, [JsVar] and [Template] require a distinct
+// widget value for each live Element. [Register] supports multiple live Elements
+// only when its Updater does. Distinct widgets may still share synchronized
+// application state. This is the canonical package-wide classification; each
+// concrete type's documentation states its conditions.
 //
 // HTML-inner widgets route content through [bind.MakeHTMLGetter]. Plain strings
 // are treated as trusted HTML, while [bind.Getter][string], [bind.Binder][string]

--- a/lib/ui/doc.go
+++ b/lib/ui/doc.go
@@ -17,6 +17,13 @@
 // application state, binders, handlers or tags when that shared state is
 // synchronized as required.
 //
+// Most constructors return a pointer ([Option] and [Register] are the value-typed
+// exceptions), and the widgets dereference their fields without checking the
+// receiver. JaWS core accepts a typed nil and dispatches to it like any other
+// [jaws.UI] value (see [jaws.UI]), so rendering or updating one panics here: no
+// widget in this package documents nil-receiver tolerance. The zero value of a
+// widget, such as &[Template]{}, is the supported empty form.
+//
 // Within one request, a widget normally backs at most one live [jaws.Element].
 // The HTML-inner widgets, [Img] and [Option] document support for backing
 // multiple live Elements because they retain no Element-specific state; their

--- a/lib/ui/handler.go
+++ b/lib/ui/handler.go
@@ -16,7 +16,11 @@ import (
 // with Handler.
 type uiHandler struct {
 	*jaws.Jaws
-	Template pageTemplate
+	// name and dot are the page template's parameters rather than a prepared
+	// pageTemplate: a pageTemplate tracks the Elements of one render, so ServeHTTP
+	// constructs a fresh one per request instead of copying a shared value.
+	name string
+	dot  any
 }
 
 // pageTemplate wraps a [Template] used as a whole-page document template.
@@ -30,7 +34,7 @@ var _ jaws.UI = (*pageTemplate)(nil)
 // JawsUpdate is a no-op because a page-level template is render-only: the
 // embedded [Template.JawsUpdate] would re-render the entire document into itself
 // when OuterHTMLTag is set, so it is deliberately silenced here.
-func (pageTemplate) JawsUpdate(*jaws.Element) {}
+func (*pageTemplate) JawsUpdate(*jaws.Element) {}
 
 // JawsRender renders the whole-page template, looking it up and executing it
 // directly.
@@ -41,10 +45,14 @@ func (pageTemplate) JawsUpdate(*jaws.Element) {}
 // element cannot re-render itself, deriving tag identity from the page dot would
 // serve no purpose; nested UI created during execution registers its own tags
 // independently.
-func (pt pageTemplate) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err error) {
+func (pt *pageTemplate) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err error) {
 	var lookedUp *template.Template
 	if lookedUp, err = pt.lookup(elem); err == nil {
-		err = pt.execute(elem, w, lookedUp)
+		if err = pt.execute(elem, w, lookedUp); err != nil {
+			// The page Element is unregistered by RequestWriter.NewUI; the nested UI
+			// this failed execution created is ours to drop.
+			deleteOwnedElements(elem.Request, pt.takeOwnedElements())
+		}
 	}
 	return
 }
@@ -71,13 +79,14 @@ func (h uiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	rq := h.NewRequest(r)
 	sr := &statusRecorder{ResponseWriter: w}
 	rw := RequestWriter{Request: rq, Writer: sr}
-	// Render through a fresh per-request pointer so the UI is comparable as a map
-	// key regardless of the page dot: ordinary html/template data such as a slice
-	// or map is not usable as a tag and would fail the runtime comparability check
-	// in Request.NewElement if a bare pageTemplate value (whose Dot is any) were
-	// used. The pointer identity is always comparable and fresh per request.
-	pt := h.Template
-	if err := rw.NewUI(&pt); err != nil {
+	// Build a fresh per-request pointer so the UI is comparable as a map key
+	// regardless of the page dot: ordinary html/template data such as a slice or map
+	// is not usable as a tag and would fail the runtime comparability check in
+	// Request.NewElement if a bare pageTemplate value (whose Dot is any) were used.
+	// The pointer identity is always comparable and fresh per request, and each
+	// request gets its own Element-tracking state.
+	pt := &pageTemplate{Template: Template{Name: h.name, Dot: h.dot}}
+	if err := rw.NewUI(pt); err != nil {
 		_ = h.Log(err)
 		// A failure before any output (for example a missing template) can still
 		// become a proper error response; once bytes have been written the status
@@ -96,5 +105,5 @@ func (h uiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // lookupers and rendered with a [With] value as the template data, exposing
 // dot through its Dot field.
 func Handler(jw *jaws.Jaws, name string, dot any) http.Handler {
-	return uiHandler{Jaws: jw, Template: pageTemplate{Template: Template{Name: name, Dot: dot}}}
+	return uiHandler{Jaws: jw, name: name, dot: dot}
 }

--- a/lib/ui/owned.go
+++ b/lib/ui/owned.go
@@ -1,0 +1,53 @@
+package ui
+
+import "github.com/linkdata/jaws"
+
+// elementOwner is implemented by widgets in this package that create and track
+// [jaws.Element] values of their own, so a subtree that has left the browser DOM can
+// be unregistered recursively.
+//
+// Ownership is one level deep per widget: a nested widget tracks the Elements it
+// creates itself, and the walk below reaches them through it.
+type elementOwner interface {
+	// takeOwnedElements returns the tracked Elements and clears the tracking state,
+	// so the caller becomes responsible for unregistering them.
+	takeOwnedElements() []*jaws.Element
+}
+
+// appendOwnedElements appends elems and, recursively, the Elements they own to dst.
+//
+// Taking each owner's set as the walk proceeds detaches the subtree and makes the
+// recursion self-limiting, so an unexpected ownership cycle terminates instead of
+// recursing forever. It must not be called with a widget lock held: it locks each
+// visited owner in turn.
+func appendOwnedElements(dst []*jaws.Element, elems []*jaws.Element) []*jaws.Element {
+	for _, elem := range elems {
+		dst = append(dst, elem)
+		dst = appendOwnedBy(dst, elem)
+	}
+	return dst
+}
+
+// appendOwnedBy appends the Elements owned by elem, recursively, to dst. It does not
+// append elem itself, so a caller that unregisters elem separately (through
+// [jaws.Element.Remove], say) can still collect its descendants.
+func appendOwnedBy(dst []*jaws.Element, elem *jaws.Element) []*jaws.Element {
+	if owner, ok := elem.UI().(elementOwner); ok {
+		dst = appendOwnedElements(dst, owner.takeOwnedElements())
+	}
+	return dst
+}
+
+// deleteOwnedElements unregisters elems and, recursively, the Elements they own,
+// using a single pass over the [jaws.Request] registry.
+//
+// It queues no browser operations, so callers use it when the DOM holding elems is
+// already gone (replaced by [jaws.Element.SetInner], or removed) or was never
+// delivered to the browser at all.
+func deleteOwnedElements(rq *jaws.Request, elems []*jaws.Element) {
+	if len(elems) > 0 {
+		// Sized for the common case of elems owning nothing further, so a wide
+		// generation does not regrow the slice on the way out.
+		rq.DeleteElements(appendOwnedElements(make([]*jaws.Element, 0, len(elems)), elems))
+	}
+}

--- a/lib/ui/radiogroup.go
+++ b/lib/ui/radiogroup.go
@@ -98,10 +98,12 @@ func (re RadioElement) Label(params ...any) template.HTML {
 // radio Element's request-scoped [jaws.Jid].
 //
 // The radio and label Elements are created through [jaws.Request.NewElement] rather
-// than [RequestWriter.NewUI], so a surrounding [Template] does not own them: a group
-// rendered from inside a template body outlives the template content it belongs to,
-// and every re-render of that template adds another set. The browser still reports
-// the removal of the input and label elements it had in the DOM.
+// than [RequestWriter.NewUI], so a surrounding [Template] neither owns nor unregisters
+// them when the template re-renders. Cleanup falls to the browser, which reports the
+// JaWS ids it removed from the DOM as the surrounding wrapper's new content is applied;
+// a rendered radio or label carries its own id, so it is reported. One that never
+// reached the DOM stays registered until the [jaws.Request] ends, including the
+// unrendered radio Element a [RadioElement.Label] without its Radio leaves behind.
 func (rw RequestWriter) RadioGroup(nba *named.BoolArray) (rel []RadioElement) {
 	group := &radioGroupState{}
 	nba.ReadLocked(func(nbl []*named.Bool) {

--- a/lib/ui/radiogroup.go
+++ b/lib/ui/radiogroup.go
@@ -96,6 +96,12 @@ func (re RadioElement) Label(params ...any) template.HTML {
 // Elements are created lazily as they are rendered; see [RadioElement]. Every
 // rendered radio in the group shares a name derived from the first created
 // radio Element's request-scoped [jaws.Jid].
+//
+// The radio and label Elements are created through [jaws.Request.NewElement] rather
+// than [RequestWriter.NewUI], so a surrounding [Template] does not own them: a group
+// rendered from inside a template body outlives the template content it belongs to,
+// and every re-render of that template adds another set. The browser still reports
+// the removal of the input and label elements it had in the DOM.
 func (rw RequestWriter) RadioGroup(nba *named.BoolArray) (rel []RadioElement) {
 	group := &radioGroupState{}
 	nba.ReadLocked(func(nbl []*named.Bool) {

--- a/lib/ui/register.go
+++ b/lib/ui/register.go
@@ -33,6 +33,13 @@ func (u Register) JawsRender(elem *jaws.Element, w io.Writer, params []any) erro
 // The updater's [jaws.Updater.JawsUpdate] method will be called immediately to
 // ensure the initial rendering is correct.
 //
+// Register creates its Element through [jaws.Request.NewElement] rather than
+// [RequestWriter.NewUI], so a surrounding [Template] does not own it: an Element
+// registered from inside a template body outlives the template content it belongs to,
+// and every re-render of that template adds another. The browser still reports the
+// removal of one whose returned [jid.Jid] reached the DOM as an id. Use a widget
+// helper, or register outside the updating template, when that matters.
+//
 // Register does not call [jaws.Renderer.JawsRender]. The updater must therefore
 // be ready for JawsUpdate and event handling without render-time initialization.
 // In particular, the standard input widgets and [Select] initialize their dirty

--- a/lib/ui/register.go
+++ b/lib/ui/register.go
@@ -34,11 +34,12 @@ func (u Register) JawsRender(elem *jaws.Element, w io.Writer, params []any) erro
 // ensure the initial rendering is correct.
 //
 // Register creates its Element through [jaws.Request.NewElement] rather than
-// [RequestWriter.NewUI], so a surrounding [Template] does not own it: an Element
-// registered from inside a template body outlives the template content it belongs to,
-// and every re-render of that template adds another. The browser still reports the
-// removal of one whose returned [jid.Jid] reached the DOM as an id. Use a widget
-// helper, or register outside the updating template, when that matters.
+// [RequestWriter.NewUI], so a surrounding [Template] neither owns nor unregisters it
+// when the template re-renders. Cleanup falls to the browser, which reports the JaWS
+// ids it removed from the DOM as the surrounding wrapper's new content is applied. Use
+// the returned [jid.Jid] as an element id for that to work: an Element whose id never
+// reaches the DOM stays registered until the [jaws.Request] ends, and every re-render
+// of the template adds another.
 //
 // Register does not call [jaws.Renderer.JawsRender]. The updater must therefore
 // be ready for JawsUpdate and event handling without render-time initialization.

--- a/lib/ui/requestwriter.go
+++ b/lib/ui/requestwriter.go
@@ -11,6 +11,15 @@ import (
 type RequestWriter struct {
 	*jaws.Request
 	io.Writer
+	// elementRendered, when non-nil, is called by NewUI with each Element it
+	// successfully rendered, letting the widget that owns this writer track the
+	// Elements created through it. A returned error fails the NewUI call.
+	//
+	// It is deliberately unexported: RequestWriter is embedded in [With], so an
+	// exported func field would be callable from any template as
+	// {{call $.ElementRendered $.Element}}, letting a template make an Element own
+	// itself and have its own wrapper unregistered on the next update.
+	elementRendered func(elem *jaws.Element) (err error)
 }
 
 // NewUI creates an element for ui and renders it to the underlying writer.
@@ -19,8 +28,15 @@ type RequestWriter struct {
 // requirements documented by [jaws.UI].
 func (rw RequestWriter) NewUI(ui jaws.UI, params ...any) (err error) {
 	elem := rw.NewElement(ui)
-	if err = elem.JawsRender(rw, params); err != nil {
-		rw.DeleteElement(elem)
+	if err = elem.JawsRender(rw, params); err == nil {
+		if rw.elementRendered != nil {
+			err = rw.elementRendered(elem)
+		}
+	}
+	if err != nil {
+		// Unregister anything the failed Element already owns along with it, so no
+		// widget can strand a subtree by not rolling back itself.
+		deleteOwnedElements(rw.Request, []*jaws.Element{elem})
 	}
 	return
 }

--- a/lib/ui/template.go
+++ b/lib/ui/template.go
@@ -60,10 +60,10 @@ var (
 )
 
 // The methods below dereference tmpl without a nil check, like the other
-// pointer-based widgets in this package (*Span, *Container, *JsVar). Core accepts a
-// typed nil UI and dispatches to it, but tolerating a nil receiver is each widget
-// type's own choice, and this one does not: a zero &Template{} is the supported
-// empty value and reports ErrMissingTemplate.
+// pointer-based widgets in this package (*Span, *Container, *JsVar): jaws.UI accepts
+// a typed nil and dispatches to it, but leaves surviving a nil receiver to the
+// concrete type, and this package documents that none of its widgets do (see doc.go).
+// A zero &Template{} is the supported empty value and reports ErrMissingTemplate.
 
 // String returns a debug representation of t.
 func (tmpl *Template) String() string {

--- a/lib/ui/template.go
+++ b/lib/ui/template.go
@@ -5,6 +5,7 @@ import (
 	"html/template"
 	"io"
 	"strings"
+	"sync"
 
 	"github.com/linkdata/jaws"
 	"github.com/linkdata/jaws/lib/tag"
@@ -12,10 +13,11 @@ import (
 
 // Template references a Go [html/template] template to be rendered through JaWS.
 //
-// A Template retains no Element-specific state and may back multiple live
-// [jaws.Element] values. Its Dot and any callbacks reached during execution are
-// shared by those Elements and must be safe for their render, update and event
-// calls.
+// A Template tracks the [jaws.Element] values created while its template executes,
+// so it must back at most one live Element. Construct a distinct Template for each
+// place the template is rendered; [RequestWriter.Template] does so for every call.
+// Its Dot and any callbacks reached during execution are shared with anything else
+// referencing them and must be safe for those calls.
 //
 // The OuterHTMLTag field identifies the generated wrapper element used for
 // partial templates. If OuterHTMLTag is empty, the template is rendered without
@@ -26,31 +28,76 @@ import (
 // helper. The referenced template must be a partial template, not a full HTML
 // document.
 //
+// Nested JaWS UI rendered by the template belongs to the Template that rendered
+// it: when [Template.JawsUpdate] replaces the wrapper's content, the Elements from
+// the previous execution are unregistered along with the DOM that held them, and a
+// nested widget's own Elements go with it.
+//
 // Template execution is best-effort rather than transactional. Template actions
 // and nested JaWS helpers run as the template executes, so an execution error
-// after partial output can leave already-written HTML, registered nested
-// elements, queued messages, domain mutations or other side effects in place.
-// Treat such errors as application bugs: validate data before rendering and keep
-// template actions infallible once they start emitting output or nested UI.
+// after partial output can leave already-written HTML, queued messages, domain
+// mutations or other side effects in place. The nested Elements created by the
+// failed execution are unregistered. Treat such errors as application bugs:
+// validate data before rendering and keep template actions infallible once they
+// start emitting output or nested UI.
 type Template struct {
 	OuterHTMLTag string // Optional wrapper tag for partial templates, for example "div" or "tr"; empty renders unwrapped.
 	Name         string // Template name to be looked up using Jaws.LookupTemplate.
 	Dot          any    // Dot value to place in With.
+	// mu serializes the owned operations, which run on the rendering goroutine and
+	// on the request loop goroutine during updates (mirrors ContainerHelper).
+	mu sync.Mutex
+	// owned are the Elements created while the template executed, in creation
+	// order. It tracks one live Element's nested UI.
+	owned []*jaws.Element
 }
 
 var (
-	_ jaws.UI                 = Template{} // statically ensure interface is defined
-	_ jaws.ClickHandler       = Template{} // statically ensure interface is defined
-	_ jaws.ContextMenuHandler = Template{} // statically ensure interface is defined
-	_ jaws.InputHandler       = Template{} // statically ensure interface is defined
+	_ jaws.UI                 = (*Template)(nil) // statically ensure interface is defined
+	_ jaws.ClickHandler       = (*Template)(nil) // statically ensure interface is defined
+	_ jaws.ContextMenuHandler = (*Template)(nil) // statically ensure interface is defined
+	_ jaws.InputHandler       = (*Template)(nil) // statically ensure interface is defined
 )
 
+// The methods below dereference tmpl without a nil check, like the other
+// pointer-based widgets in this package (*Span, *Container, *JsVar). Core accepts a
+// typed nil UI and dispatches to it, but tolerating a nil receiver is each widget
+// type's own choice, and this one does not: a zero &Template{} is the supported
+// empty value and reports ErrMissingTemplate.
+
 // String returns a debug representation of t.
-func (tmpl Template) String() string {
+func (tmpl *Template) String() string {
 	return fmt.Sprintf("{%q, %q, %s}", tmpl.OuterHTMLTag, tmpl.Name, tag.TagString(tmpl.Dot))
 }
 
-func (tmpl Template) lookup(elem *jaws.Element) (lookedUp *template.Template, err error) {
+// ownElement records child as created while tmpl's template executed. It is the
+// [RequestWriter] element-rendered hook installed by execute.
+func (tmpl *Template) ownElement(child *jaws.Element) (err error) {
+	tmpl.mu.Lock()
+	tmpl.owned = append(tmpl.owned, child)
+	tmpl.mu.Unlock()
+	return
+}
+
+// takeOwnedElements returns the Elements created by the most recent execution and
+// clears the tracking state, transferring responsibility for unregistering them to
+// the caller. It implements elementOwner.
+func (tmpl *Template) takeOwnedElements() (owned []*jaws.Element) {
+	tmpl.mu.Lock()
+	owned, tmpl.owned = tmpl.owned, nil
+	tmpl.mu.Unlock()
+	return
+}
+
+// restoreOwnedElements makes owned the tracked set again, for an update whose
+// output was discarded and whose previous Elements still match the browser DOM.
+func (tmpl *Template) restoreOwnedElements(owned []*jaws.Element) {
+	tmpl.mu.Lock()
+	tmpl.owned = owned
+	tmpl.mu.Unlock()
+}
+
+func (tmpl *Template) lookup(elem *jaws.Element) (lookedUp *template.Template, err error) {
 	err = errMissingTemplate(tmpl.Name)
 	if lookedUp = elem.Request.Jaws.LookupTemplate(tmpl.Name); lookedUp != nil {
 		err = nil
@@ -58,7 +105,7 @@ func (tmpl Template) lookup(elem *jaws.Element) (lookedUp *template.Template, er
 	return
 }
 
-func (tmpl Template) auth(elem *jaws.Element) (auth jaws.Auth) {
+func (tmpl *Template) auth(elem *jaws.Element) (auth jaws.Auth) {
 	if f := elem.Request.Jaws.MakeAuth; f != nil {
 		auth = f(elem.Request)
 	} else {
@@ -69,10 +116,18 @@ func (tmpl Template) auth(elem *jaws.Element) (auth jaws.Auth) {
 	return
 }
 
-func (tmpl Template) execute(elem *jaws.Element, w io.Writer, lookedUp *template.Template) (err error) {
+func (tmpl *Template) execute(elem *jaws.Element, w io.Writer, lookedUp *template.Template) (err error) {
+	// The hook makes tmpl own the Elements the template creates through this writer.
+	// A nested RequestWriter.Template builds its own writer in its own execute, so
+	// each level owns only its direct children and deeper ones are reached through
+	// them; see appendOwnedElements.
+	//
+	// Tracking assumes html/template's synchronous execution on this goroutine. A
+	// template action that renders from another goroutine is already unsupported: it
+	// races on the shared io.Writer, and on the render as a whole.
 	err = lookedUp.Execute(w, With{
 		Element:       elem,
-		RequestWriter: RequestWriter{Request: elem.Request, Writer: w},
+		RequestWriter: RequestWriter{Request: elem.Request, Writer: w, elementRendered: tmpl.ownElement},
 		Dot:           tmpl.Dot,
 		Auth:          tmpl.auth(elem),
 	})
@@ -92,7 +147,7 @@ func writeTemplateWrapperStart(elem *jaws.Element, w io.Writer, outerHTMLTag str
 	return
 }
 
-func (tmpl Template) render(elem *jaws.Element, w io.Writer, params []any) (err error) {
+func (tmpl *Template) render(elem *jaws.Element, w io.Writer, params []any) (err error) {
 	doWrap := tmpl.OuterHTMLTag != ""
 	var expandedTags []any
 	if expandedTags, err = tag.TagExpand(elem.Request, tmpl.Dot); err == nil {
@@ -116,6 +171,12 @@ func (tmpl Template) render(elem *jaws.Element, w io.Writer, params []any) (err 
 						err = werr
 					}
 				}
+				if err != nil {
+					// The Element itself is unregistered by whoever created it
+					// (RequestWriter.NewUI, or a container). Its nested UI is ours to
+					// drop, since it will never be updated.
+					deleteOwnedElements(elem.Request, tmpl.takeOwnedElements())
+				}
 			}
 		}
 	}
@@ -125,7 +186,7 @@ func (tmpl Template) render(elem *jaws.Element, w io.Writer, params []any) (err 
 // JawsRender renders t through the request's configured template lookupers,
 // streaming output directly to w. Template execution has the best-effort error
 // behavior described on [Template].
-func (tmpl Template) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err error) {
+func (tmpl *Template) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err error) {
 	err = tmpl.render(elem, w, params)
 	return
 }
@@ -137,15 +198,27 @@ func (tmpl Template) JawsRender(elem *jaws.Element, w io.Writer, params []any) (
 // elements. The wrapper's SetInner is queued only after execution succeeds (see the
 // best-effort error behavior on [Template]).
 //
+// A successful update unregisters the Elements from the previous execution, along
+// with any they own: SetInner replaces the DOM that held them. If execution fails
+// nothing is queued, so the Elements it created are unregistered instead and the
+// previous ones stay live to match the unchanged DOM.
+//
 // Lookup or execution errors are reported through [jaws.Request.MustLog], which may
 // panic when no [jaws.Jaws.Logger] is configured.
-func (tmpl Template) JawsUpdate(elem *jaws.Element) {
+func (tmpl *Template) JawsUpdate(elem *jaws.Element) {
 	if tmpl.OuterHTMLTag != "" {
 		lookedUp, err := tmpl.lookup(elem)
 		if err == nil {
+			// Detach before executing so the new Elements accumulate on their own; a
+			// lookup failure returns above with the set untouched.
+			previous := tmpl.takeOwnedElements()
 			var sb strings.Builder
 			if err = tmpl.execute(elem, &sb, lookedUp); err == nil {
 				elem.SetInner(template.HTML(sb.String())) // #nosec G203
+				deleteOwnedElements(elem.Request, previous)
+			} else {
+				deleteOwnedElements(elem.Request, tmpl.takeOwnedElements())
+				tmpl.restoreOwnedElements(previous)
 			}
 		}
 		elem.Request.MustLog(err)
@@ -153,7 +226,7 @@ func (tmpl Template) JawsUpdate(elem *jaws.Element) {
 }
 
 // JawsClick delegates click events to t.Dot when it implements [jaws.ClickHandler].
-func (tmpl Template) JawsClick(elem *jaws.Element, click jaws.Click) (err error) {
+func (tmpl *Template) JawsClick(elem *jaws.Element, click jaws.Click) (err error) {
 	err = jaws.ErrEventUnhandled
 	if h, ok := tmpl.Dot.(jaws.ClickHandler); ok {
 		err = h.JawsClick(elem, click)
@@ -163,7 +236,7 @@ func (tmpl Template) JawsClick(elem *jaws.Element, click jaws.Click) (err error)
 
 // JawsContextMenu delegates context-menu events to t.Dot when it implements
 // [jaws.ContextMenuHandler].
-func (tmpl Template) JawsContextMenu(elem *jaws.Element, click jaws.Click) (err error) {
+func (tmpl *Template) JawsContextMenu(elem *jaws.Element, click jaws.Click) (err error) {
 	err = jaws.ErrEventUnhandled
 	if h, ok := tmpl.Dot.(jaws.ContextMenuHandler); ok {
 		err = h.JawsContextMenu(elem, click)
@@ -172,7 +245,7 @@ func (tmpl Template) JawsContextMenu(elem *jaws.Element, click jaws.Click) (err 
 }
 
 // JawsInput delegates input events to t.Dot when it implements [jaws.InputHandler].
-func (tmpl Template) JawsInput(elem *jaws.Element, value string) (err error) {
+func (tmpl *Template) JawsInput(elem *jaws.Element, value string) (err error) {
 	err = jaws.ErrEventUnhandled
 	if h, ok := tmpl.Dot.(jaws.InputHandler); ok {
 		err = h.JawsInput(elem, value)
@@ -188,8 +261,11 @@ func (tmpl Template) JawsInput(elem *jaws.Element, value string) (err error) {
 // wrapper to update) if empty. The name is resolved at render or update time via
 // [jaws.Jaws.LookupTemplate]. See [Template] for the field semantics, event
 // delegation and best-effort error behavior.
-func NewTemplate(outerHTMLTag, name string, dot any) Template {
-	return Template{OuterHTMLTag: outerHTMLTag, Name: name, Dot: dot}
+//
+// The returned Template is request-scoped and tracks the Elements one live
+// [jaws.Element] renders; call NewTemplate again for each place it is rendered.
+func NewTemplate(outerHTMLTag, name string, dot any) *Template {
+	return &Template{OuterHTMLTag: outerHTMLTag, Name: name, Dot: dot}
 }
 
 // Template renders the named partial template with dot exposed as [With.Dot],

--- a/lib/ui/template.go
+++ b/lib/ui/template.go
@@ -28,15 +28,22 @@ import (
 // helper. The referenced template must be a partial template, not a full HTML
 // document.
 //
-// Nested JaWS UI rendered by the template belongs to the Template that rendered
-// it: when [Template.JawsUpdate] replaces the wrapper's content, the Elements from
-// the previous execution are unregistered along with the DOM that held them, and a
-// nested widget's own Elements go with it.
+// The Elements a template creates through [RequestWriter.NewUI], which every
+// RequestWriter widget helper (including a nested [RequestWriter.Template]) goes
+// through, belong to the Template that rendered them: when [Template.JawsUpdate]
+// replaces the wrapper's content, those Elements are unregistered along with the DOM
+// that held them, and a nested widget's own Elements go with it.
+//
+// [RequestWriter.Register] and [RequestWriter.RadioGroup] create their Elements
+// through [jaws.Request.NewElement] instead, so they are not tracked: an Element
+// either helper creates inside a template stays registered for the [jaws.Request]
+// lifetime, and re-rendering the template adds another. Their generated JaWS ids do
+// let the browser report the removal of any that reached the DOM.
 //
 // Template execution is best-effort rather than transactional. Template actions
 // and nested JaWS helpers run as the template executes, so an execution error
 // after partial output can leave already-written HTML, queued messages, domain
-// mutations or other side effects in place. The nested Elements created by the
+// mutations or other side effects in place. The tracked Elements created by the
 // failed execution are unregistered. Treat such errors as application bugs:
 // validate data before rendering and keep template actions infallible once they
 // start emitting output or nested UI.
@@ -198,10 +205,11 @@ func (tmpl *Template) JawsRender(elem *jaws.Element, w io.Writer, params []any) 
 // elements. The wrapper's SetInner is queued only after execution succeeds (see the
 // best-effort error behavior on [Template]).
 //
-// A successful update unregisters the Elements from the previous execution, along
-// with any they own: SetInner replaces the DOM that held them. If execution fails
-// nothing is queued, so the Elements it created are unregistered instead and the
-// previous ones stay live to match the unchanged DOM.
+// A successful update unregisters the tracked Elements from the previous execution,
+// along with any they own: SetInner replaces the DOM that held them. If execution
+// fails nothing is queued, so the tracked Elements it created are unregistered
+// instead and the previous ones stay live to match the unchanged DOM. See [Template]
+// for which Elements are tracked.
 //
 // Lookup or execution errors are reported through [jaws.Request.MustLog], which may
 // panic when no [jaws.Jaws.Logger] is configured.

--- a/lib/ui/template.go
+++ b/lib/ui/template.go
@@ -28,17 +28,20 @@ import (
 // helper. The referenced template must be a partial template, not a full HTML
 // document.
 //
-// The Elements a template creates through [RequestWriter.NewUI], which every
-// RequestWriter widget helper (including a nested [RequestWriter.Template]) goes
-// through, belong to the Template that rendered them: when [Template.JawsUpdate]
-// replaces the wrapper's content, those Elements are unregistered along with the DOM
-// that held them, and a nested widget's own Elements go with it.
+// The Elements a template creates through [RequestWriter.NewUI] — the path taken by
+// every RequestWriter widget helper except [RequestWriter.Register] and
+// [RequestWriter.RadioGroup], including a nested [RequestWriter.Template] — belong to
+// the Template that rendered them: when [Template.JawsUpdate] replaces the wrapper's
+// content, those Elements are unregistered along with the DOM that held them, and a
+// nested widget's own Elements go with it.
 //
-// [RequestWriter.Register] and [RequestWriter.RadioGroup] create their Elements
-// through [jaws.Request.NewElement] instead, so they are not tracked: an Element
-// either helper creates inside a template stays registered for the [jaws.Request]
-// lifetime, and re-rendering the template adds another. Their generated JaWS ids do
-// let the browser report the removal of any that reached the DOM.
+// Those two helpers create their Elements through [jaws.Request.NewElement] instead,
+// so a Template neither tracks nor unregisters them. Their cleanup is left to the
+// browser, which reports the JaWS ids it removed from the DOM as the wrapper's new
+// content is applied, and the [jaws.Request] unregisters those Elements. An Element
+// whose id never reaches the DOM has nothing to report it and stays registered until
+// the Request ends: one from an execution that failed before its markup was
+// delivered, or from a Register call whose returned Jid the template discards.
 //
 // Template execution is best-effort rather than transactional. Template actions
 // and nested JaWS helpers run as the template executes, so an execution error

--- a/lib/ui/template_handler_test.go
+++ b/lib/ui/template_handler_test.go
@@ -417,7 +417,7 @@ func TestTemplate_UpdateLogsExecuteError(t *testing.T) {
 }
 
 func TestPageTemplate_UpdateNoop(t *testing.T) {
-	pageTemplate{}.JawsUpdate(nil)
+	(&pageTemplate{}).JawsUpdate(nil)
 }
 
 func TestTemplate_RenderReturnsTagExpandError(t *testing.T) {

--- a/lib/ui/template_owned_benchmark_test.go
+++ b/lib/ui/template_owned_benchmark_test.go
@@ -1,0 +1,82 @@
+package ui
+
+import (
+	"html/template"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/linkdata/jaws"
+	"github.com/linkdata/jaws/lib/tag"
+)
+
+// benchOwnedTemplates renders a wrapped template containing many unwrapped nested
+// templates, the shape that makes a template update replace a whole generation of
+// Elements at once.
+const benchOwnedTemplates = `
+{{define "bench-parent"}}{{range $.Dot.Names}}{{$.RequestWriter.Template "" "bench-leaf" $.Dot}}{{end}}{{end}}
+{{define "bench-leaf"}}leaf{{end}}
+`
+
+// benchOwnedDot is the dot for the benchmark templates. A pointer is usable as a tag.
+type benchOwnedDot struct{ names []string }
+
+func (d *benchOwnedDot) Names() []string { return d.names }
+
+// benchOwnedFixture builds a rendered wrapped template with nested Elements and
+// returns the Jaws to close plus a func performing one update. Each call gets its own
+// Jaws and Request, so an implementation that leaks Elements cannot accumulate them
+// across benchmark iterations and skew the result.
+//
+// The update is returned as a closure rather than the template and Element, so this
+// file also compiles against a revision where NewTemplate returns a value: only type
+// inference sees the difference.
+func benchOwnedFixture(b *testing.B, nested int) (jw *jaws.Jaws, update func()) {
+	b.Helper()
+	var err error
+	if jw, err = jaws.New(); err != nil {
+		b.Fatal(err)
+	}
+	if err = jw.AddTemplateLookuper(template.Must(template.New("bench").Parse(benchOwnedTemplates))); err != nil {
+		jw.Close()
+		b.Fatal(err)
+	}
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	if rq == nil {
+		jw.Close()
+		b.Fatal("nil request")
+	}
+	names := make([]string, nested)
+	for i := range names {
+		names[i] = "row-" + strconv.Itoa(i)
+	}
+	tmpl := NewTemplate("div", "bench-parent", &benchOwnedDot{names: names})
+	elem := rq.NewElement(tmpl)
+	// Extra tags on the wrapper, so unregistering a generation has to visit more than
+	// one tag entry: removeElementsLocked scans every tag entry per call.
+	if err = elem.JawsRender(io.Discard, []any{tag.Tag("alpha"), tag.Tag("beta"), tag.Tag("gamma")}); err != nil {
+		jw.Close()
+		b.Fatal(err)
+	}
+	update = func() { tmpl.JawsUpdate(elem) }
+	return
+}
+
+// BenchmarkTemplateUpdateOwnedCleanup measures one update of a wrapped template with
+// many nested Elements: it renders a fresh generation and unregisters the replaced
+// one. It guards the batched unregister against regressing to a per-element
+// registry pass.
+func BenchmarkTemplateUpdateOwnedCleanup(b *testing.B) {
+	b.ReportAllocs()
+	const nested = 1000
+	for range b.N {
+		b.StopTimer()
+		jw, update := benchOwnedFixture(b, nested)
+		b.StartTimer()
+		update()
+		b.StopTimer()
+		jw.Close()
+	}
+}

--- a/lib/ui/template_owned_test.go
+++ b/lib/ui/template_owned_test.go
@@ -1,0 +1,490 @@
+package ui
+
+import (
+	"errors"
+	"fmt"
+	"html/template"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/linkdata/jaws"
+	"github.com/linkdata/jaws/jawstest"
+	"github.com/linkdata/jaws/lib/tag"
+	"github.com/linkdata/jaws/lib/what"
+	"github.com/linkdata/jaws/lib/wire"
+)
+
+// The templates used by the ownership tests. Every nested helper passes $.Dot along,
+// so one dot tags the whole subtree and GetElements(dot) counts it.
+const ownedTestTemplates = `
+{{define "owned-parent"}}{{$.RequestWriter.Template "" "owned-leaf" $.Dot}}{{end}}
+{{define "owned-leaf"}}leaf{{end}}
+{{define "owned-deep"}}{{$.RequestWriter.Template "" "owned-parent" $.Dot}}{{end}}
+{{define "owned-failafter"}}{{$.RequestWriter.Template "" "owned-leaf" $.Dot}}{{$.Dot.Check}}{{end}}
+{{define "owned-many"}}{{range $.Dot.Names}}{{$.RequestWriter.Template "" "owned-leaf" $.Dot}}{{end}}{{end}}
+{{define "owned-container"}}{{$.RequestWriter.Container "div" $.Dot.Container}}{{end}}
+`
+
+var errOwnedDotCheck = errors.New("owned dot check failed")
+
+// ownedDot is the template data for the ownership tests. A pointer is usable as a
+// tag, and Check fails template execution after nested UI has already rendered.
+type ownedDot struct {
+	mu        sync.Mutex
+	fail      error
+	container *testContainer
+	names     []string
+}
+
+func (d *ownedDot) Check() (string, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return "checked", d.fail
+}
+
+func (d *ownedDot) setFail(err error) {
+	d.mu.Lock()
+	d.fail = err
+	d.mu.Unlock()
+}
+
+func (d *ownedDot) Container() jaws.Container { return d.container }
+
+func (d *ownedDot) Names() []string { return d.names }
+
+func newOwnedLookuper(t *testing.T) *template.Template {
+	t.Helper()
+	return template.Must(template.New("owned").Parse(ownedTestTemplates))
+}
+
+// newOwnedRequest returns a Jaws with the ownership test templates registered and a
+// request to render them into.
+func newOwnedRequest(t *testing.T) (*jaws.Jaws, *jaws.Request) {
+	t.Helper()
+	jw, rq := newCoreRequest(t)
+	if err := jw.AddTemplateLookuper(newOwnedLookuper(t)); err != nil {
+		t.Fatal(err)
+	}
+	return jw, rq
+}
+
+// maxProbedJid bounds the Jid probe in countRegistered. The ownership tests create
+// well under this many Elements.
+const maxProbedJid = jaws.Jid(500)
+
+// countRegistered returns how many Elements are still registered in rq, probing the
+// Jid space directly so Elements carrying no tag of their own (unwrapped nested
+// templates, container children) are counted too.
+func countRegistered(t *testing.T, rq *jaws.Request) (count int) {
+	t.Helper()
+	for jid := jaws.Jid(1); jid <= maxProbedJid; jid++ {
+		if rq.GetElementByJid(jid) != nil {
+			count++
+		}
+	}
+	return
+}
+
+// renderOwned renders ui into a new Element and returns it.
+func renderOwned(t *testing.T, rq *jaws.Request, ui jaws.UI) *jaws.Element {
+	t.Helper()
+	elem := rq.NewElement(ui)
+	var sb strings.Builder
+	if err := elem.JawsRender(&sb, nil); err != nil {
+		t.Fatal(err)
+	}
+	return elem
+}
+
+// TestTemplate_NestedUnwrappedDoesNotLeakOnUpdate is the reported issue (#216): a
+// wrapped template invoking an unwrapped nested one must not register an extra
+// Element on every update.
+func TestTemplate_NestedUnwrappedDoesNotLeakOnUpdate(t *testing.T) {
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+	if err = jw.AddTemplateLookuper(newOwnedLookuper(t)); err != nil {
+		t.Fatal(err)
+	}
+	go jw.Serve()
+
+	tr := jawstest.NewTestRequest(jw, nil)
+	t.Cleanup(func() {
+		tr.Close()
+		<-tr.DoneCh
+	})
+	<-tr.ReadyCh
+
+	dot := &ownedDot{}
+	rw := RequestWriter{Request: tr.Request, Writer: tr.Recorder}
+	if err = rw.Template("div", "owned-parent", dot); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(tr.GetElements(dot)); got != 2 {
+		t.Fatalf("initial tagged elements = %d, want 2 (wrapper and nested)", got)
+	}
+
+	for round := 1; round <= 3; round++ {
+		tr.BcastCh <- wire.Message{Dest: dot, What: what.Update}
+		select {
+		case msg := <-tr.OutCh:
+			if msg.What != what.Inner {
+				t.Fatalf("round %d: queued %v, want %v", round, msg.What, what.Inner)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("round %d: timeout waiting for parent update", round)
+		}
+		if got := len(tr.GetElements(dot)); got != 2 {
+			t.Fatalf("tagged elements after %d update(s) = %d, want 2", round, got)
+		}
+	}
+}
+
+// TestTemplate_UpdateReplacesOwnedGeneration checks that the surviving nested
+// Element is the one the update created, and the replaced one is unregistered.
+func TestTemplate_UpdateReplacesOwnedGeneration(t *testing.T) {
+	_, rq := newOwnedRequest(t)
+
+	dot := &ownedDot{}
+	tmpl := NewTemplate("div", "owned-parent", dot)
+	elem := renderOwned(t, rq, tmpl)
+
+	first := tr1Nested(t, rq, dot, elem)
+	tmpl.JawsUpdate(elem)
+	second := tr1Nested(t, rq, dot, elem)
+
+	if first == second {
+		t.Fatal("update reused the previous nested Element instead of rendering a new one")
+	}
+	if !first.Deleted() {
+		t.Error("replaced nested Element does not report Deleted")
+	}
+	if rq.GetElementByJid(first.Jid()) != nil {
+		t.Error("replaced nested Element is still registered")
+	}
+}
+
+// tr1Nested returns the single nested Element tagged with dot, failing if the
+// wrapper is not accompanied by exactly one.
+func tr1Nested(t *testing.T, rq *jaws.Request, dot *ownedDot, wrapper *jaws.Element) *jaws.Element {
+	t.Helper()
+	var nested []*jaws.Element
+	for _, elem := range rq.GetElements(dot) {
+		if elem != wrapper {
+			nested = append(nested, elem)
+		}
+	}
+	if len(nested) != 1 {
+		t.Fatalf("nested elements = %d, want 1", len(nested))
+	}
+	return nested[0]
+}
+
+// TestTemplate_UpdateExecuteFailureKeepsPreviousGeneration checks the rollback: a
+// failed update discards the Elements it created, keeps the previous ones (their DOM
+// is untouched), and a later successful update reclaims exactly those.
+func TestTemplate_UpdateExecuteFailureKeepsPreviousGeneration(t *testing.T) {
+	jw, rq := newOwnedRequest(t)
+	logger := new(templateLogger)
+	jw.Logger = logger
+
+	dot := &ownedDot{}
+	tmpl := NewTemplate("div", "owned-failafter", dot)
+	elem := renderOwned(t, rq, tmpl)
+	first := tr1Nested(t, rq, dot, elem)
+
+	dot.setFail(errOwnedDotCheck)
+	tmpl.JawsUpdate(elem)
+
+	if len(logger.errors) != 1 || !errors.Is(logger.errors[0], errOwnedDotCheck) {
+		t.Fatalf("logged errors = %v, want one %v", logger.errors, errOwnedDotCheck)
+	}
+	if got := tr1Nested(t, rq, dot, elem); got != first {
+		t.Fatal("failed update did not keep the previous nested Element")
+	}
+	if first.Deleted() {
+		t.Fatal("failed update deleted the previous nested Element whose DOM is still live")
+	}
+
+	// The previous generation must still be owned, so a later success reclaims it
+	// rather than leaking it.
+	dot.setFail(nil)
+	tmpl.JawsUpdate(elem)
+	if !first.Deleted() {
+		t.Error("the following successful update did not reclaim the previous nested Element")
+	}
+	if got := len(rq.GetElements(dot)); got != 2 {
+		t.Errorf("tagged elements after recovery = %d, want 2", got)
+	}
+}
+
+// TestTemplate_UpdateLookupFailureKeepsPreviousGeneration covers the update path
+// that returns before the owned set is detached.
+func TestTemplate_UpdateLookupFailureKeepsPreviousGeneration(t *testing.T) {
+	jw, rq := newCoreRequest(t)
+	logger := new(templateLogger)
+	jw.Logger = logger
+	lookuper := newOwnedLookuper(t)
+	if err := jw.AddTemplateLookuper(lookuper); err != nil {
+		t.Fatal(err)
+	}
+
+	dot := &ownedDot{}
+	tmpl := NewTemplate("div", "owned-parent", dot)
+	elem := renderOwned(t, rq, tmpl)
+	first := tr1Nested(t, rq, dot, elem)
+
+	if err := jw.RemoveTemplateLookuper(lookuper); err != nil {
+		t.Fatal(err)
+	}
+	tmpl.JawsUpdate(elem)
+	if len(logger.errors) != 1 || !errors.Is(logger.errors[0], ErrMissingTemplate) {
+		t.Fatalf("logged errors = %v, want one %v", logger.errors, ErrMissingTemplate)
+	}
+	if got := tr1Nested(t, rq, dot, elem); got != first || first.Deleted() {
+		t.Fatal("lookup failure disturbed the previous nested Element")
+	}
+
+	if err := jw.AddTemplateLookuper(lookuper); err != nil {
+		t.Fatal(err)
+	}
+	tmpl.JawsUpdate(elem)
+	if !first.Deleted() {
+		t.Error("the following successful update did not reclaim the previous nested Element")
+	}
+}
+
+// TestTemplate_RenderFailureDeletesOwnedElements checks that an execution error
+// during the initial render leaves nothing registered: NewUI drops the wrapper and
+// the template drops the nested UI it had already created.
+func TestTemplate_RenderFailureDeletesOwnedElements(t *testing.T) {
+	_, rq := newOwnedRequest(t)
+
+	dot := &ownedDot{fail: errOwnedDotCheck}
+	var sb strings.Builder
+	rw := RequestWriter{Request: rq, Writer: &sb}
+	if err := rw.Template("div", "owned-failafter", dot); !errors.Is(err, errOwnedDotCheck) {
+		t.Fatalf("render error = %v, want %v", err, errOwnedDotCheck)
+	}
+	if !strings.Contains(sb.String(), "leaf") {
+		t.Fatalf("nested UI did not render before the failure: %q", sb.String())
+	}
+	if got := countRegistered(t, rq); got != 0 {
+		t.Fatalf("registered elements after failed render = %d, want 0", got)
+	}
+}
+
+// failOnPayload fails the write whose payload matches exactly, so a test can fail
+// the wrapper's closing tag without counting writes.
+type failOnPayload struct {
+	payload string
+	err     error
+	sb      strings.Builder
+}
+
+func (w *failOnPayload) Write(p []byte) (int, error) {
+	if string(p) == w.payload {
+		return 0, w.err
+	}
+	return w.sb.Write(p)
+}
+
+// TestTemplate_RenderClosingWriteFailureDeletesOwnedElements mirrors
+// TestRequestWriterUI_ContainerClosingWriteErrorDoesNotLeakChildren: the nested UI
+// renders, then the wrapper's closing tag fails to write.
+func TestTemplate_RenderClosingWriteFailureDeletesOwnedElements(t *testing.T) {
+	_, rq := newOwnedRequest(t)
+
+	writeErr := errors.New("closing write failed")
+	writer := &failOnPayload{payload: "</div>", err: writeErr}
+	dot := &ownedDot{}
+	rw := RequestWriter{Request: rq, Writer: writer}
+	if err := rw.Template("div", "owned-parent", dot); !errors.Is(err, writeErr) {
+		t.Fatalf("render error = %v, want %v", err, writeErr)
+	}
+	if !strings.Contains(writer.sb.String(), "leaf") {
+		t.Fatalf("nested UI did not render before the failure: %q", writer.sb.String())
+	}
+	if got := countRegistered(t, rq); got != 0 {
+		t.Fatalf("registered elements after failed closing write = %d, want 0", got)
+	}
+}
+
+// TestRequestWriter_NewUIElementRenderedFailureDeletesOwnedElements checks that a
+// failing element-rendered hook unregisters the Element and everything it owns.
+func TestRequestWriter_NewUIElementRenderedFailureDeletesOwnedElements(t *testing.T) {
+	_, rq := newOwnedRequest(t)
+
+	hookErr := errors.New("hook refused the element")
+	var seen int
+	var sb strings.Builder
+	rw := RequestWriter{
+		Request: rq,
+		Writer:  &sb,
+		elementRendered: func(elem *jaws.Element) error {
+			seen++
+			return hookErr
+		},
+	}
+	if err := rw.Template("div", "owned-parent", &ownedDot{}); !errors.Is(err, hookErr) {
+		t.Fatalf("NewUI error = %v, want %v", err, hookErr)
+	}
+	if seen != 1 {
+		t.Fatalf("hook calls = %d, want 1 (only Elements created through this writer)", seen)
+	}
+	if got := countRegistered(t, rq); got != 0 {
+		t.Fatalf("registered elements after hook failure = %d, want 0", got)
+	}
+}
+
+// TestTemplate_UpdateReclaimsWholeSubtree covers the recursive walk: the wrapper
+// owns a nested unwrapped template that owns another one.
+func TestTemplate_UpdateReclaimsWholeSubtree(t *testing.T) {
+	_, rq := newOwnedRequest(t)
+
+	dot := &ownedDot{}
+	tmpl := NewTemplate("div", "owned-deep", dot)
+	elem := renderOwned(t, rq, tmpl)
+	if got := countRegistered(t, rq); got != 3 {
+		t.Fatalf("registered elements after render = %d, want 3", got)
+	}
+
+	for round := 1; round <= 3; round++ {
+		tmpl.JawsUpdate(elem)
+		if got := countRegistered(t, rq); got != 3 {
+			t.Fatalf("registered elements after %d update(s) = %d, want 3", round, got)
+		}
+	}
+}
+
+// TestTemplate_UpdateReclaimsNestedContainer covers a container nested in a
+// template: the replaced container Element takes its children with it.
+func TestTemplate_UpdateReclaimsNestedContainer(t *testing.T) {
+	_, rq := newOwnedRequest(t)
+
+	tc := &testContainer{contents: []jaws.UI{NewSpan(testHTMLGetter("a")), NewSpan(testHTMLGetter("b"))}}
+	dot := &ownedDot{container: tc}
+	tmpl := NewTemplate("div", "owned-container", dot)
+	elem := renderOwned(t, rq, tmpl)
+	// wrapper, container, two spans
+	if got := countRegistered(t, rq); got != 4 {
+		t.Fatalf("registered elements after render = %d, want 4", got)
+	}
+
+	for round := 1; round <= 3; round++ {
+		tmpl.JawsUpdate(elem)
+		if got := countRegistered(t, rq); got != 4 {
+			t.Fatalf("registered elements after %d update(s) = %d, want 4", round, got)
+		}
+	}
+}
+
+// TestContainer_RemovedChildReleasesOwnedElements covers the other nesting
+// direction: a container child that owns nested UI releases it when removed.
+func TestContainer_RemovedChildReleasesOwnedElements(t *testing.T) {
+	_, rq := newOwnedRequest(t)
+
+	dot := &ownedDot{}
+	keep := NewTemplate("div", "owned-parent", dot)
+	drop := NewTemplate("div", "owned-parent", dot)
+	tc := &testContainer{contents: []jaws.UI{keep, drop}}
+	container := NewContainer("div", tc)
+	elem := renderOwned(t, rq, container)
+	// container, two child templates, one nested Element each
+	if got := countRegistered(t, rq); got != 5 {
+		t.Fatalf("registered elements after render = %d, want 5", got)
+	}
+
+	tc.contents = []jaws.UI{keep}
+	container.JawsUpdate(elem)
+	if got := countRegistered(t, rq); got != 3 {
+		t.Fatalf("registered elements after removing a child = %d, want 3", got)
+	}
+}
+
+// TestContainer_FailedAppendReleasesOwnedElementsBeforePanic checks that the failed
+// child and its nested UI are unregistered before MustLog panics for want of a
+// configured logger.
+func TestContainer_FailedAppendReleasesOwnedElementsBeforePanic(t *testing.T) {
+	_, rq := newOwnedRequest(t)
+
+	tc := &testContainer{}
+	container := NewContainer("div", tc)
+	elem := renderOwned(t, rq, container)
+	before := countRegistered(t, rq)
+
+	dot := &ownedDot{fail: errOwnedDotCheck}
+	tc.contents = []jaws.UI{NewTemplate("div", "owned-failafter", dot)}
+	recovered := func() (recovered any) {
+		defer func() { recovered = recover() }()
+		container.JawsUpdate(elem)
+		return
+	}()
+	if err, ok := recovered.(error); !ok || !errors.Is(err, errOwnedDotCheck) {
+		t.Fatalf("recovered = %v, want a panic wrapping %v", recovered, errOwnedDotCheck)
+	}
+	if got := countRegistered(t, rq); got != before {
+		t.Fatalf("registered elements after failed append = %d, want %d", got, before)
+	}
+}
+
+// TestPageTemplate_RenderFailureDeletesOwnedElements covers the page template's
+// error path, which has no update to reclaim anything later.
+func TestPageTemplate_RenderFailureDeletesOwnedElements(t *testing.T) {
+	_, rq := newOwnedRequest(t)
+
+	dot := &ownedDot{fail: errOwnedDotCheck}
+	var sb strings.Builder
+	rw := RequestWriter{Request: rq, Writer: &sb}
+	err := rw.NewUI(&pageTemplate{Template: Template{Name: "owned-failafter", Dot: dot}})
+	if !errors.Is(err, errOwnedDotCheck) {
+		t.Fatalf("render error = %v, want %v", err, errOwnedDotCheck)
+	}
+	if got := countRegistered(t, rq); got != 0 {
+		t.Fatalf("registered elements after failed page render = %d, want 0", got)
+	}
+}
+
+// TestTemplate_UpdateReclaimsManyTaggedDescendants exercises the batched
+// unregister with a generation large enough to span several tag entries.
+func TestTemplate_UpdateReclaimsManyTaggedDescendants(t *testing.T) {
+	_, rq := newOwnedRequest(t)
+
+	const nested = 50
+	names := make([]string, nested)
+	for i := range names {
+		names[i] = fmt.Sprintf("row-%d", i)
+	}
+	dot := &ownedDot{names: names}
+	tmpl := NewTemplate("div", "owned-many", dot)
+	// Several extra tags on the wrapper, so removing a generation has to visit more
+	// than one tag entry.
+	elem := rq.NewElement(tmpl)
+	var sb strings.Builder
+	if err := elem.JawsRender(&sb, []any{tag.Tag("alpha"), tag.Tag("beta"), tag.Tag("gamma")}); err != nil {
+		t.Fatal(err)
+	}
+
+	want := countRegistered(t, rq)
+	if want != nested+1 {
+		t.Fatalf("registered elements after render = %d, want %d", want, nested+1)
+	}
+	for round := 1; round <= 3; round++ {
+		tmpl.JawsUpdate(elem)
+		if got := countRegistered(t, rq); got != want {
+			t.Fatalf("registered elements after %d update(s) = %d, want %d", round, got, want)
+		}
+		if got := len(rq.GetElements(dot)); got != want {
+			t.Fatalf("tagged elements after %d update(s) = %d, want %d", round, got, want)
+		}
+	}
+	for _, tagValue := range []tag.Tag{"alpha", "beta", "gamma"} {
+		if got := rq.GetElements(tagValue); len(got) != 1 || got[0] != elem {
+			t.Errorf("tag %q resolves to %v, want only the wrapper", tagValue, got)
+		}
+	}
+}

--- a/lib/ui/template_owned_test.go
+++ b/lib/ui/template_owned_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/linkdata/jaws"
 	"github.com/linkdata/jaws/jawstest"
+	"github.com/linkdata/jaws/lib/named"
 	"github.com/linkdata/jaws/lib/tag"
 	"github.com/linkdata/jaws/lib/what"
 	"github.com/linkdata/jaws/lib/wire"
@@ -25,6 +26,8 @@ const ownedTestTemplates = `
 {{define "owned-failafter"}}{{$.RequestWriter.Template "" "owned-leaf" $.Dot}}{{$.Dot.Check}}{{end}}
 {{define "owned-many"}}{{range $.Dot.Names}}{{$.RequestWriter.Template "" "owned-leaf" $.Dot}}{{end}}{{end}}
 {{define "owned-container"}}{{$.RequestWriter.Container "div" $.Dot.Container}}{{end}}
+{{define "owned-register"}}<div id="{{$.RequestWriter.Register $.Dot}}"></div>{{end}}
+{{define "owned-radiogroup"}}{{range $.RequestWriter.RadioGroup $.Dot.Radios}}{{.Radio}}{{.Label}}{{end}}{{end}}
 `
 
 var errOwnedDotCheck = errors.New("owned dot check failed")
@@ -36,6 +39,7 @@ type ownedDot struct {
 	fail      error
 	container *testContainer
 	names     []string
+	radios    *named.BoolArray
 }
 
 func (d *ownedDot) Check() (string, error) {
@@ -53,6 +57,12 @@ func (d *ownedDot) setFail(err error) {
 func (d *ownedDot) Container() jaws.Container { return d.container }
 
 func (d *ownedDot) Names() []string { return d.names }
+
+func (d *ownedDot) Radios() *named.BoolArray { return d.radios }
+
+// JawsUpdate makes ownedDot usable as the $.Register updater. Register tags its
+// Element with the updater, so the dot still tags the whole subtree.
+func (d *ownedDot) JawsUpdate(*jaws.Element) {}
 
 func newOwnedLookuper(t *testing.T) *template.Template {
 	t.Helper()
@@ -446,6 +456,46 @@ func TestPageTemplate_RenderFailureDeletesOwnedElements(t *testing.T) {
 	}
 	if got := countRegistered(t, rq); got != 0 {
 		t.Fatalf("registered elements after failed page render = %d, want 0", got)
+	}
+}
+
+// TestTemplate_UpdateDoesNotTrackRegisterOrRadioGroup pins the documented
+// exclusion: Register and RadioGroup create their Elements through
+// Request.NewElement rather than RequestWriter.NewUI, so a Template does not own
+// them and each update adds another. Should either helper start reporting through
+// the element-rendered hook, the counts below become constant — update this test
+// along with the Template, Register, RadioGroup and README docs stating the
+// exclusion.
+func TestTemplate_UpdateDoesNotTrackRegisterOrRadioGroup(t *testing.T) {
+	radios := named.NewBoolArray(false)
+	radios.Add("1", "one")
+
+	for _, tt := range []struct {
+		name     string
+		template string
+		dot      *ownedDot
+		perRound int // Elements the helper adds per execution
+	}{
+		{"register", "owned-register", &ownedDot{}, 1},
+		{"radiogroup", "owned-radiogroup", &ownedDot{radios: radios}, 2}, // input and label
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, rq := newOwnedRequest(t)
+			tmpl := NewTemplate("div", tt.template, tt.dot)
+			elem := renderOwned(t, rq, tmpl)
+
+			want := 1 + tt.perRound // the wrapper, plus the first execution's
+			if got := countRegistered(t, rq); got != want {
+				t.Fatalf("registered elements after render = %d, want %d", got, want)
+			}
+			for round := 1; round <= 3; round++ {
+				tmpl.JawsUpdate(elem)
+				want += tt.perRound
+				if got := countRegistered(t, rq); got != want {
+					t.Fatalf("registered elements after %d update(s) = %d, want %d", round, got, want)
+				}
+			}
+		})
 	}
 }
 

--- a/lib/ui/template_owned_test.go
+++ b/lib/ui/template_owned_test.go
@@ -462,10 +462,15 @@ func TestPageTemplate_RenderFailureDeletesOwnedElements(t *testing.T) {
 // TestTemplate_UpdateDoesNotTrackRegisterOrRadioGroup pins the documented
 // exclusion: Register and RadioGroup create their Elements through
 // Request.NewElement rather than RequestWriter.NewUI, so a Template does not own
-// them and each update adds another. Should either helper start reporting through
-// the element-rendered hook, the counts below become constant — update this test
-// along with the Template, Register, RadioGroup and README docs stating the
-// exclusion.
+// them and each update registers another set.
+//
+// The growth measured here is what the server does on its own. In a live session the
+// browser reports the ids it removes as the wrapper's new content is applied and the
+// Request unregisters those Elements; there is no client here to send that
+// acknowledgement, which is also the state of an Element whose id never reaches the
+// DOM. Should either helper start reporting through the element-rendered hook, these
+// counts become constant — update this test along with the Template, Register,
+// RadioGroup, README and skill docs stating the exclusion.
 func TestTemplate_UpdateDoesNotTrackRegisterOrRadioGroup(t *testing.T) {
 	radios := named.NewBoolArray(false)
 	radios.Add("1", "one")

--- a/request_test.go
+++ b/request_test.go
@@ -106,6 +106,61 @@ func TestRequest_DeleteElementNil(t *testing.T) {
 	rq.DeleteElement(nil)
 }
 
+func TestRequest_DeleteElements(t *testing.T) {
+	rq := newTestRequest(t)
+	defer rq.Close()
+	other := newTestRequest(t)
+	defer other.Close()
+
+	shared := tag.Tag("shared")
+	newTagged := func(rq *testRequest) *Element {
+		elem := rq.NewElement(&testUi{})
+		elem.Tag(shared)
+		return elem
+	}
+
+	// Empty and all-unusable input must not disturb the registry, and must not panic
+	// on the nil element.
+	rq.DeleteElements(nil)
+	rq.DeleteElements([]*Element{})
+	foreign := newTagged(other)
+	rq.DeleteElements([]*Element{nil, foreign})
+	if foreign.Deleted() {
+		t.Error("DeleteElements deleted an element belonging to another Request")
+	}
+
+	// Single element: the fast path still unregisters and marks it deleted.
+	single := newTagged(rq)
+	rq.DeleteElements([]*Element{single})
+	if !single.Deleted() || rq.GetElementByJid(single.Jid()) != nil {
+		t.Error("DeleteElements did not unregister a single element")
+	}
+
+	// Several elements at once, with a repeat and a foreign element mixed in. The
+	// shared tag entry must be dropped once its last element is gone.
+	keep := newTagged(rq)
+	a, b, c := newTagged(rq), newTagged(rq), newTagged(rq)
+	rq.DeleteElements([]*Element{a, b, c, b, nil, foreign})
+	for i, elem := range []*Element{a, b, c} {
+		if !elem.Deleted() {
+			t.Errorf("element %d not marked deleted", i)
+		}
+		if rq.GetElementByJid(elem.Jid()) != nil {
+			t.Errorf("element %d still registered", i)
+		}
+	}
+	if foreign.Deleted() {
+		t.Error("DeleteElements deleted a foreign element in a batch")
+	}
+	if got := rq.GetElements(shared); len(got) != 1 || got[0] != keep {
+		t.Errorf("tag entry after batch = %v, want only the kept element", got)
+	}
+	rq.DeleteElements([]*Element{keep})
+	if got := rq.GetElements(shared); len(got) != 0 {
+		t.Errorf("tag entry not dropped once empty: %v", got)
+	}
+}
+
 func TestRequest_Registrations(t *testing.T) {
 	is := newTestHelper(t)
 	rq := newTestRequest(t)

--- a/requestloop.go
+++ b/requestloop.go
@@ -417,6 +417,37 @@ func (rq *Request) DeleteElement(elem *Element) {
 	rq.deleteElementLocked(elem)
 }
 
+// DeleteElements removes all of elems from the [Request] element registry in a
+// single pass, without queueing browser operations.
+//
+// It is the batched form of [Request.DeleteElement], for unregistering a whole
+// subtree at once: one pass over the registry regardless of how many elements are
+// dropped, rather than one pass per element. Nil elements and elements belonging to
+// another Request are skipped, and repeated elements are tolerated.
+func (rq *Request) DeleteElements(elems []*Element) {
+	if len(elems) == 0 {
+		return
+	}
+	rq.mu.Lock()
+	defer rq.mu.Unlock()
+	if len(elems) == 1 {
+		// Avoid allocating a victims map for the common single-element case.
+		rq.deleteElementLocked(elems[0])
+		return
+	}
+	victims := make(map[*Element]struct{}, len(elems))
+	for _, elem := range elems {
+		if elem != nil && elem.Request == rq {
+			elem.deleted.Store(true)
+			victims[elem] = struct{}{}
+		}
+	}
+	if len(victims) == 0 {
+		return
+	}
+	rq.removeElementsLocked(func(e *Element) bool { _, ok := victims[e]; return ok })
+}
+
 // makeUpdateList drains the pending-dirt tag list, resolves it to the distinct
 // elements needing an update, clears the list, and returns those elements sorted
 // by Jid. It takes rq.mu. The Serve loop calls JawsUpdate on each returned element.


### PR DESCRIPTION
Closes #216.

## The leak

A wrapped `ui.Template` re-registered its nested Elements on every update and never unregistered the previous ones. `Template.JawsUpdate` executes into a builder and queues `SetInner`, which replaces the wrapper's entire inner DOM, so every Element rendered inside it during the previous execution is dead while staying in `rq.elems` and `rq.tagMap` for the Request's lifetime.

The browser hid most of this: `jawsRemoving` acks an `Inner` by reporting the ids of the descendants it removed, and `Request.handleRemove` unregisters them. That ack can only name DOM nodes carrying `id="Jid.N"`, so the leak was exact for **Elements with no DOM identity of their own** — an unwrapped nested template (`{{$.RequestWriter.Template "" "child" .}}`), which both `ui.Template` and `RequestWriter.Template` document as supported, being the direct case. Repeated updates grew the element registry and tag routing state without bound, and tag broadcasts increasingly walked stale Elements.

## The fix

`RequestWriter` gains an **unexported** `elementRendered` hook, called by `NewUI` with each Element it rendered, and `ui.Template` becomes a pointer widget that uses it to track the Elements its execution creates. Unexported matters: `RequestWriter` is embedded in `With`, so an exported func field would be callable from any template as `{{call $.ElementRendered $.Element}}`, letting a template make an Element own itself and have its own wrapper unregistered on the next update.

Update semantics:

| outcome | previous generation | generation just created |
| --- | --- | --- |
| execute succeeded | unregistered with the DOM `SetInner` replaced | kept |
| execute failed | **restored** — no `SetInner` was queued, so it still matches the DOM | unregistered |
| lookup failed | untouched (returns before the set is detached) | none |

Restoring on a failed execute is what lets the next successful update reclaim that generation instead of leaking it. Initial-render failures, including a failed closing-tag write, drop the nested UI the failed execution had already created.

`ContainerHelper` participates through the same unexported `elementOwner` interface, so template/container nesting reconciles both directions: a replaced container Element takes its children with it, and a removed container child releases the nested UI it owned. Its removals collect descendants only once `Element.Remove` has actually applied — `Remove` can reject the operation and leave the DOM alone — and its failed-append cleanup stays ahead of `MustLog`, which panics when no logger is configured.

## `Request.DeleteElements`

Unregisters a whole subtree in one pass over the registry, using the batched pattern `handleRemove` already uses. A per-descendant `DeleteElement` retakes `rq.mu` and rescans `rq.elems` *and every* `tagMap` slice, which is quadratic in the size of the generation being replaced.

`BenchmarkTemplateUpdateOwnedCleanup` (1000 nested Elements, 3 extra wrapper tags, arm64, `-count=6`), committed as a regression guard:

```
per-element DeleteElement -> batched DeleteElements
sec/op      7.923m ± 2%  ->  3.174m ± 11%   -59.94% (p=0.002 n=6)
allocs/op   26.79k ± 0%  ->  26.79k ±  0%     ~     (p=0.015 n=6)

base (no cleanup, leaks a generation per update) -> this change
sec/op      2.553m ± 1%  ->  3.174m ± 11%   +24.33% (p=0.002 n=6)
B/op       1.001Mi ± 0%  ->  1.131Mi ±  0%  +12.92% (p=0.002 n=6)
allocs/op   25.77k ± 0%  ->  26.79k ±  0%    +3.95% (p=0.002 n=6)
```

The second comparison is the cost of doing the cleanup at all, measured against a revision that does none. The benchmark is written so it compiles on both revisions: it returns the update as a closure, so only type inference sees the value/pointer difference.

## Breaking change

`NewTemplate` returns `*Template` and a `ui.Template` value no longer satisfies `jaws.UI`, so one `Template` backs one live Element like every other stateful widget in the package (`*Span`, `*Container`, `*JsVar`). Callers passing `NewTemplate(...)` straight to `NewUI`/`NewElement` are unaffected; `ui.Template{...}` literals used as UI need `&`. Containers whose `JawsContains` builds a fresh `*Template` per call no longer reuse child Elements — identical to every pointer widget today — and it removes the hazard of a `Template` with a non-comparable `Dot` being hashed as a container pool key. `lib/ui/doc.go`'s canonical multiplicity classification and the `lib/ui` README are updated to match.

## Not covered

Neither is a regression; both need core-side knowledge of ownership:

- `RequestWriter.Register` and `RadioGroup` create Elements via `Request.NewElement` directly, bypassing `NewUI`, so no template tracks or unregisters them. Their cleanup falls entirely to the browser ack, which reports the ids removed from the DOM as the wrapper's new content is applied. An Element whose id never reaches the DOM has nothing to report it and stays registered until the Request ends — a discarded `$.Register` Jid, or an execution that failed before delivering its markup. `TestTemplate_UpdateDoesNotTrackRegisterOrRadioGroup` pins the server-side behaviour.
- An owner deleted out-of-band — `jw.Delete(tag)`, `jw.SetInner(tag, html)`, a user `Element.Remove` — leaves its DOM-less descendants registered, since only jaws core observes those deletions.

## Testing

13 new tests in `lib/ui/template_owned_test.go` (the issue repro through the real broadcast loop, generation identity, execute/lookup/render/closing-write/hook failure paths, recursion depth, both nesting directions, the failed-append panic window, page-template failure, many tagged descendants) plus a `Request.DeleteElements` unit test covering nil/foreign/duplicate input, the single-element fast path and tag-entry cleanup.

They were checked to be load-bearing rather than merely passing: with the cleanup neutered in a throwaway worktree, **all 13 fail**.

Gate run locally: `gofmt`, `go vet` (including the copylocks fallout of the new mutex), `staticcheck`, `golangci-lint` (0 issues), `gosec`, and the race, release-tag and debug-tag test legs. `lib/ui` coverage is 100.0%.