### PR TITLE
fix: keep ui.Template a value, holding its state on the Element

### DIFF
--- a/.agents/skills/jaws/SKILL.md
+++ b/.agents/skills/jaws/SKILL.md
@@ -46,7 +46,7 @@ JaWS is an immediate-mode, server-driven UI framework, not an MVC framework.
   nil `UI` interface is a no-op. Surviving such a call is up to the concrete type, not
   a requirement: a widget that dereferences its fields panics, and none of the
   standard `lib/ui` widgets document nil-receiver tolerance. Do not pass a nil pointer
-  of a type that does not; use its zero value (e.g. `&ui.Template{}`) instead.
+  of a type that does not; use its zero value (e.g. `ui.Template{}`) instead.
 - Every JaWS `UI` value is request-scoped. Once used by one Request, never use
   that value with another Request; construct fresh widgets per request. The
   widgets may still refer to shared, synchronized application state, binders,
@@ -108,9 +108,9 @@ These are the two usual building blocks for widget handlers passed to `$.Button`
   returns a value, so the dot is part of the widget the container widgets use as a map key.
   A slice, map, func or NaN-bearing dot makes the widget unusable as a container child.
 - Implementing `JawsGetTag(tag.Context) any` does **not** fix a non-comparable dot — it
-  resolves the *tag*, not the widget's comparability. Wrap such a dot in a pointer, or render
-  through a `*ui.Template` and hand the container the same pointer each time, since reuse then
-  keys on pointer identity. `ui.Handler` is the arbitrary-dot exception.
+  resolves the *tag*, not the widget's comparability. A non-comparable dot is unsupported.
+  Always use the Template itself as a value; taking its address is unsupported because it
+  changes container reuse to pointer identity. `ui.Handler` is the arbitrary-dot exception.
 - Do not use plain `string`, numeric, `bool`, `template.HTML`, or `template.HTMLAttr` as tags; `tag.TagExpand` rejects them.
 - If you need string-like semantic tags, use `tag.Tag("...")` or a comparable typed struct/pointer.
 
@@ -161,9 +161,9 @@ For clickable content rendering:
 
 - Keep HTML structure in templates; avoid manual HTML string assembly in Go.
 - `ui.Template.JawsUpdate` re-renders the template data into the generated wrapper.
-- `ui.NewTemplate` returns a `*ui.Template`, which tracks the Elements its execution
-  creates, but keeps that set in the rendering Element's state slot rather than on itself, so
-  `ui.NewTemplate` returns a plain **value** that may back multiple live Elements. A
+- `ui.NewTemplate` returns a plain `ui.Template` **value** that may back multiple live
+  Elements because it keeps the Elements its execution creates in each rendering Element's
+  state slot rather than on itself. Do not take its address. A
   successful update unregisters every Element the previous execution created through the
   writer it was given — the widget helpers, `$.Register`, `$.RadioGroup` and nested
   `$.Template` alike — since `SetInner` replaces the DOM holding them. Ownership is recorded

--- a/.agents/skills/jaws/SKILL.md
+++ b/.agents/skills/jaws/SKILL.md
@@ -104,6 +104,8 @@ These are the two usual building blocks for widget handlers passed to `$.Button`
 
 - `ui.Template` expands `Dot` into tags via `tag.TagExpand` (package `github.com/linkdata/jaws/lib/tag`, imported as `tag`); the root dot is part of identity/tag behavior.
 - `ui.Template` is for partial templates only; full document/page templates should be rendered through `ui.Handler`.
+- A nil-interface Template `Dot` is valid and contributes no tag; a typed nil follows its
+  dynamic type's comparability and expansion behavior.
 - The root dot **must** be comparable at runtime and equal to itself: `ui.NewTemplate`
   returns a value, so the dot is part of the widget the container widgets use as a map key.
   A slice, map, func or NaN-bearing dot makes the widget unusable as a container child.
@@ -113,9 +115,11 @@ These are the two usual building blocks for widget handlers passed to `$.Button`
   changes container reuse to pointer identity. `ui.Handler` is the arbitrary-dot exception.
 - `tag.TagExpand` rejects exactly these as tags: `string`, `bool`, `int`/`int8`/`int16`/`int32`/`int64`,
   `uint`/`uint8`/`uint16`/`uint32`/`uint64`, `float32`/`float64`, `template.HTML`, `template.HTMLAttr`,
-  `jid.Jid` and `key.Key`. It is a switch on exact types, so `uintptr`, the complex types and your own
-  named types (`type RowID string`) are not rejected by it — they still have to be comparable and equal
-  to themselves, and one implementing `tag.TagGetter` is expanded instead.
+  `jid.Jid` and `key.Key`. It is a switch on exact types, so aliases of a rejected type are rejected,
+  while `uintptr` and the complex types are not on the rejection list. Other defined types
+  (`type RowID string`) are not rejected merely because their underlying predeclared type is on it —
+  they still have to be comparable and equal to themselves, and one implementing `tag.TagGetter` is
+  expanded instead.
 - This applies to a Template's `Dot` too, since rendering expands it: a comparable, reflexive `string`
   dot still fails at render with `illegal tag type string`.
 - If you need string-like semantic tags, use `tag.Tag("...")` or a comparable typed struct/pointer.
@@ -178,8 +182,10 @@ For clickable content rendering:
   every call and their Elements are still reused — that equality *is* the reuse key.
 - The state slot is claimed while rendering, which constrains composition:
   - at most one Template may render a given Element;
-  - a **wrapped** Template updates only an Element some Template rendered, so it is not
-    usable as a `$.Register` updater;
+  - a composite UI must use Template values equal under `==` for rendering and updating
+    an Element; using unequal values is unsupported;
+  - a **wrapped** Template updates only an Element rendered by an equal Template value, so
+    it is not usable as a `$.Register` updater;
   - an **unwrapped** Template is usable there — its updates are a documented no-op — but only
     `$.Register` (the `RequestWriter` helper) also delivers its click/input/context-menu
     handlers; a bare `ui.Register`/`ui.NewRegister` value promotes no handler methods.

--- a/.agents/skills/jaws/SKILL.md
+++ b/.agents/skills/jaws/SKILL.md
@@ -104,8 +104,13 @@ These are the two usual building blocks for widget handlers passed to `$.Button`
 
 - `ui.Template` expands `Dot` into tags via `tag.TagExpand` (package `github.com/linkdata/jaws/lib/tag`, imported as `tag`); the root dot is part of identity/tag behavior.
 - `ui.Template` is for partial templates only; full document/page templates should be rendered through `ui.Handler`.
-- Prefer comparable root dots (pointers or small comparable structs).
-- If root dot is non-comparable, implement `JawsGetTag(tag.Context) any` and return a comparable tag.
+- The root dot **must** be comparable at runtime and equal to itself: `ui.NewTemplate`
+  returns a value, so the dot is part of the widget the container widgets use as a map key.
+  A slice, map, func or NaN-bearing dot makes the widget unusable as a container child.
+- Implementing `JawsGetTag(tag.Context) any` does **not** fix a non-comparable dot — it
+  resolves the *tag*, not the widget's comparability. Wrap such a dot in a pointer, or render
+  through a `*ui.Template` and hand the container the same pointer each time, since reuse then
+  keys on pointer identity. `ui.Handler` is the arbitrary-dot exception.
 - Do not use plain `string`, numeric, `bool`, `template.HTML`, or `template.HTMLAttr` as tags; `tag.TagExpand` rejects them.
 - If you need string-like semantic tags, use `tag.Tag("...")` or a comparable typed struct/pointer.
 
@@ -157,12 +162,21 @@ For clickable content rendering:
 - Keep HTML structure in templates; avoid manual HTML string assembly in Go.
 - `ui.Template.JawsUpdate` re-renders the template data into the generated wrapper.
 - `ui.NewTemplate` returns a `*ui.Template`, which tracks the Elements its execution
-  creates and therefore backs one live Element; construct a fresh one per render
-  (`$.Template` already does). A successful update unregisters every Element the
-  previous execution created through the writer it was given — the widget helpers,
-  `$.Register`, `$.RadioGroup` and nested `$.Template` alike — since `SetInner` replaces
-  the DOM holding them. Ownership is recorded at creation, so an Element that never
-  rendered is reclaimed as well.
+  creates, but keeps that set in the rendering Element's state slot rather than on itself, so
+  `ui.NewTemplate` returns a plain **value** that may back multiple live Elements. A
+  successful update unregisters every Element the previous execution created through the
+  writer it was given — the widget helpers, `$.Register`, `$.RadioGroup` and nested
+  `$.Template` alike — since `SetInner` replaces the DOM holding them. Ownership is recorded
+  at creation, so an Element that never rendered is reclaimed as well.
+- Because the value is stateless, a container's `JawsContains` may rebuild equal children on
+  every call and their Elements are still reused — that equality *is* the reuse key.
+- The state slot is claimed while rendering, which constrains composition:
+  - at most one Template may render a given Element;
+  - a **wrapped** Template updates only an Element some Template rendered, so it is not
+    usable as a `$.Register` updater;
+  - an **unwrapped** Template is usable there — its updates are a documented no-op — but only
+    `$.Register` (the `RequestWriter` helper) also delivers its click/input/context-menu
+    handlers; a bare `ui.Register`/`ui.NewRegister` value promotes no handler methods.
 - Call `$.RadioGroup` from the template that renders the group: its Elements belong to
   the template whose body called it, not to the wrapper their markup lands in.
 - HTML getter paths must not mutate domain state, but they may call element update methods (`SetClass`, `RemoveClass`, `SetAttr`, `RemoveAttr`, etc.) on the passed-in `*Element` to co-ordinate wrapper class/attribute changes with the inner-HTML refresh. No custom `JawsUpdate` is needed for that case — the queued wrapper updates flush alongside the `SetInner` from `HTMLInner.JawsUpdate`.

--- a/.agents/skills/jaws/SKILL.md
+++ b/.agents/skills/jaws/SKILL.md
@@ -111,7 +111,13 @@ These are the two usual building blocks for widget handlers passed to `$.Button`
   resolves the *tag*, not the widget's comparability. A non-comparable dot is unsupported.
   Always use the Template itself as a value; taking its address is unsupported because it
   changes container reuse to pointer identity. `ui.Handler` is the arbitrary-dot exception.
-- Do not use plain `string`, numeric, `bool`, `template.HTML`, or `template.HTMLAttr` as tags; `tag.TagExpand` rejects them.
+- `tag.TagExpand` rejects exactly these as tags: `string`, `bool`, `int`/`int8`/`int16`/`int32`/`int64`,
+  `uint`/`uint8`/`uint16`/`uint32`/`uint64`, `float32`/`float64`, `template.HTML`, `template.HTMLAttr`,
+  `jid.Jid` and `key.Key`. It is a switch on exact types, so `uintptr`, the complex types and your own
+  named types (`type RowID string`) are not rejected by it — they still have to be comparable and equal
+  to themselves, and one implementing `tag.TagGetter` is expanded instead.
+- This applies to a Template's `Dot` too, since rendering expands it: a comparable, reflexive `string`
+  dot still fails at render with `illegal tag type string`.
 - If you need string-like semantic tags, use `tag.Tag("...")` or a comparable typed struct/pointer.
 
 ## `$.Template(...)` signature and parameter semantics

--- a/contracts.go
+++ b/contracts.go
@@ -108,6 +108,9 @@ type Updater interface {
 	// JawsUpdate is called for an [Element] that has been marked dirty to update its HTML.
 	// Do not call this yourself unless it is from within another JawsUpdate implementation.
 	// The engine does not invoke this once the [Element] is deleted (see [Element.Deleted]).
+	// A UI implementation that delegates rendering and updating must delegate both calls
+	// to the same UI widget. Rendering elem through one widget and updating it through
+	// another is unsupported.
 	JawsUpdate(elem *Element)
 }
 

--- a/contracts.go
+++ b/contracts.go
@@ -44,6 +44,12 @@ type Renderer interface {
 	// JawsRender is called once per [Element] when rendering the initial webpage.
 	// Do not call this yourself unless it is from within another JawsRender implementation.
 	// The engine does not invoke this once the [Element] is deleted (see [Element.Deleted]).
+	//
+	// When delegating, note that a renderer may claim the Element's widget state slot
+	// (see [SetElementState]) and that only one of them can: a delegate whose own
+	// renderer claims the slot — [github.com/linkdata/jaws/lib/ui.Template] does —
+	// fails with [ErrElementStateClaimed] if the delegating renderer, or an earlier
+	// delegate, already claimed it.
 	JawsRender(elem *Element, w io.Writer, params []any) error
 }
 
@@ -61,8 +67,10 @@ type TemplateLookuper interface {
 // Within its owning Request, a UI value must back at most one live Element
 // unless its concrete type documents support for multiple live Elements. Such
 // a type must not retain state on the shared UI value that can differ between
-// those Elements. To render the same application state more than once, construct
-// distinct UI values that share getters, setters, handlers or tags.
+// those Elements — [SetElementState] gives it somewhere else to keep such state,
+// keyed to the Element rather than to the widget, but opting in remains the concrete
+// type's decision to document. To render the same application state more than once,
+// construct distinct UI values that share getters, setters, handlers or tags.
 // An Element stops being live when it is deleted or its owning Request lifecycle
 // ends.
 //

--- a/element.go
+++ b/element.go
@@ -39,9 +39,13 @@ type Element struct {
 	// All builds enforce this: appendHandlers drops late mutations (debug builds
 	// panic).
 	handlers []any
-	jid      jid.Jid     // JaWS ID, unique to this Element within its Request
-	deleted  atomic.Bool // true once the Element has been removed from its Request
-	frozen   atomic.Bool // set when handlers are sealed (JawsRender returns or Freeze called); guards handler mutators in all builds
+	// data is the widget state slot, claimed by the widget rendering this Element and
+	// reached through [ElementState] and [SetElementState]. It is guarded by
+	// Request.mu; the stored value's own synchronization guards its contents.
+	data    any
+	jid     jid.Jid     // JaWS ID, unique to this Element within its Request
+	deleted atomic.Bool // true once the Element has been removed from its Request
+	frozen  atomic.Bool // set when handlers are sealed (JawsRender returns or Freeze called); guards handler mutators in all builds
 }
 
 // String returns a debug representation of elem: its UI type, Jid, and tags.

--- a/element_create_benchmark_test.go
+++ b/element_create_benchmark_test.go
@@ -7,9 +7,8 @@ import (
 	"testing"
 )
 
-// This file holds the cross-version element-creation benchmark and nothing else, so it can
-// be copied onto the base commit unchanged: it measures what every Element pays for the
-// widget state slot, whether or not that Element ever uses one.
+// This file isolates the element-creation benchmark, which measures what every Element
+// pays for the widget state slot whether or not that Element ever uses one.
 
 // benchCreateUI is a stateless widget that never touches the state slot, so the measurement
 // is the per-Element cost rather than any Template bookkeeping. It documents support for
@@ -31,7 +30,7 @@ func (benchCreateUI) JawsUpdate(elem *Element) {}
 // calibration would pick an enormous b.N, and the excluded setup would run for minutes.
 // Amortising both calls over the batch keeps that honest, and deleting the batch keeps the
 // Request registry bounded instead of growing across iterations. The reported figure is per
-// batch, so read it only as a base-versus-new comparison.
+// batch and is intended for comparisons between benchmark runs.
 func BenchmarkElementCreateBatch(b *testing.B) {
 	b.ReportAllocs()
 	const batch = 64

--- a/element_create_benchmark_test.go
+++ b/element_create_benchmark_test.go
@@ -30,7 +30,11 @@ func (benchCreateUI) JawsUpdate(elem *Element) {}
 // calibration would pick an enormous b.N, and the excluded setup would run for minutes.
 // Amortising both calls over the batch keeps that honest, and deleting the batch keeps the
 // Request registry bounded instead of growing across iterations. The reported figure is per
-// batch and is intended for comparisons between benchmark runs.
+// batch of 64 Elements.
+//
+// The Jaws and Request are built before b.ResetTimer, and the final b.StopTimer excludes the
+// deferred Close: both would otherwise be divided into every reported figure, time and
+// allocations alike, making the result depend on b.N rather than on the Element.
 func BenchmarkElementCreateBatch(b *testing.B) {
 	b.ReportAllocs()
 	const batch = 64
@@ -47,6 +51,7 @@ func BenchmarkElementCreateBatch(b *testing.B) {
 	var ui benchCreateUI
 	elems := make([]*Element, 0, batch)
 
+	b.ResetTimer()
 	for range b.N {
 		elems = elems[:0]
 		for range batch {
@@ -60,4 +65,5 @@ func BenchmarkElementCreateBatch(b *testing.B) {
 		rq.DeleteElements(elems)
 		b.StartTimer()
 	}
+	b.StopTimer()
 }

--- a/element_create_benchmark_test.go
+++ b/element_create_benchmark_test.go
@@ -1,0 +1,64 @@
+package jaws
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// This file holds the cross-version element-creation benchmark and nothing else, so it can
+// be copied onto the base commit unchanged: it measures what every Element pays for the
+// widget state slot, whether or not that Element ever uses one.
+
+// benchCreateUI is a stateless widget that never touches the state slot, so the measurement
+// is the per-Element cost rather than any Template bookkeeping. It documents support for
+// multiple live Elements because one value backs every Element the benchmark creates.
+type benchCreateUI struct{}
+
+func (benchCreateUI) JawsRender(elem *Element, w io.Writer, params []any) error {
+	_, err := io.WriteString(w, "<span>x</span>")
+	return err
+}
+
+func (benchCreateUI) JawsUpdate(elem *Element) {}
+
+// BenchmarkElementCreateBatch creates and renders a fixed batch of Elements per iteration,
+// then deletes them with the timer stopped.
+//
+// Batching is deliberate: b.StopTimer and b.StartTimer each call runtime.ReadMemStats, so
+// toggling around a single sub-microsecond creation would leave the timed section tiny,
+// calibration would pick an enormous b.N, and the excluded setup would run for minutes.
+// Amortising both calls over the batch keeps that honest, and deleting the batch keeps the
+// Request registry bounded instead of growing across iterations. The reported figure is per
+// batch, so read it only as a base-versus-new comparison.
+func BenchmarkElementCreateBatch(b *testing.B) {
+	b.ReportAllocs()
+	const batch = 64
+
+	jw, err := New()
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer jw.Close()
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	if rq == nil {
+		b.Fatal("nil request")
+	}
+	var ui benchCreateUI
+	elems := make([]*Element, 0, batch)
+
+	for range b.N {
+		elems = elems[:0]
+		for range batch {
+			elem := rq.NewElement(ui)
+			if err := elem.JawsRender(io.Discard, nil); err != nil {
+				b.Fatal(err)
+			}
+			elems = append(elems, elem)
+		}
+		b.StopTimer()
+		rq.DeleteElements(elems)
+		b.StartTimer()
+	}
+}

--- a/elementstate.go
+++ b/elementstate.go
@@ -12,17 +12,18 @@ var ErrElementStateNil = errors.New("jaws: element state must not be nil")
 
 // ElementState returns the widget state stored for elem, or nil if none was claimed.
 //
-// The state belongs to the [Element], not to the widget value that claimed it, so any
-// widget of the claiming type recognizes it. Loading never claims: a widget that finds
-// no state did not claim this Element. Most widgets never claim one, so a nil return
-// says nothing about whether the Element was rendered.
+// The state belongs to the [Element], not to the widget value that claimed it.
+// ElementState therefore does not identify its caller, but that storage detail does not
+// permit a different UI widget to update the Element; see [Updater]. Loading never
+// claims: a widget that finds no state did not claim this Element. Most widgets never
+// claim one, so a nil return says nothing about whether the Element was rendered.
 //
 // Safe for concurrent use; it takes the [Request] lock. Only the slot itself is
 // synchronized: whatever the stored value contains is guarded by that value's own
 // synchronization, not by this call.
 //
-// elem must belong to a [Request]: ElementState dereferences elem.Request, so a nil
-// elem, or one not obtained from [Request.NewElement], panics.
+// elem must be a non-nil Element obtained from [Request.NewElement]. ElementState does
+// not verify that provenance. It panics if elem or elem.Request is nil.
 func ElementState(elem *Element) (state any) {
 	rq := elem.Request
 	rq.mu.RLock()
@@ -50,9 +51,9 @@ func ElementState(elem *Element) (state any) {
 // the claim is synchronized; mutating the stored value afterwards is guarded by that
 // value's own synchronization, not by this call.
 //
-// elem must belong to a [Request]: SetElementState dereferences elem.Request, so a nil
-// elem, or one not obtained from [Request.NewElement], panics — except when state is nil,
-// which is rejected before elem is touched.
+// When state is non-nil, elem must be a non-nil Element obtained from
+// [Request.NewElement]. SetElementState does not verify that provenance. It panics if
+// elem or elem.Request is nil; a nil state is rejected before elem is examined.
 func SetElementState(elem *Element, state any) error {
 	// The two functions are package-level rather than methods on Element because
 	// ui.With embeds both *Element and ui.RequestWriter, so any method returning a value

--- a/elementstate.go
+++ b/elementstate.go
@@ -14,9 +14,15 @@ var ErrElementStateNil = errors.New("jaws: element state must not be nil")
 //
 // The state belongs to the [Element], not to the widget value that claimed it, so any
 // widget of the claiming type recognizes it. Loading never claims: a widget that finds
-// no state did not render this Element.
+// no state did not claim this Element. Most widgets never claim one, so a nil return
+// says nothing about whether the Element was rendered.
 //
-// elem must not be nil.
+// Safe for concurrent use; it takes the [Request] lock. Only the slot itself is
+// synchronized: whatever the stored value contains is guarded by that value's own
+// synchronization, not by this call.
+//
+// elem must belong to a [Request]: ElementState dereferences elem.Request, so a nil
+// elem, or one not obtained from [Request.NewElement], panics.
 func ElementState(elem *Element) (state any) {
 	rq := elem.Request
 	rq.mu.RLock()
@@ -36,10 +42,17 @@ func ElementState(elem *Element) (state any) {
 //
 // A nil state returns [ErrElementStateNil] and stores nothing, since a nil interface is
 // how an unclaimed slot is represented; that check comes first, so a nil state is
-// rejected whatever the slot holds. A typed nil is a non-nil interface and does claim the
-// slot.
+// rejected whatever the slot holds, and before elem is examined at all. A typed nil is a
+// non-nil interface and does claim the slot.
 //
-// elem must not be nil.
+// Safe for concurrent use: concurrent claims on one Element are serialized by the
+// [Request] lock and exactly one wins, the rest reporting [ErrElementStateClaimed]. Only
+// the claim is synchronized; mutating the stored value afterwards is guarded by that
+// value's own synchronization, not by this call.
+//
+// elem must belong to a [Request]: SetElementState dereferences elem.Request, so a nil
+// elem, or one not obtained from [Request.NewElement], panics — except when state is nil,
+// which is rejected before elem is touched.
 func SetElementState(elem *Element, state any) error {
 	// The two functions are package-level rather than methods on Element because
 	// ui.With embeds both *Element and ui.RequestWriter, so any method returning a value

--- a/elementstate.go
+++ b/elementstate.go
@@ -1,0 +1,60 @@
+package jaws
+
+import "errors"
+
+// ErrElementStateClaimed is returned by [SetElementState] when the [Element] already
+// has widget state, including state of the same type.
+var ErrElementStateClaimed = errors.New("jaws: element state already claimed")
+
+// ErrElementStateNil is returned by [SetElementState] when the state to store is a nil
+// interface, which cannot be distinguished from an unclaimed slot.
+var ErrElementStateNil = errors.New("jaws: element state must not be nil")
+
+// ElementState returns the widget state stored for elem, or nil if none was claimed.
+//
+// The state belongs to the [Element], not to the widget value that claimed it, so any
+// widget of the claiming type recognizes it. Loading never claims: a widget that finds
+// no state did not render this Element.
+//
+// elem must not be nil.
+func ElementState(elem *Element) (state any) {
+	rq := elem.Request
+	rq.mu.RLock()
+	state = elem.data
+	rq.mu.RUnlock()
+	return
+}
+
+// SetElementState claims elem's widget state slot, which a widget does while rendering
+// the Element so its updates and cleanup can find that state again.
+//
+// There is one slot per Element and it cannot be replaced, only claimed: a second claim
+// returns [ErrElementStateClaimed] and leaves the stored state untouched, even when the
+// new state has the same type. At most one widget may claim a given Element, so a widget
+// that renders an Element and delegates to another renderer on that same Element must
+// decide which of them claims it.
+//
+// A nil state returns [ErrElementStateNil] and stores nothing, since a nil interface is
+// how an unclaimed slot is represented; that check comes first, so a nil state is
+// rejected whatever the slot holds. A typed nil is a non-nil interface and does claim the
+// slot.
+//
+// elem must not be nil.
+func SetElementState(elem *Element, state any) error {
+	// The two functions are package-level rather than methods on Element because
+	// ui.With embeds both *Element and ui.RequestWriter, so any method returning a value
+	// is reachable from a template: {{$.Element.SetElementState $.Dot}} would let a
+	// template claim the slot out from under the renderer. html/template cannot call a
+	// package-level function.
+	if state == nil {
+		return ErrElementStateNil
+	}
+	rq := elem.Request
+	rq.mu.Lock()
+	defer rq.mu.Unlock()
+	if elem.data != nil {
+		return ErrElementStateClaimed
+	}
+	elem.data = state
+	return nil
+}

--- a/elementstate_test.go
+++ b/elementstate_test.go
@@ -1,0 +1,121 @@
+package jaws
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+type testElementState struct{ name string }
+
+func TestElementState_ClaimOnce(t *testing.T) {
+	rq := newTestRequest(t)
+	defer rq.Close()
+
+	elem := rq.NewElement(&testUi{})
+	if got := ElementState(elem); got != nil {
+		t.Fatalf("unclaimed slot = %v, want nil", got)
+	}
+
+	first := &testElementState{name: "first"}
+	if err := SetElementState(elem, first); err != nil {
+		t.Fatalf("first claim: %v", err)
+	}
+	if got := ElementState(elem); got != first {
+		t.Fatalf("loaded %v, want the claimed state", got)
+	}
+
+	// A second claim fails and leaves the original in place, including one carrying the
+	// same dynamic type: same type does not mean same owner.
+	for _, state := range []any{&testElementState{name: "same type"}, "other type"} {
+		if err := SetElementState(elem, state); !errors.Is(err, ErrElementStateClaimed) {
+			t.Fatalf("second claim with %T = %v, want %v", state, err, ErrElementStateClaimed)
+		}
+	}
+	if got := ElementState(elem); got != first {
+		t.Fatalf("state after rejected claims = %v, want the original", got)
+	}
+
+	// Slots are per Element.
+	other := rq.NewElement(&testUi{})
+	if got := ElementState(other); got != nil {
+		t.Fatalf("second element's slot = %v, want nil", got)
+	}
+	if err := SetElementState(other, &testElementState{name: "second"}); err != nil {
+		t.Fatalf("claiming a different element: %v", err)
+	}
+	if ElementState(elem) != first {
+		t.Error("claiming another element disturbed the first element's state")
+	}
+}
+
+func TestElementState_NilHandling(t *testing.T) {
+	rq := newTestRequest(t)
+	defer rq.Close()
+
+	elem := rq.NewElement(&testUi{})
+
+	// A nil interface cannot be stored: it is indistinguishable from an unclaimed slot,
+	// so accepting it would report success while leaving the slot claimable.
+	if err := SetElementState(elem, nil); !errors.Is(err, ErrElementStateNil) {
+		t.Fatalf("nil claim = %v, want %v", err, ErrElementStateNil)
+	}
+	if got := ElementState(elem); got != nil {
+		t.Fatalf("slot after nil claim = %v, want still nil", got)
+	}
+
+	// A typed nil is a non-nil interface, so it does claim the slot.
+	var typedNil *testElementState
+	if err := SetElementState(elem, typedNil); err != nil {
+		t.Fatalf("typed-nil claim: %v", err)
+	}
+	if err := SetElementState(elem, &testElementState{}); !errors.Is(err, ErrElementStateClaimed) {
+		t.Fatalf("claim after typed nil = %v, want %v", err, ErrElementStateClaimed)
+	}
+
+	// The nil-argument check precedes the occupancy check, so a nil state against an
+	// occupied slot still reports ErrElementStateNil.
+	if err := SetElementState(elem, nil); !errors.Is(err, ErrElementStateNil) {
+		t.Fatalf("nil claim on occupied slot = %v, want %v", err, ErrElementStateNil)
+	}
+}
+
+func TestElementState_ConcurrentClaims(t *testing.T) {
+	rq := newTestRequest(t)
+	defer rq.Close()
+
+	elem := rq.NewElement(&testUi{})
+	const claimants = 8
+
+	var wg sync.WaitGroup
+	errs := make([]error, claimants)
+	states := make([]any, claimants)
+	start := make(chan struct{})
+	for i := range claimants {
+		states[i] = &testElementState{name: "claimant"}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			errs[i] = SetElementState(elem, states[i])
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	var winners int
+	for i, err := range errs {
+		switch {
+		case err == nil:
+			winners++
+			if got := ElementState(elem); got != states[i] {
+				t.Errorf("claimant %d succeeded but the slot holds %v", i, got)
+			}
+		case !errors.Is(err, ErrElementStateClaimed):
+			t.Errorf("claimant %d = %v, want %v", i, err, ErrElementStateClaimed)
+		}
+	}
+	if winners != 1 {
+		t.Errorf("successful claims = %d, want exactly 1", winners)
+	}
+}

--- a/jaws.go
+++ b/jaws.go
@@ -17,11 +17,12 @@
 //
 //	Jaws.mu  ->  Request.mu  ->  Session.mu
 //
-// Request.muQueue and per-[Element] state are leaf locks taken below all of the
-// above. The [Element] widget state slot is guarded by Request.mu rather than being a
-// leaf: [ElementState] and [SetElementState] take Request.mu themselves, so a caller
-// must hold neither it nor the stored value's own lock. That stored lock is a leaf
-// below Request.mu and is released before any core lock is acquired, so nothing nests.
+// Request.muQueue and any lock a widget keeps for one [Element] are leaf locks taken
+// below all of the above. The [Element] widget state slot is not one of them: the slot
+// itself is guarded by Request.mu, which [ElementState] and [SetElementState] take
+// themselves, so a caller must hold neither Request.mu nor the stored value's own lock.
+// Whatever lock that stored value keeps is a leaf, and it is released before any core
+// lock is acquired, so nothing nests.
 // Blocking work (channel sends, user callbacks) is always performed after
 // snapshotting the needed state and releasing the relevant lock; see
 // [Session.Broadcast] and [Session.Close] for the canonical pattern. The

--- a/jaws.go
+++ b/jaws.go
@@ -18,7 +18,11 @@
 //	Jaws.mu  ->  Request.mu  ->  Session.mu
 //
 // Request.muQueue and per-[Element] state are leaf locks taken below all of the
-// above. Blocking work (channel sends, user callbacks) is always performed after
+// above. The [Element] widget state slot is guarded by Request.mu rather than being a
+// leaf: [ElementState] and [SetElementState] take Request.mu themselves, so a caller
+// must hold neither it nor the stored value's own lock. That stored lock is a leaf
+// below Request.mu and is released before any core lock is acquired, so nothing nests.
+// Blocking work (channel sends, user callbacks) is always performed after
 // snapshotting the needed state and releasing the relevant lock; see
 // [Session.Broadcast] and [Session.Close] for the canonical pattern. The
 // [Request.SetContext] transform is the deliberate exception: it runs while

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -57,18 +57,25 @@ Template must be comparable at runtime and equal to itself — a slice, map or f
 makes the whole widget unusable, and implementing `tag.TagGetter` does not change that,
 since it addresses tag resolution rather than widget comparability.
 
-Comparability alone is not enough: rendering expands `Dot` through `tag.TagExpand`, which
-rejects `string`, `bool`, the sized and unsized integer and float types, `template.HTML`,
-`template.HTMLAttr`, `jid.Jid` and `key.Key`. A plain `string` `Dot` is comparable and
-equal to itself yet still fails at render, so wrap such values in `tag.Tag("...")` or a
-comparable struct.
+Comparability alone is not enough. A nil-interface `Dot` is valid and contributes no tag.
+A typed nil is a non-nil interface and follows its dynamic type's comparability and
+expansion rules. Rendering expands a non-nil-interface `Dot` through `tag.TagExpand`,
+which rejects the exact dynamic types `string`, `bool`, `int`/`int8`/`int16`/`int32`/`int64`,
+`uint`/`uint8`/`uint16`/`uint32`/`uint64`, `float32`/`float64`, `template.HTML`,
+`template.HTMLAttr`, `jid.Jid` and `key.Key`. Aliases of a rejected type have that same
+dynamic type and are rejected. `uintptr` and the complex types are not on the rejection
+list. Other defined types are not rejected merely because their underlying predeclared
+type is on it; they must still be comparable and equal to themselves. Wrap a rejected
+scalar in `tag.Tag("...")` or a comparable struct when it should be a tag.
 
 A template claims that slot while rendering, so at most one template may render a given
-element, and a wrapped template updates only an element some template rendered. A wrapped
-template is therefore not usable as a `$.Register` updater — Register never renders its
-element — while an unwrapped one is, since its updates are a documented no-op. On an
-element no template claimed, a wrapped template's update reports `ErrElementStateUnclaimed`
-through `jaws.Request.MustLog`, which **panics** when no `Jaws.Logger` is configured.
+element. A composite UI must use template values equal under `==` for rendering and
+updating that element; using unequal values is unsupported. A wrapped template is
+therefore not usable as a `$.Register` updater — `$.Register` never invokes its updater's
+render method — while an unwrapped one is, since its updates are a documented no-op. On
+an element no template claimed, a wrapped template's update reports
+`ErrElementStateUnclaimed` through `jaws.Request.MustLog`, which **panics** when no
+`Jaws.Logger` is configured.
 
 You can also use explicit constructors through:
 

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -46,6 +46,22 @@ the template whose body called it, not to the wrapper their markup lands in. Cal
 from the template that renders the group; see `RequestWriter.RadioGroup` for what
 happens when the two differ.
 
+The ownership set lives in the element's widget state slot (`jaws.SetElementState`),
+not on the `ui.Template` value, which is what keeps `NewTemplate` returning a plain
+comparable value. That matters for containers: a `JawsContains` implementation may
+rebuild equal child values on every call and the container will still reuse their
+elements, because that equality *is* the reuse key. It also means the `Dot` must be
+comparable at runtime and equal to itself — a slice, map or func Dot makes the whole
+widget unusable as a child key, and implementing `tag.TagGetter` does not change that,
+since it addresses tag resolution rather than widget comparability. Render through a
+`*ui.Template` when the Dot cannot be comparable, accepting that reuse then keys on
+pointer identity.
+
+A template claims that slot while rendering, so at most one template may render a given
+element, and a wrapped template updates only an element some template rendered. A wrapped
+template is therefore not usable as a `$.Register` updater — Register never renders its
+element — while an unwrapped one is, since its updates are a documented no-op.
+
 You can also use explicit constructors through:
 
 ```go

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -48,14 +48,14 @@ happens when the two differ.
 
 The ownership set lives in the element's widget state slot (`jaws.SetElementState`),
 not on the `ui.Template` value, which is what keeps `NewTemplate` returning a plain
-comparable value. That matters for containers: a `JawsContains` implementation may
+value. That matters for containers: a `JawsContains` implementation may
 rebuild equal child values on every call and the container will still reuse their
-elements, because that equality *is* the reuse key. It also means the `Dot` must be
-comparable at runtime and equal to itself — a slice, map or func Dot makes the whole
-widget unusable as a child key, and implementing `tag.TagGetter` does not change that,
-since it addresses tag resolution rather than widget comparability. Render through a
-`*ui.Template` when the Dot cannot be comparable, accepting that reuse then keys on
-pointer identity.
+elements, because that equality *is* the reuse key. Always use `ui.Template` as a
+value, as `NewTemplate` returns it; taking its address is unsupported because it changes
+container reuse to pointer identity. Under the general `jaws.UI` contract, the resulting
+Template must be comparable at runtime and equal to itself — a slice, map or func `Dot`
+makes the whole widget unusable, and implementing `tag.TagGetter` does not change that,
+since it addresses tag resolution rather than widget comparability.
 
 A template claims that slot while rendering, so at most one template may render a given
 element, and a wrapped template updates only an element some template rendered. A wrapped

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -57,10 +57,18 @@ Template must be comparable at runtime and equal to itself — a slice, map or f
 makes the whole widget unusable, and implementing `tag.TagGetter` does not change that,
 since it addresses tag resolution rather than widget comparability.
 
+Comparability alone is not enough: rendering expands `Dot` through `tag.TagExpand`, which
+rejects `string`, `bool`, the sized and unsized integer and float types, `template.HTML`,
+`template.HTMLAttr`, `jid.Jid` and `key.Key`. A plain `string` `Dot` is comparable and
+equal to itself yet still fails at render, so wrap such values in `tag.Tag("...")` or a
+comparable struct.
+
 A template claims that slot while rendering, so at most one template may render a given
 element, and a wrapped template updates only an element some template rendered. A wrapped
 template is therefore not usable as a `$.Register` updater — Register never renders its
-element — while an unwrapped one is, since its updates are a documented no-op.
+element — while an unwrapped one is, since its updates are a documented no-op. On an
+element no template claimed, a wrapped template's update reports `ErrElementStateUnclaimed`
+through `jaws.Request.MustLog`, which **panics** when no `Jaws.Logger` is configured.
 
 You can also use explicit constructors through:
 

--- a/lib/ui/container_reuse_benchmark_test.go
+++ b/lib/ui/container_reuse_benchmark_test.go
@@ -1,0 +1,112 @@
+package ui
+
+import (
+	"html/template"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/linkdata/jaws"
+)
+
+// This file holds the cross-version container benchmarks and nothing else, so it can be
+// copied onto the base commit unchanged. It must not reference anything the base revision
+// lacks: NewTemplate's result is only ever handed straight to a container, so it compiles
+// whether that result is a value or a pointer.
+
+const benchReuseTemplate = `{{define "bench-row"}}<span>row</span>{{end}}`
+
+// benchReuseRow is a comparable dot.
+type benchReuseRow struct{ id int }
+
+// benchRebuildingContainer builds its children afresh on every call, the way an
+// application container does. Reuse therefore depends on those values comparing equal.
+type benchRebuildingContainer struct {
+	rows  []*benchReuseRow
+	build func(*benchReuseRow) jaws.UI
+}
+
+func (c *benchRebuildingContainer) JawsContains(elem *jaws.Element) (contents []jaws.UI) {
+	contents = make([]jaws.UI, 0, len(c.rows))
+	for _, row := range c.rows {
+		contents = append(contents, c.build(row))
+	}
+	return
+}
+
+// benchStableContainer hands back the same child values every call.
+type benchStableContainer struct{ contents []jaws.UI }
+
+func (c *benchStableContainer) JawsContains(elem *jaws.Element) []jaws.UI { return c.contents }
+
+func benchReuseRequest(b *testing.B) (*jaws.Jaws, *jaws.Request) {
+	b.Helper()
+	jw, err := jaws.New()
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err = jw.AddTemplateLookuper(template.Must(template.New("bench").Parse(benchReuseTemplate))); err != nil {
+		jw.Close()
+		b.Fatal(err)
+	}
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	if rq == nil {
+		jw.Close()
+		b.Fatal("nil request")
+	}
+	return jw, rq
+}
+
+// BenchmarkContainerOfTemplatesUpdate times one update of a container whose children are
+// rebuilt on every JawsContains call and whose collection has not changed. When the child
+// values compare equal the container reuses their Elements and the update is nearly free;
+// when they do not, it removes and re-appends the whole collection.
+func BenchmarkContainerOfTemplatesUpdate(b *testing.B) {
+	b.ReportAllocs()
+	const rows = 200
+	for range b.N {
+		b.StopTimer()
+		jw, rq := benchReuseRequest(b)
+		tc := &benchRebuildingContainer{
+			build: func(row *benchReuseRow) jaws.UI { return NewTemplate("div", "bench-row", row) },
+		}
+		for i := range rows {
+			tc.rows = append(tc.rows, &benchReuseRow{id: i})
+		}
+		container := NewContainer("div", tc)
+		elem := rq.NewElement(container)
+		if err := elem.JawsRender(io.Discard, nil); err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+		container.JawsUpdate(elem)
+		b.StopTimer()
+		jw.Close()
+	}
+}
+
+// BenchmarkContainerOfStableChildrenUpdate is the same measurement for children that were
+// already reusable before this change, so the comparison covers a shape that must not
+// regress rather than only the one being repaired.
+func BenchmarkContainerOfStableChildrenUpdate(b *testing.B) {
+	b.ReportAllocs()
+	const rows = 200
+	for range b.N {
+		b.StopTimer()
+		jw, rq := benchReuseRequest(b)
+		tc := &benchStableContainer{}
+		for i := range rows {
+			tc.contents = append(tc.contents, NewSpan(&benchReuseRow{id: i}))
+		}
+		container := NewContainer("div", tc)
+		elem := rq.NewElement(container)
+		if err := elem.JawsRender(io.Discard, nil); err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+		container.JawsUpdate(elem)
+		b.StopTimer()
+		jw.Close()
+	}
+}

--- a/lib/ui/container_reuse_benchmark_test.go
+++ b/lib/ui/container_reuse_benchmark_test.go
@@ -10,10 +10,8 @@ import (
 	"github.com/linkdata/jaws"
 )
 
-// This file holds the cross-version container benchmarks and nothing else, so it can be
-// copied onto the base commit unchanged. It must not reference anything the base revision
-// lacks: NewTemplate's result is only ever handed straight to a container, so it compiles
-// whether that result is a value or a pointer.
+// This file isolates benchmarks for the container's two child-reuse paths: equal rebuilt
+// values and stable values returned unchanged.
 
 const benchReuseTemplate = `{{define "bench-row"}}<span>row</span>{{end}}`
 
@@ -86,9 +84,8 @@ func BenchmarkContainerOfTemplatesUpdate(b *testing.B) {
 	}
 }
 
-// BenchmarkContainerOfStableChildrenUpdate is the same measurement for children that were
-// already reusable before this change, so the comparison covers a shape that must not
-// regress rather than only the one being repaired.
+// BenchmarkContainerOfStableChildrenUpdate measures updates whose child values are returned
+// unchanged, guarding the identity-based reuse path alongside equal rebuilt values.
 func BenchmarkContainerOfStableChildrenUpdate(b *testing.B) {
 	b.ReportAllocs()
 	const rows = 200

--- a/lib/ui/container_reuse_test.go
+++ b/lib/ui/container_reuse_test.go
@@ -83,14 +83,9 @@ func newReuseRequest(t *testing.T) *jawstest.TestRequest {
 	return tr
 }
 
-// TestContainer_RebuiltTemplateChildrenAreReused is the guard for the regression #221
-// introduced: ui.Template held per-Element state, so it had to be a pointer, and
-// reconcile's pool — keyed on the child UI value — stopped matching children a container
-// rebuilds on every JawsContains call. Every update then removed and re-appended the whole
-// collection, with fresh Jids and full DOM churn.
-//
-// Reuse means the child Jids are unchanged and an unchanged collection queues no DOM
-// mutation at all.
+// TestContainer_RebuiltTemplateChildrenAreReused checks value-based reuse for a container
+// that constructs equal Template children on every JawsContains call. Reuse means the child
+// Jids stay unchanged and an unchanged collection queues no DOM mutation.
 func TestContainer_RebuiltTemplateChildrenAreReused(t *testing.T) {
 	tr := newReuseRequest(t)
 
@@ -128,9 +123,8 @@ func TestContainer_RebuiltTemplateChildrenAreReused(t *testing.T) {
 	}
 }
 
-// TestContainer_StableChildrenAreReused covers the shape that already reused before this
-// change — children handed back as the same values each call — so the guard above cannot
-// pass through some accident that also breaks this one.
+// TestContainer_StableChildrenAreReused checks identity-based reuse for children returned as
+// the same values on every JawsContains call.
 func TestContainer_StableChildrenAreReused(t *testing.T) {
 	tr := newReuseRequest(t)
 
@@ -156,9 +150,8 @@ func TestContainer_StableChildrenAreReused(t *testing.T) {
 	assertNoDOMMutation(t, tr, 1)
 }
 
-// TestContainer_NonComparableTemplateDotCancels pins the hazard a by-value widget carries
-// and that this change deliberately does not spread further: the widget is a pool key, so a
-// Dot that cannot be hashed terminates the Request instead of corrupting the pool.
+// TestContainer_NonComparableTemplateDotCancels checks the container key constraint for a
+// Template value: a Dot that cannot be hashed terminates the Request before pool use.
 func TestContainer_NonComparableTemplateDotCancels(t *testing.T) {
 	jw, rq := newCoreRequest(t)
 	_ = jw.AddTemplateLookuper(template.Must(template.New("row").Parse(`<span>row</span>`)))

--- a/lib/ui/container_reuse_test.go
+++ b/lib/ui/container_reuse_test.go
@@ -1,0 +1,176 @@
+package ui
+
+import (
+	"context"
+	"errors"
+	"html/template"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/linkdata/jaws"
+	"github.com/linkdata/jaws/jawstest"
+	"github.com/linkdata/jaws/lib/tag"
+	"github.com/linkdata/jaws/lib/what"
+	"github.com/linkdata/jaws/lib/wire"
+)
+
+// reuseRow is a comparable dot for the reuse fixtures.
+type reuseRow struct{ id int }
+
+// rebuildingContainer returns freshly built child values on every JawsContains call, the
+// way an application container naturally does. Reuse therefore depends entirely on those
+// values comparing equal.
+type rebuildingContainer struct {
+	rows  []*reuseRow
+	build func(*reuseRow) jaws.UI
+}
+
+func (c *rebuildingContainer) JawsContains(elem *jaws.Element) (contents []jaws.UI) {
+	for _, row := range c.rows {
+		contents = append(contents, c.build(row))
+	}
+	return
+}
+
+// childJids returns the container's child Jids in order.
+func childJids(t *testing.T, u *ContainerHelper) (jids []jaws.Jid) {
+	t.Helper()
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	for _, childElem := range u.contents {
+		jids = append(jids, childElem.Jid())
+	}
+	return
+}
+
+// assertNoDOMMutation wakes the harness loop so any queued operations flush, then fails on
+// an Append, Remove or Order — the traffic a container produces when it cannot reuse a
+// child and has to replace the collection instead.
+func assertNoDOMMutation(t *testing.T, tr *jawstest.TestRequest, round int) {
+	t.Helper()
+	tr.InCh <- wire.WsMsg{}
+	for {
+		select {
+		case msg := <-tr.OutCh:
+			switch msg.What {
+			case what.Append, what.Remove, what.Order:
+				t.Fatalf("round %d: unchanged collection queued %v for %v", round, msg.What, msg.Jid)
+			}
+		case <-time.After(300 * time.Millisecond):
+			return
+		}
+	}
+}
+
+func newReuseRequest(t *testing.T) *jawstest.TestRequest {
+	t.Helper()
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+	if err = jw.AddTemplateLookuper(template.Must(template.New("row").Parse(`<span>row</span>`))); err != nil {
+		t.Fatal(err)
+	}
+	go jw.Serve()
+	tr := jawstest.NewTestRequest(jw, nil)
+	t.Cleanup(func() {
+		tr.Close()
+		<-tr.DoneCh
+	})
+	<-tr.ReadyCh
+	return tr
+}
+
+// TestContainer_RebuiltTemplateChildrenAreReused is the guard for the regression #221
+// introduced: ui.Template held per-Element state, so it had to be a pointer, and
+// reconcile's pool — keyed on the child UI value — stopped matching children a container
+// rebuilds on every JawsContains call. Every update then removed and re-appended the whole
+// collection, with fresh Jids and full DOM churn.
+//
+// Reuse means the child Jids are unchanged and an unchanged collection queues no DOM
+// mutation at all.
+func TestContainer_RebuiltTemplateChildrenAreReused(t *testing.T) {
+	tr := newReuseRequest(t)
+
+	tc := &rebuildingContainer{
+		rows: []*reuseRow{{id: 1}, {id: 2}, {id: 3}},
+		build: func(row *reuseRow) jaws.UI {
+			return NewTemplate("div", "row", row)
+		},
+	}
+	container := NewContainer("div", tc)
+	elem := tr.NewElement(container)
+	var sb strings.Builder
+	if err := elem.JawsRender(&sb, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	before := childJids(t, &container.ContainerHelper)
+	if len(before) != len(tc.rows) {
+		t.Fatalf("child elements after render = %d, want %d", len(before), len(tc.rows))
+	}
+
+	for round := 1; round <= 3; round++ {
+		container.JawsUpdate(elem)
+		after := childJids(t, &container.ContainerHelper)
+		if len(after) != len(before) {
+			t.Fatalf("round %d: child elements = %d, want %d", round, len(after), len(before))
+		}
+		for i := range after {
+			if after[i] != before[i] {
+				t.Fatalf("round %d: child %d Jid = %v, want %v (Element was not reused)",
+					round, i, after[i], before[i])
+			}
+		}
+		assertNoDOMMutation(t, tr, round)
+	}
+}
+
+// TestContainer_StableChildrenAreReused covers the shape that already reused before this
+// change — children handed back as the same values each call — so the guard above cannot
+// pass through some accident that also breaks this one.
+func TestContainer_StableChildrenAreReused(t *testing.T) {
+	tr := newReuseRequest(t)
+
+	tc := &testContainer{contents: []jaws.UI{NewSpan(testHTMLGetter("a")), NewSpan(testHTMLGetter("b"))}}
+	container := NewContainer("div", tc)
+	elem := tr.NewElement(container)
+	var sb strings.Builder
+	if err := elem.JawsRender(&sb, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	before := childJids(t, &container.ContainerHelper)
+	container.JawsUpdate(elem)
+	after := childJids(t, &container.ContainerHelper)
+	if len(after) != len(before) {
+		t.Fatalf("child elements = %d, want %d", len(after), len(before))
+	}
+	for i := range after {
+		if after[i] != before[i] {
+			t.Fatalf("child %d Jid = %v, want %v", i, after[i], before[i])
+		}
+	}
+	assertNoDOMMutation(t, tr, 1)
+}
+
+// TestContainer_NonComparableTemplateDotCancels pins the hazard a by-value widget carries
+// and that this change deliberately does not spread further: the widget is a pool key, so a
+// Dot that cannot be hashed terminates the Request instead of corrupting the pool.
+func TestContainer_NonComparableTemplateDotCancels(t *testing.T) {
+	jw, rq := newCoreRequest(t)
+	_ = jw.AddTemplateLookuper(template.Must(template.New("row").Parse(`<span>row</span>`)))
+
+	// A map Dot satisfies the compile-time comparability of the any field but not the
+	// runtime check.
+	tc := &testContainer{contents: []jaws.UI{NewTemplate("div", "row", map[string]int{"a": 1})}}
+	elem := rq.NewElement(NewContainer("div", tc))
+	var sb strings.Builder
+	_ = elem.JawsRender(&sb, nil)
+
+	if cause := context.Cause(rq.Context()); !errors.Is(cause, tag.ErrNotUsableAsTag) {
+		t.Fatalf("cancellation cause = %v, want wrapping %v", cause, tag.ErrNotUsableAsTag)
+	}
+}

--- a/lib/ui/container_reuse_test.go
+++ b/lib/ui/container_reuse_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"html/template"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -44,21 +45,42 @@ func childJids(t *testing.T, u *ContainerHelper) (jids []jaws.Jid) {
 	return
 }
 
-// assertNoDOMMutation wakes the harness loop so any queued operations flush, then fails on
-// an Append, Remove or Order — the traffic a container produces when it cannot reuse a
-// child and has to replace the collection instead.
+// assertNoDOMMutation drains everything the container queued and fails on an Append, Remove
+// or Order — the traffic it produces when it cannot reuse a child and has to replace the
+// collection instead.
+//
+// The drain is bounded by a probe rather than by a timeout, so a slow machine cannot turn
+// "the mutation has not arrived yet" into a pass. Two steps are needed, and for different
+// reasons. The update ran on this goroutine, so its messages are already sitting in the
+// queue; the unbuffered InCh send is consumed by the request loop, whose `continue` runs
+// sendQueue before it can select anything else, forcing that batch out first. Only then is
+// the Alert broadcast queued — otherwise getSendMsgs, which sorts by Jid, would place a
+// Jid-0 Alert ahead of the element-addressed operations in a single flush and the barrier
+// would prove nothing.
 func assertNoDOMMutation(t *testing.T, tr *jawstest.TestRequest, round int) {
 	t.Helper()
 	tr.InCh <- wire.WsMsg{}
+
+	probe := "drained " + strconv.Itoa(round)
+	tr.BcastCh <- wire.Message{What: what.Alert, Data: probe}
 	for {
 		select {
-		case msg := <-tr.OutCh:
+		case msg, ok := <-tr.OutCh:
+			if !ok {
+				t.Fatalf("round %d: the request loop stopped before the probe arrived", round)
+			}
 			switch msg.What {
 			case what.Append, what.Remove, what.Order:
 				t.Fatalf("round %d: unchanged collection queued %v for %v", round, msg.What, msg.Jid)
+			case what.Alert:
+				if msg.Data == probe {
+					return
+				}
 			}
-		case <-time.After(300 * time.Millisecond):
-			return
+		case <-tr.DoneCh:
+			t.Fatalf("round %d: the request loop stopped before the probe arrived", round)
+		case <-time.After(5 * time.Second):
+			t.Fatalf("round %d: timed out waiting for the drain probe", round)
 		}
 	}
 }
@@ -154,14 +176,20 @@ func TestContainer_StableChildrenAreReused(t *testing.T) {
 // Template value: a Dot that cannot be hashed terminates the Request before pool use.
 func TestContainer_NonComparableTemplateDotCancels(t *testing.T) {
 	jw, rq := newCoreRequest(t)
-	_ = jw.AddTemplateLookuper(template.Must(template.New("row").Parse(`<span>row</span>`)))
+	if err := jw.AddTemplateLookuper(template.Must(template.New("row").Parse(`<span>row</span>`))); err != nil {
+		t.Fatal(err)
+	}
 
 	// A map Dot satisfies the compile-time comparability of the any field but not the
 	// runtime check.
 	tc := &testContainer{contents: []jaws.UI{NewTemplate("div", "row", map[string]int{"a": 1})}}
 	elem := rq.NewElement(NewContainer("div", tc))
 	var sb strings.Builder
-	_ = elem.JawsRender(&sb, nil)
+	// The render itself reports nothing: RenderContainer skips the children and still
+	// closes its wrapper, so terminating the Request is the whole signal.
+	if err := elem.JawsRender(&sb, nil); err != nil {
+		t.Fatalf("render = %v, want nil: the unusable child cancels the Request instead", err)
+	}
 
 	if cause := context.Cause(rq.Context()); !errors.Is(cause, tag.ErrNotUsableAsTag) {
 		t.Fatalf("cancellation cause = %v, want wrapping %v", cause, tag.ErrNotUsableAsTag)

--- a/lib/ui/doc.go
+++ b/lib/ui/doc.go
@@ -19,10 +19,11 @@
 //
 // Most constructors return a pointer ([Option], [Register] and [Template] are the
 // value-typed exceptions), and the pointer widgets dereference their fields without
-// checking the receiver. JaWS core accepts a typed nil and dispatches to it like any
-// other [jaws.UI] value (see [jaws.UI]), so rendering or updating one panics here: no
-// widget in this package documents nil-receiver tolerance. The zero value of a widget is
-// the supported empty form.
+// checking the receiver. Always use Template as a value, as [NewTemplate] returns it;
+// taking its address is unsupported. JaWS core accepts a typed nil and dispatches to it
+// like any other [jaws.UI] value (see [jaws.UI]), so rendering or updating one panics
+// here: no widget in this package documents nil-receiver tolerance. The zero value of a
+// widget is the supported empty form.
 //
 // Within one request, a widget normally backs at most one live [jaws.Element].
 // The HTML-inner widgets, [Img], [Option] and [Template] document support for backing
@@ -36,7 +37,8 @@
 //
 // A widget needing state keyed to one Element rather than to itself claims the Element's
 // state slot with [jaws.SetElementState] while rendering, as [Template] does. That is what
-// lets such a widget stay a comparable value the container widgets can reuse as a map key.
+// keeps Element-specific state off the widget value, allowing containers to reuse rebuilt
+// equal Template values.
 //
 // HTML-inner widgets route content through [bind.MakeHTMLGetter]. Plain strings
 // are treated as trusted HTML, while [bind.Getter][string], [bind.Binder][string]

--- a/lib/ui/doc.go
+++ b/lib/ui/doc.go
@@ -17,22 +17,26 @@
 // application state, binders, handlers or tags when that shared state is
 // synchronized as required.
 //
-// Most constructors return a pointer ([Option] and [Register] are the value-typed
-// exceptions), and the widgets dereference their fields without checking the
-// receiver. JaWS core accepts a typed nil and dispatches to it like any other
-// [jaws.UI] value (see [jaws.UI]), so rendering or updating one panics here: no
-// widget in this package documents nil-receiver tolerance. The zero value of a
-// widget, such as &[Template]{}, is the supported empty form.
+// Most constructors return a pointer ([Option], [Register] and [Template] are the
+// value-typed exceptions), and the pointer widgets dereference their fields without
+// checking the receiver. JaWS core accepts a typed nil and dispatches to it like any
+// other [jaws.UI] value (see [jaws.UI]), so rendering or updating one panics here: no
+// widget in this package documents nil-receiver tolerance. The zero value of a widget is
+// the supported empty form.
 //
 // Within one request, a widget normally backs at most one live [jaws.Element].
-// The HTML-inner widgets, [Img] and [Option] document support for backing
+// The HTML-inner widgets, [Img], [Option] and [Template] document support for backing
 // multiple live Elements because they retain no Element-specific state; their
-// shared getters and handlers must also be safe for those calls. Input widgets,
-// [ContainerHelper]-based widgets, [JsVar] and [Template] require a distinct
-// widget value for each live Element. [Register] supports multiple live Elements
-// only when its Updater does. Distinct widgets may still share synchronized
-// application state. This is the canonical package-wide classification; each
-// concrete type's documentation states its conditions.
+// shared getters, handlers and template data must also be safe for those calls. Input
+// widgets, [ContainerHelper]-based widgets and [JsVar] require a distinct widget value
+// for each live Element. [Register] supports multiple live Elements only when its Updater
+// does. Distinct widgets may still share synchronized application state. This is the
+// canonical package-wide classification; each concrete type's documentation states its
+// conditions.
+//
+// A widget needing state keyed to one Element rather than to itself claims the Element's
+// state slot with [jaws.SetElementState] while rendering, as [Template] does. That is what
+// lets such a widget stay a comparable value the container widgets can reuse as a map key.
 //
 // HTML-inner widgets route content through [bind.MakeHTMLGetter]. Plain strings
 // are treated as trusted HTML, while [bind.Getter][string], [bind.Binder][string]

--- a/lib/ui/errelementstateunclaimed.go
+++ b/lib/ui/errelementstateunclaimed.go
@@ -4,12 +4,13 @@ import (
 	"strconv"
 )
 
-// ErrElementStateUnclaimed reports a wrapped [Template] updating an [jaws.Element] no
-// Template claimed while rendering.
+// ErrElementStateUnclaimed reports that a wrapped [Template] tried to update a
+// [jaws.Element] for which no Template claimed the state slot during rendering.
 //
 // With no claim there is no previous generation to reconcile against, so the update
-// executes nothing. The usual cause is updating an Element that was never rendered, such
-// as a wrapped Template used as a [RequestWriter.Register] updater.
+// executes nothing. The usual cause is using a wrapped Template as a
+// [RequestWriter.Register] updater; RequestWriter.Register does not call
+// [Template.JawsRender], so it cannot claim the Element while rendering.
 //
 // [Template.JawsUpdate] reports it through [jaws.Request.MustLog] rather than returning
 // it, so it reaches a caller as a returned error only where that panic is recovered: an

--- a/lib/ui/errelementstateunclaimed.go
+++ b/lib/ui/errelementstateunclaimed.go
@@ -4,12 +4,18 @@ import (
 	"strconv"
 )
 
-// ErrElementStateUnclaimed is returned when a wrapped [Template] is asked to update a
-// [jaws.Element] that no Template claimed while rendering, so there is no previous
-// generation to reconcile against.
+// ErrElementStateUnclaimed reports a wrapped [Template] updating an [jaws.Element] no
+// Template claimed while rendering.
 //
-// The usual cause is updating an Element that was never rendered, such as a wrapped
-// Template used as a [RequestWriter.Register] updater.
+// With no claim there is no previous generation to reconcile against, so the update
+// executes nothing. The usual cause is updating an Element that was never rendered, such
+// as a wrapped Template used as a [RequestWriter.Register] updater.
+//
+// [Template.JawsUpdate] reports it through [jaws.Request.MustLog] rather than returning
+// it, so it reaches a caller as a returned error only where that panic is recovered: an
+// `html/template` action wraps it in an execution error, which [errors.Is] resolves
+// through. Template lookup happens first, so a missing template reports
+// [ErrMissingTemplate] and this error is reached only after a successful lookup.
 var ErrElementStateUnclaimed errElementStateUnclaimed
 
 type errElementStateUnclaimed string

--- a/lib/ui/errelementstateunclaimed.go
+++ b/lib/ui/errelementstateunclaimed.go
@@ -1,0 +1,23 @@
+package ui
+
+import (
+	"strconv"
+)
+
+// ErrElementStateUnclaimed is returned when a wrapped [Template] is asked to update a
+// [jaws.Element] that no Template claimed while rendering, so there is no previous
+// generation to reconcile against.
+//
+// The usual cause is updating an Element that was never rendered, such as a wrapped
+// Template used as a [RequestWriter.Register] updater.
+var ErrElementStateUnclaimed errElementStateUnclaimed
+
+type errElementStateUnclaimed string
+
+func (e errElementStateUnclaimed) Error() string {
+	return "template " + strconv.Quote(string(e)) + " updating an element it did not render"
+}
+
+func (errElementStateUnclaimed) Is(target error) bool {
+	return target == ErrElementStateUnclaimed
+}

--- a/lib/ui/handler.go
+++ b/lib/ui/handler.go
@@ -17,8 +17,8 @@ import (
 type uiHandler struct {
 	*jaws.Jaws
 	// name and dot are the page template's parameters rather than a prepared
-	// pageTemplate: a pageTemplate tracks the Elements of one render, so ServeHTTP
-	// constructs a fresh one per request instead of copying a shared value.
+	// pageTemplate, so ServeHTTP can construct a fresh request-scoped page UI while
+	// accepting arbitrary page data.
 	name string
 	dot  any
 }
@@ -87,8 +87,8 @@ func (h uiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// regardless of the page dot: ordinary html/template data such as a slice or map
 	// is not usable as a tag and would fail the runtime comparability check in
 	// Request.NewElement if a bare pageTemplate value (whose Dot is any) were used.
-	// The pointer identity is always comparable and fresh per request, and each
-	// request gets its own Element-tracking state.
+	// The pointer identity is always comparable and fresh per request. Element tracking
+	// lives in the page Element's state slot claimed by pageTemplate.JawsRender.
 	pt := &pageTemplate{Template: Template{Name: h.name, Dot: h.dot}}
 	if err := rw.NewUI(pt); err != nil {
 		_ = h.Log(err)

--- a/lib/ui/handler.go
+++ b/lib/ui/handler.go
@@ -46,12 +46,16 @@ func (*pageTemplate) JawsUpdate(*jaws.Element) {}
 // serve no purpose; nested UI created during execution registers its own tags
 // independently.
 func (pt *pageTemplate) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err error) {
-	var lookedUp *template.Template
-	if lookedUp, err = pt.lookup(elem); err == nil {
-		if err = pt.execute(elem, w, lookedUp); err != nil {
-			// The page Element is unregistered by RequestWriter.NewUI; the nested UI
-			// this failed execution created is ours to drop.
-			deleteOwnedElements(elem.Request, pt.takeOwnedElements())
+	// Claim the state slot here rather than relying on Template.render, which this
+	// bypasses: without a claim the page's nested UI would be tracked by nothing at all.
+	// This is the only renderer of the page Element, so the claim always succeeds.
+	st := &templateState{}
+	if err = jaws.SetElementState(elem, st); err == nil {
+		var lookedUp *template.Template
+		if lookedUp, err = pt.lookup(elem); err == nil {
+			// A failed execution needs no cleanup here: RequestWriter.NewUI unregisters
+			// the page Element and, through the state slot, everything it owns.
+			err = pt.execute(elem, w, lookedUp, st)
 		}
 	}
 	return

--- a/lib/ui/owned.go
+++ b/lib/ui/owned.go
@@ -31,9 +31,18 @@ func appendOwnedElements(dst []*jaws.Element, elems []*jaws.Element) []*jaws.Ele
 // appendOwnedBy appends the Elements owned by elem, recursively, to dst. It does not
 // append elem itself, so a caller that unregisters elem separately (through
 // [jaws.Element.Remove], say) can still collect its descendants.
+//
+// Ownership lives in two places: on the UI value for the container widgets, and in the
+// Element's widget state slot for [Template]. The slot is matched to *templateState
+// specifically rather than to elementOwner, because the slot legitimately holds any
+// value a renderer put there — a typed nil satisfying elementOwner through a promoted
+// method would panic here on a nil receiver.
 func appendOwnedBy(dst []*jaws.Element, elem *jaws.Element) []*jaws.Element {
 	if owner, ok := elem.UI().(elementOwner); ok {
 		dst = appendOwnedElements(dst, owner.takeOwnedElements())
+	}
+	if st := templateStateOf(elem); st != nil {
+		dst = appendOwnedElements(dst, st.takeOwnedElements())
 	}
 	return dst
 }

--- a/lib/ui/register.go
+++ b/lib/ui/register.go
@@ -13,9 +13,17 @@ import (
 // One Register value may back multiple live [jaws.Element] values only when its
 // Updater supports those calls without retaining Element-specific state on a
 // shared value.
+//
+// The Element is never rendered, so an updater that needs state claimed during a render
+// cannot work here: a wrapped [Template] reports [ErrElementStateUnclaimed] instead of
+// updating. An unwrapped Template is fine, since its updates are a documented no-op —
+// though only [RequestWriter.Register] also delivers its event handlers, because Register
+// embeds [jaws.Updater] and so promotes no handler methods of its own.
 type Register struct{ jaws.Updater }
 
 // NewRegister returns an update-only widget that invokes updater during updates.
+//
+// See [Register] for why a wrapped [Template] cannot be used as the updater.
 func NewRegister(updater jaws.Updater) Register { return Register{Updater: updater} }
 
 // JawsRender renders no HTML for update-only registration.
@@ -41,6 +49,13 @@ func (u Register) JawsRender(elem *jaws.Element, w io.Writer, params []any) erro
 // a managed child outright. Only an Element no removal ever reports, such as one whose
 // returned [jid.Jid] never becomes an element id, necessarily stays registered until the
 // [jaws.Request] ends.
+//
+// Because the Element is never rendered, an updater needing state claimed at render time
+// cannot be used: a wrapped [Template] reports [ErrElementStateUnclaimed] through
+// [jaws.Request.MustLog] rather than updating. An unwrapped Template works — its updates
+// are a documented no-op — and this helper is the only Register form that also delivers a
+// Template's click, input and context-menu handlers, since it adds the concrete updater to
+// the Element's handler list.
 //
 // Register does not call [jaws.Renderer.JawsRender]. The updater must therefore
 // be ready for JawsUpdate and event handling without render-time initialization.

--- a/lib/ui/register.go
+++ b/lib/ui/register.go
@@ -16,7 +16,8 @@ import (
 //
 // The Element is never rendered, so an updater that needs state claimed during a render
 // cannot work here: a wrapped [Template] reports [ErrElementStateUnclaimed] instead of
-// updating. An unwrapped Template is fine, since its updates are a documented no-op —
+// updating, through [jaws.Request.MustLog], which panics when no [jaws.Jaws.Logger] is
+// configured. An unwrapped Template is fine, since its updates are a documented no-op —
 // though only [RequestWriter.Register] also delivers its event handlers, because Register
 // embeds [jaws.Updater] and so promotes no handler methods of its own.
 type Register struct{ jaws.Updater }

--- a/lib/ui/register.go
+++ b/lib/ui/register.go
@@ -14,12 +14,13 @@ import (
 // Updater supports those calls without retaining Element-specific state on a
 // shared value.
 //
-// The Element is never rendered, so an updater that needs state claimed during a render
-// cannot work here: a wrapped [Template] reports [ErrElementStateUnclaimed] instead of
-// updating, through [jaws.Request.MustLog], which panics when no [jaws.Jaws.Logger] is
-// configured. An unwrapped Template is fine, since its updates are a documented no-op —
-// though only [RequestWriter.Register] also delivers its event handlers, because Register
-// embeds [jaws.Updater] and so promotes no handler methods of its own.
+// Register does not call the embedded updater's [jaws.Renderer.JawsRender], so an updater
+// that needs state claimed during its render cannot work here: a wrapped [Template]
+// reports [ErrElementStateUnclaimed] instead of updating, through [jaws.Request.MustLog],
+// which panics when no [jaws.Jaws.Logger] is configured. An unwrapped Template is fine,
+// since its updates are a documented no-op — though only [RequestWriter.Register] also
+// delivers its event handlers, because Register embeds [jaws.Updater] and so promotes no
+// handler methods of its own.
 type Register struct{ jaws.Updater }
 
 // NewRegister returns an update-only widget that invokes updater during updates.
@@ -51,18 +52,16 @@ func (u Register) JawsRender(elem *jaws.Element, w io.Writer, params []any) erro
 // returned [jid.Jid] never becomes an element id, necessarily stays registered until the
 // [jaws.Request] ends.
 //
-// Because the Element is never rendered, an updater needing state claimed at render time
-// cannot be used: a wrapped [Template] reports [ErrElementStateUnclaimed] through
+// RequestWriter.Register does not call the updater's [jaws.Renderer.JawsRender]. The
+// updater must therefore be ready for JawsUpdate and event handling without render-time
+// initialization. A wrapped [Template] reports [ErrElementStateUnclaimed] through
 // [jaws.Request.MustLog] rather than updating. An unwrapped Template works — its updates
-// are a documented no-op — and this helper is the only Register form that also delivers a
-// Template's click, input and context-menu handlers, since it adds the concrete updater to
-// the Element's handler list.
-//
-// Register does not call [jaws.Renderer.JawsRender]. The updater must therefore
-// be ready for JawsUpdate and event handling without render-time initialization.
-// In particular, the standard input widgets and [Select] initialize their dirty
-// targets while rendering; register them with [RequestWriter.NewUI] or their
-// RequestWriter helper when they need to handle input events.
+// are a documented no-op — and this helper is the only Register form that also delivers
+// a Template's click, input and context-menu handlers, since it adds the concrete updater
+// to the Element's handler list. In particular, the standard input widgets and [Select]
+// initialize their dirty targets while rendering; register them with
+// [RequestWriter.NewUI] or their RequestWriter helper when they need to handle input
+// events.
 //
 // Returns a [jid.Jid], suitable for including as an HTML id attribute:
 //

--- a/lib/ui/template.go
+++ b/lib/ui/template.go
@@ -27,12 +27,17 @@ import (
 // Like every [jaws.UI] value passed to [jaws.Request.NewElement], a Template must be
 // comparable at runtime and equal to itself because the container widgets use UI values
 // as map keys. A Dot holding a slice, map, func or NaN makes the Template unusable.
-// Comparability is necessary but not sufficient: rendering expands Dot through
-// [github.com/linkdata/jaws/lib/tag.TagExpand], which rejects the types listed there —
-// among them string, bool, the sized and unsized integer and float types,
-// [html/template.HTML], [html/template.HTMLAttr], [github.com/linkdata/jaws/lib/jid.Jid]
-// and [github.com/linkdata/jaws/lib/key.Key]. A plain string Dot is comparable and equal
-// to itself, yet fails at render. [Handler] is the arbitrary-Dot exception; its private
+// Comparability is necessary but not sufficient. A nil-interface Dot is valid and
+// contributes no tag. A typed nil is a non-nil interface and follows its dynamic type's
+// comparability and expansion rules. Rendering expands a non-nil-interface Dot through
+// [github.com/linkdata/jaws/lib/tag.TagExpand], which rejects the exact dynamic types
+// string, bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64,
+// float32, float64, [html/template.HTML], [html/template.HTMLAttr],
+// [github.com/linkdata/jaws/lib/jid.Jid] and [github.com/linkdata/jaws/lib/key.Key].
+// Aliases of a rejected type have that same dynamic type and are rejected. uintptr and
+// the complex types are not on the rejection list. Other defined types are not rejected
+// merely because their underlying predeclared type is on it; they must still be comparable
+// and equal to themselves. [Handler] is the arbitrary-Dot exception; its private
 // whole-page renderer is distinct from a Template widget and does not use the page dot as
 // a tag.
 //
@@ -40,10 +45,11 @@ import (
 // Element. On an Element no Template claimed, an unwrapped [Template.JawsUpdate] is a
 // no-op while a wrapped one executes nothing and reports [ErrElementStateUnclaimed]
 // through [jaws.Request.MustLog], which panics when no [jaws.Jaws.Logger] is configured.
-// The claim belongs to the Element rather than to the Template value that installed it,
-// so a composite renderer may legitimately delegate JawsRender to one Template and
-// JawsUpdate to another; and a claim survives a render error the delegating renderer
-// handles, so a later update still runs.
+// A composite UI that delegates rendering and updating to a Template must use Template
+// values equal under == for both calls; using unequal values is unsupported. A claim
+// survives a render error the delegating renderer handles, so a later update through an
+// equal Template value can still run when the delegator preserves the wrapped Template's
+// DOM target.
 //
 // The OuterHTMLTag field identifies the generated wrapper element used for
 // partial templates. If OuterHTMLTag is empty, the template is rendered without
@@ -247,7 +253,7 @@ func (tmpl Template) JawsRender(elem *jaws.Element, w io.Writer, params []any) (
 	return
 }
 
-// JawsUpdate re-renders t into the template wrapper.
+// JawsUpdate re-renders the Template into its wrapper.
 //
 // Unwrapped templates have no generated DOM element to update, so updates are
 // ignored; nested JaWS UI rendered by the template can still update through its own
@@ -260,12 +266,14 @@ func (tmpl Template) JawsRender(elem *jaws.Element, w io.Writer, params []any) (
 // instead and the previous ones stay live to match the unchanged DOM. See [Template]
 // for which Elements are tracked.
 //
-// A wrapped Template updates only an Element some Template claimed while rendering it
-// (see [jaws.SetElementState]); with no claim there is nothing to reconcile against, so
-// it executes nothing and reports [ErrElementStateUnclaimed]. That makes a wrapped
-// Template unusable as a [RequestWriter.Register] updater, since Register never renders
-// its Element. Lookup happens first, so a missing template reports [ErrMissingTemplate]
-// and the missing-claim diagnostic is reached only after a successful lookup.
+// A wrapped Template updates only an Element rendered by a Template value equal under ==
+// (see [jaws.SetElementState]); using an unequal value for the update is unsupported. With
+// no claim there is nothing to reconcile against, so it executes nothing and reports
+// [ErrElementStateUnclaimed]. That makes a wrapped Template unusable as a
+// [RequestWriter.Register] updater, since RequestWriter.Register never invokes the
+// updater's [Template.JawsRender]. Lookup happens first, so a missing template reports
+// [ErrMissingTemplate] and the missing-claim diagnostic is reached only after a
+// successful lookup.
 //
 // Lookup, missing-state or execution errors are reported through
 // [jaws.Request.MustLog], which may panic when no [jaws.Jaws.Logger] is configured.
@@ -331,11 +339,12 @@ func (tmpl Template) JawsInput(elem *jaws.Element, value string) (err error) {
 //
 // The returned Template holds no per-Element state, so equal Templates are
 // interchangeable and a container that rebuilds its children on every
-// [jaws.Container.JawsContains] call still reuses their Elements. dot must be comparable
-// at runtime, equal to itself, and usable as a tag: rendering expands it through
-// [github.com/linkdata/jaws/lib/tag.TagExpand], so a plain string, bool, integer or float
-// dot is rejected at render even though it satisfies comparability. See [Template] for
-// the full list. Use the returned Template as a value; taking its address is unsupported.
+// [jaws.Container.JawsContains] call still reuses their Elements. dot may be a nil
+// interface, which contributes no tag. Otherwise it must be comparable at runtime, equal
+// to itself and usable as a tag because rendering expands it through
+// [github.com/linkdata/jaws/lib/tag.TagExpand]. See [Template] for the exact rejected
+// dynamic types; the rules distinguish aliases from new defined types. Use the returned
+// Template as a value; taking its address is unsupported.
 func NewTemplate(outerHTMLTag, name string, dot any) Template {
 	return Template{OuterHTMLTag: outerHTMLTag, Name: name, Dot: dot}
 }

--- a/lib/ui/template.go
+++ b/lib/ui/template.go
@@ -19,13 +19,16 @@ import (
 // Template. Its Dot and any callbacks reached during execution are shared by those
 // Elements and must be safe for their render, update and event calls.
 //
-// A Template value is used as a map key by the container widgets, so its fields must be
-// comparable at runtime and equal to themselves — a Dot holding a slice, map, func or
-// NaN makes the widget unusable as a child. Rendering through a *Template avoids that,
-// since an interface holding a pointer is always comparable, but then container reuse
-// keys on pointer identity and needs the same pointer back on every
-// [jaws.Container.JawsContains] call. [Handler] is the arbitrary-Dot exception and
-// renders a fresh pointer per request for exactly this reason.
+// Template is a value widget and must be passed to JaWS as a value, normally the value
+// returned by [NewTemplate]. Do not take its address: although Go gives *Template the
+// value receiver's method set, a container would then key reuse on pointer identity
+// instead of Template value equality.
+//
+// Like every [jaws.UI] value passed to [jaws.Request.NewElement], a Template must be
+// comparable at runtime and equal to itself because the container widgets use UI values
+// as map keys. A Dot holding a slice, map, func or NaN makes the Template unusable.
+// [Handler] is the arbitrary-Dot exception; its private whole-page renderer is distinct
+// from a Template widget and does not use the page dot as a tag.
 //
 // The state slot is claimed while rendering, so at most one Template may render a given
 // Element and [Template.JawsUpdate] does nothing on an Element no Template rendered. The
@@ -320,7 +323,8 @@ func (tmpl Template) JawsInput(elem *jaws.Element, value string) (err error) {
 // The returned Template holds no per-Element state, so equal Templates are
 // interchangeable and a container that rebuilds its children on every
 // [jaws.Container.JawsContains] call still reuses their Elements. dot must be comparable
-// at runtime and equal to itself; see [Template].
+// at runtime and equal to itself. Use the returned Template as a value; taking its
+// address is unsupported. See [Template].
 func NewTemplate(outerHTMLTag, name string, dot any) Template {
 	return Template{OuterHTMLTag: outerHTMLTag, Name: name, Dot: dot}
 }

--- a/lib/ui/template.go
+++ b/lib/ui/template.go
@@ -13,11 +13,26 @@ import (
 
 // Template references a Go [html/template] template to be rendered through JaWS.
 //
-// A Template tracks the [jaws.Element] values created while its template executes,
-// so it must back at most one live Element. Construct a distinct Template for each
-// place the template is rendered; [RequestWriter.Template] does so for every call.
-// Its Dot and any callbacks reached during execution are shared with anything else
-// referencing them and must be safe for those calls.
+// A Template retains no Element-specific state and may back multiple live
+// [jaws.Element] values: the Elements created while it executes are tracked in the
+// rendering Element's widget state slot (see [jaws.SetElementState]), not on the
+// Template. Its Dot and any callbacks reached during execution are shared by those
+// Elements and must be safe for their render, update and event calls.
+//
+// A Template value is used as a map key by the container widgets, so its fields must be
+// comparable at runtime and equal to themselves — a Dot holding a slice, map, func or
+// NaN makes the widget unusable as a child. Rendering through a *Template avoids that,
+// since an interface holding a pointer is always comparable, but then container reuse
+// keys on pointer identity and needs the same pointer back on every
+// [jaws.Container.JawsContains] call. [Handler] is the arbitrary-Dot exception and
+// renders a fresh pointer per request for exactly this reason.
+//
+// The state slot is claimed while rendering, so at most one Template may render a given
+// Element and [Template.JawsUpdate] does nothing on an Element no Template rendered. The
+// claim belongs to the Element rather than to the Template value that installed it, so a
+// composite renderer may legitimately delegate JawsRender to one Template and JawsUpdate
+// to another; and a claim survives a render error the delegating renderer handles, so a
+// later update still runs.
 //
 // The OuterHTMLTag field identifies the generated wrapper element used for
 // partial templates. If OuterHTMLTag is empty, the template is rendered without
@@ -53,60 +68,64 @@ type Template struct {
 	OuterHTMLTag string // Optional wrapper tag for partial templates, for example "div" or "tr"; empty renders unwrapped.
 	Name         string // Template name to be looked up using Jaws.LookupTemplate.
 	Dot          any    // Dot value to place in With.
-	// mu serializes the owned operations, which run on the rendering goroutine and
-	// on the request loop goroutine during updates (mirrors ContainerHelper).
-	mu sync.Mutex
-	// owned are the Elements created while the template executed, in creation
-	// order. It tracks one live Element's nested UI.
-	owned []*jaws.Element
 }
 
 var (
-	_ jaws.UI                 = (*Template)(nil) // statically ensure interface is defined
-	_ jaws.ClickHandler       = (*Template)(nil) // statically ensure interface is defined
-	_ jaws.ContextMenuHandler = (*Template)(nil) // statically ensure interface is defined
-	_ jaws.InputHandler       = (*Template)(nil) // statically ensure interface is defined
+	_ jaws.UI                 = Template{} // statically ensure interface is defined
+	_ jaws.ClickHandler       = Template{} // statically ensure interface is defined
+	_ jaws.ContextMenuHandler = Template{} // statically ensure interface is defined
+	_ jaws.InputHandler       = Template{} // statically ensure interface is defined
 )
 
-// The methods below dereference tmpl without a nil check, like the other
-// pointer-based widgets in this package (*Span, *Container, *JsVar): jaws.UI accepts
-// a typed nil and dispatches to it, but leaves surviving a nil receiver to the
-// concrete type, and this package documents that none of its widgets do (see doc.go).
-// A zero &Template{} is the supported empty value and reports ErrMissingTemplate.
-
-// String returns a debug representation of t.
-func (tmpl *Template) String() string {
-	return fmt.Sprintf("{%q, %q, %s}", tmpl.OuterHTMLTag, tmpl.Name, tag.TagString(tmpl.Dot))
+// templateState is the per-Element state a Template claims while rendering, held in the
+// Element's widget state slot so the Template itself stays a stateless comparable value.
+type templateState struct {
+	// mu serializes the owned operations, which run on the rendering goroutine and
+	// on the request loop goroutine during updates (mirrors ContainerHelper).
+	mu sync.Mutex
+	// owned are the Elements created while the template executed, in creation order.
+	owned []*jaws.Element
 }
 
-// ownElement records child as created while tmpl's template executed. It is the
+// templateStateOf returns the state claimed for elem, or nil if no Template rendered it.
+func templateStateOf(elem *jaws.Element) (st *templateState) {
+	st, _ = jaws.ElementState(elem).(*templateState)
+	return
+}
+
+// ownElement records child as created while the template executed. It is the
 // [RequestWriter] element-created hook installed by execute, so it is called as soon
 // as the Element exists and makes no assumption about whether it rendered.
-func (tmpl *Template) ownElement(child *jaws.Element) {
-	tmpl.mu.Lock()
-	tmpl.owned = append(tmpl.owned, child)
-	tmpl.mu.Unlock()
+func (st *templateState) ownElement(child *jaws.Element) {
+	st.mu.Lock()
+	st.owned = append(st.owned, child)
+	st.mu.Unlock()
 }
 
 // takeOwnedElements returns the Elements created by the most recent execution and
 // clears the tracking state, transferring responsibility for unregistering them to
 // the caller. It implements elementOwner.
-func (tmpl *Template) takeOwnedElements() (owned []*jaws.Element) {
-	tmpl.mu.Lock()
-	owned, tmpl.owned = tmpl.owned, nil
-	tmpl.mu.Unlock()
+func (st *templateState) takeOwnedElements() (owned []*jaws.Element) {
+	st.mu.Lock()
+	owned, st.owned = st.owned, nil
+	st.mu.Unlock()
 	return
 }
 
 // restoreOwnedElements makes owned the tracked set again, for an update whose
 // output was discarded and whose previous Elements still match the browser DOM.
-func (tmpl *Template) restoreOwnedElements(owned []*jaws.Element) {
-	tmpl.mu.Lock()
-	tmpl.owned = owned
-	tmpl.mu.Unlock()
+func (st *templateState) restoreOwnedElements(owned []*jaws.Element) {
+	st.mu.Lock()
+	st.owned = owned
+	st.mu.Unlock()
 }
 
-func (tmpl *Template) lookup(elem *jaws.Element) (lookedUp *template.Template, err error) {
+// String returns a debug representation of t.
+func (tmpl Template) String() string {
+	return fmt.Sprintf("{%q, %q, %s}", tmpl.OuterHTMLTag, tmpl.Name, tag.TagString(tmpl.Dot))
+}
+
+func (tmpl Template) lookup(elem *jaws.Element) (lookedUp *template.Template, err error) {
 	err = errMissingTemplate(tmpl.Name)
 	if lookedUp = elem.Request.Jaws.LookupTemplate(tmpl.Name); lookedUp != nil {
 		err = nil
@@ -114,7 +133,7 @@ func (tmpl *Template) lookup(elem *jaws.Element) (lookedUp *template.Template, e
 	return
 }
 
-func (tmpl *Template) auth(elem *jaws.Element) (auth jaws.Auth) {
+func (tmpl Template) auth(elem *jaws.Element) (auth jaws.Auth) {
 	if f := elem.Request.Jaws.MakeAuth; f != nil {
 		auth = f(elem.Request)
 	} else {
@@ -125,8 +144,13 @@ func (tmpl *Template) auth(elem *jaws.Element) (auth jaws.Auth) {
 	return
 }
 
-func (tmpl *Template) execute(elem *jaws.Element, w io.Writer, lookedUp *template.Template) (err error) {
-	// The hook makes tmpl own the Elements the template creates through this writer.
+// execute runs the template with st owning the Elements it creates.
+//
+// st is a parameter rather than something execute loads, so every entry point has to
+// establish the state deliberately — pageTemplate renders without going through render,
+// and would otherwise silently track nothing.
+func (tmpl Template) execute(elem *jaws.Element, w io.Writer, lookedUp *template.Template, st *templateState) (err error) {
+	// The hook makes st own the Elements the template creates through this writer.
 	// A nested RequestWriter.Template builds its own writer in its own execute, so
 	// each level owns only its direct children and deeper ones are reached through
 	// them; see appendOwnedElements.
@@ -136,7 +160,7 @@ func (tmpl *Template) execute(elem *jaws.Element, w io.Writer, lookedUp *templat
 	// races on the shared io.Writer, and on the render as a whole.
 	err = lookedUp.Execute(w, With{
 		Element:       elem,
-		RequestWriter: RequestWriter{Request: elem.Request, Writer: w, elementCreated: tmpl.ownElement},
+		RequestWriter: RequestWriter{Request: elem.Request, Writer: w, elementCreated: st.ownElement},
 		Dot:           tmpl.Dot,
 		Auth:          tmpl.auth(elem),
 	})
@@ -156,7 +180,14 @@ func writeTemplateWrapperStart(elem *jaws.Element, w io.Writer, outerHTMLTag str
 	return
 }
 
-func (tmpl *Template) render(elem *jaws.Element, w io.Writer, params []any) (err error) {
+func (tmpl Template) render(elem *jaws.Element, w io.Writer, params []any) (err error) {
+	// Claim the state slot before anything observable happens: tag registration, handler
+	// registration and every write come after, so a contended Element fails having
+	// changed nothing rather than having half-registered itself.
+	st := &templateState{}
+	if err = jaws.SetElementState(elem, st); err != nil {
+		return
+	}
 	doWrap := tmpl.OuterHTMLTag != ""
 	var expandedTags []any
 	if expandedTags, err = tag.TagExpand(elem.Request, tmpl.Dot); err == nil {
@@ -170,7 +201,7 @@ func (tmpl *Template) render(elem *jaws.Element, w io.Writer, params []any) (err
 				err = writeTemplateWrapperStart(elem, w, tmpl.OuterHTMLTag, attrs)
 			}
 			if err == nil {
-				err = tmpl.execute(elem, w, lookedUp)
+				err = tmpl.execute(elem, w, lookedUp, st)
 				if doWrap {
 					// Always emit the closing tag, even when execute failed, to balance
 					// the start tag already written above (mirrors
@@ -183,8 +214,9 @@ func (tmpl *Template) render(elem *jaws.Element, w io.Writer, params []any) (err
 				if err != nil {
 					// The Element itself is unregistered by whoever created it
 					// (RequestWriter.NewUI, or a container). Its nested UI is ours to
-					// drop, since it will never be updated.
-					deleteOwnedElements(elem.Request, tmpl.takeOwnedElements())
+					// drop, since it will never be updated. The claim itself stays, so a
+					// caller that handles this error can still update the Element.
+					deleteOwnedElements(elem.Request, st.takeOwnedElements())
 				}
 			}
 		}
@@ -195,7 +227,11 @@ func (tmpl *Template) render(elem *jaws.Element, w io.Writer, params []any) (err
 // JawsRender renders t through the request's configured template lookupers,
 // streaming output directly to w. Template execution has the best-effort error
 // behavior described on [Template].
-func (tmpl *Template) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err error) {
+//
+// It claims the [jaws.Element]'s widget state slot before doing anything else, so
+// rendering a second Template into one Element fails with
+// [jaws.ErrElementStateClaimed] having changed nothing.
+func (tmpl Template) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err error) {
 	err = tmpl.render(elem, w, params)
 	return
 }
@@ -213,22 +249,31 @@ func (tmpl *Template) JawsRender(elem *jaws.Element, w io.Writer, params []any) 
 // instead and the previous ones stay live to match the unchanged DOM. See [Template]
 // for which Elements are tracked.
 //
-// Lookup or execution errors are reported through [jaws.Request.MustLog], which may
-// panic when no [jaws.Jaws.Logger] is configured.
-func (tmpl *Template) JawsUpdate(elem *jaws.Element) {
+// A wrapped Template updates only an Element some Template claimed while rendering it
+// (see [jaws.SetElementState]); with no claim there is nothing to reconcile against, so
+// it executes nothing and reports [ErrElementStateUnclaimed]. That makes a wrapped
+// Template unusable as a [RequestWriter.Register] updater, since Register never renders
+// its Element.
+//
+// Lookup, missing-state or execution errors are reported through
+// [jaws.Request.MustLog], which may panic when no [jaws.Jaws.Logger] is configured.
+func (tmpl Template) JawsUpdate(elem *jaws.Element) {
 	if tmpl.OuterHTMLTag != "" {
 		lookedUp, err := tmpl.lookup(elem)
 		if err == nil {
-			// Detach before executing so the new Elements accumulate on their own; a
-			// lookup failure returns above with the set untouched.
-			previous := tmpl.takeOwnedElements()
-			var sb strings.Builder
-			if err = tmpl.execute(elem, &sb, lookedUp); err == nil {
-				elem.SetInner(template.HTML(sb.String())) // #nosec G203
-				deleteOwnedElements(elem.Request, previous)
+			if st := templateStateOf(elem); st == nil {
+				err = errElementStateUnclaimed(tmpl.Name)
 			} else {
-				deleteOwnedElements(elem.Request, tmpl.takeOwnedElements())
-				tmpl.restoreOwnedElements(previous)
+				// Detach before executing so the new Elements accumulate on their own.
+				previous := st.takeOwnedElements()
+				var sb strings.Builder
+				if err = tmpl.execute(elem, &sb, lookedUp, st); err == nil {
+					elem.SetInner(template.HTML(sb.String())) // #nosec G203
+					deleteOwnedElements(elem.Request, previous)
+				} else {
+					deleteOwnedElements(elem.Request, st.takeOwnedElements())
+					st.restoreOwnedElements(previous)
+				}
 			}
 		}
 		elem.Request.MustLog(err)
@@ -236,7 +281,7 @@ func (tmpl *Template) JawsUpdate(elem *jaws.Element) {
 }
 
 // JawsClick delegates click events to t.Dot when it implements [jaws.ClickHandler].
-func (tmpl *Template) JawsClick(elem *jaws.Element, click jaws.Click) (err error) {
+func (tmpl Template) JawsClick(elem *jaws.Element, click jaws.Click) (err error) {
 	err = jaws.ErrEventUnhandled
 	if h, ok := tmpl.Dot.(jaws.ClickHandler); ok {
 		err = h.JawsClick(elem, click)
@@ -246,7 +291,7 @@ func (tmpl *Template) JawsClick(elem *jaws.Element, click jaws.Click) (err error
 
 // JawsContextMenu delegates context-menu events to t.Dot when it implements
 // [jaws.ContextMenuHandler].
-func (tmpl *Template) JawsContextMenu(elem *jaws.Element, click jaws.Click) (err error) {
+func (tmpl Template) JawsContextMenu(elem *jaws.Element, click jaws.Click) (err error) {
 	err = jaws.ErrEventUnhandled
 	if h, ok := tmpl.Dot.(jaws.ContextMenuHandler); ok {
 		err = h.JawsContextMenu(elem, click)
@@ -255,7 +300,7 @@ func (tmpl *Template) JawsContextMenu(elem *jaws.Element, click jaws.Click) (err
 }
 
 // JawsInput delegates input events to t.Dot when it implements [jaws.InputHandler].
-func (tmpl *Template) JawsInput(elem *jaws.Element, value string) (err error) {
+func (tmpl Template) JawsInput(elem *jaws.Element, value string) (err error) {
 	err = jaws.ErrEventUnhandled
 	if h, ok := tmpl.Dot.(jaws.InputHandler); ok {
 		err = h.JawsInput(elem, value)
@@ -272,10 +317,12 @@ func (tmpl *Template) JawsInput(elem *jaws.Element, value string) (err error) {
 // [jaws.Jaws.LookupTemplate]. See [Template] for the field semantics, event
 // delegation and best-effort error behavior.
 //
-// The returned Template is request-scoped and tracks the Elements one live
-// [jaws.Element] renders; call NewTemplate again for each place it is rendered.
-func NewTemplate(outerHTMLTag, name string, dot any) *Template {
-	return &Template{OuterHTMLTag: outerHTMLTag, Name: name, Dot: dot}
+// The returned Template holds no per-Element state, so equal Templates are
+// interchangeable and a container that rebuilds its children on every
+// [jaws.Container.JawsContains] call still reuses their Elements. dot must be comparable
+// at runtime and equal to itself; see [Template].
+func NewTemplate(outerHTMLTag, name string, dot any) Template {
+	return Template{OuterHTMLTag: outerHTMLTag, Name: name, Dot: dot}
 }
 
 // Template renders the named partial template with dot exposed as [With.Dot],

--- a/lib/ui/template.go
+++ b/lib/ui/template.go
@@ -27,15 +27,23 @@ import (
 // Like every [jaws.UI] value passed to [jaws.Request.NewElement], a Template must be
 // comparable at runtime and equal to itself because the container widgets use UI values
 // as map keys. A Dot holding a slice, map, func or NaN makes the Template unusable.
-// [Handler] is the arbitrary-Dot exception; its private whole-page renderer is distinct
-// from a Template widget and does not use the page dot as a tag.
+// Comparability is necessary but not sufficient: rendering expands Dot through
+// [github.com/linkdata/jaws/lib/tag.TagExpand], which rejects the types listed there —
+// among them string, bool, the sized and unsized integer and float types,
+// [html/template.HTML], [html/template.HTMLAttr], [github.com/linkdata/jaws/lib/jid.Jid]
+// and [github.com/linkdata/jaws/lib/key.Key]. A plain string Dot is comparable and equal
+// to itself, yet fails at render. [Handler] is the arbitrary-Dot exception; its private
+// whole-page renderer is distinct from a Template widget and does not use the page dot as
+// a tag.
 //
 // The state slot is claimed while rendering, so at most one Template may render a given
-// Element and [Template.JawsUpdate] does nothing on an Element no Template rendered. The
-// claim belongs to the Element rather than to the Template value that installed it, so a
-// composite renderer may legitimately delegate JawsRender to one Template and JawsUpdate
-// to another; and a claim survives a render error the delegating renderer handles, so a
-// later update still runs.
+// Element. On an Element no Template claimed, an unwrapped [Template.JawsUpdate] is a
+// no-op while a wrapped one executes nothing and reports [ErrElementStateUnclaimed]
+// through [jaws.Request.MustLog], which panics when no [jaws.Jaws.Logger] is configured.
+// The claim belongs to the Element rather than to the Template value that installed it,
+// so a composite renderer may legitimately delegate JawsRender to one Template and
+// JawsUpdate to another; and a claim survives a render error the delegating renderer
+// handles, so a later update still runs.
 //
 // The OuterHTMLTag field identifies the generated wrapper element used for
 // partial templates. If OuterHTMLTag is empty, the template is rendered without
@@ -256,7 +264,8 @@ func (tmpl Template) JawsRender(elem *jaws.Element, w io.Writer, params []any) (
 // (see [jaws.SetElementState]); with no claim there is nothing to reconcile against, so
 // it executes nothing and reports [ErrElementStateUnclaimed]. That makes a wrapped
 // Template unusable as a [RequestWriter.Register] updater, since Register never renders
-// its Element.
+// its Element. Lookup happens first, so a missing template reports [ErrMissingTemplate]
+// and the missing-claim diagnostic is reached only after a successful lookup.
 //
 // Lookup, missing-state or execution errors are reported through
 // [jaws.Request.MustLog], which may panic when no [jaws.Jaws.Logger] is configured.
@@ -323,8 +332,10 @@ func (tmpl Template) JawsInput(elem *jaws.Element, value string) (err error) {
 // The returned Template holds no per-Element state, so equal Templates are
 // interchangeable and a container that rebuilds its children on every
 // [jaws.Container.JawsContains] call still reuses their Elements. dot must be comparable
-// at runtime and equal to itself. Use the returned Template as a value; taking its
-// address is unsupported. See [Template].
+// at runtime, equal to itself, and usable as a tag: rendering expands it through
+// [github.com/linkdata/jaws/lib/tag.TagExpand], so a plain string, bool, integer or float
+// dot is rejected at render even though it satisfies comparability. See [Template] for
+// the full list. Use the returned Template as a value; taking its address is unsupported.
 func NewTemplate(outerHTMLTag, name string, dot any) Template {
 	return Template{OuterHTMLTag: outerHTMLTag, Name: name, Dot: dot}
 }

--- a/lib/ui/template_handler_test.go
+++ b/lib/ui/template_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"html/template"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -138,7 +139,12 @@ func TestTemplate_RenderUpdateEventAndHelpers(t *testing.T) {
 	if got, want := tpl.String(), `{"div", "uitempl", `+tag.TagString(td); !strings.Contains(got, want) {
 		t.Fatalf("template string %q does not contain %q", got, want)
 	}
+	// Render before updating: a wrapped Template claims its state slot while rendering and
+	// reports ErrElementStateUnclaimed for an Element it never rendered.
 	elem := rq.NewElement(tpl)
+	if err := elem.JawsRender(io.Discard, nil); err != nil {
+		t.Fatal(err)
+	}
 	tpl.JawsUpdate(elem)
 	if td.updated != 0 {
 		t.Fatalf("expected dot updater not called, got %d", td.updated)
@@ -396,23 +402,49 @@ func TestTemplate_UpdateWithoutWrapperNoop(t *testing.T) {
 	}
 }
 
+// TestTemplate_UpdateLogsExecuteError needs a template whose initial render succeeds and
+// whose later update fails: a wrapped Template updates only an Element it rendered, so a
+// template that always fails could never establish the state slot to begin with.
 func TestTemplate_UpdateLogsExecuteError(t *testing.T) {
 	jw, rq := newCoreRequest(t)
 	logger := new(templateLogger)
 	jw.Logger = logger
 	_ = jw.AddTemplateLookuper(template.Must(template.New("badupdate").Parse(
-		`{{$.Dot.MissingField}}`,
+		`{{$.Dot.Check}}`,
 	)))
 
-	tpl := NewTemplate("div", "badupdate", &templateUpdateDot{})
+	dot := &ownedDot{}
+	tpl := NewTemplate("div", "badupdate", dot)
 	elem := rq.NewElement(tpl)
+	if err := elem.JawsRender(io.Discard, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	dot.setFail(errOwnedDotCheck)
 	tpl.JawsUpdate(elem)
 
 	if len(logger.errors) != 1 {
 		t.Fatalf("logged errors = %d, want 1", len(logger.errors))
 	}
-	if !strings.Contains(logger.errors[0].Error(), "MissingField") {
-		t.Fatalf("logged error = %v, want MissingField error", logger.errors[0])
+	if !errors.Is(logger.errors[0], errOwnedDotCheck) {
+		t.Fatalf("logged error = %v, want %v", logger.errors[0], errOwnedDotCheck)
+	}
+}
+
+func TestTemplate_UpdateLogsUnclaimedState(t *testing.T) {
+	jw, rq := newCoreRequest(t)
+	logger := new(templateLogger)
+	jw.Logger = logger
+	_ = jw.AddTemplateLookuper(template.Must(template.New("unclaimed").Parse(`ok`)))
+
+	// A wrapped Template has nothing to reconcile against on an Element it never
+	// rendered, so it executes nothing and reports it. This is a defensive diagnostic,
+	// not a supported lifecycle.
+	tpl := NewTemplate("div", "unclaimed", tag.Tag("dot"))
+	tpl.JawsUpdate(rq.NewElement(tpl))
+
+	if len(logger.errors) != 1 || !errors.Is(logger.errors[0], ErrElementStateUnclaimed) {
+		t.Fatalf("logged errors = %v, want one %v", logger.errors, ErrElementStateUnclaimed)
 	}
 }
 

--- a/lib/ui/template_handler_test.go
+++ b/lib/ui/template_handler_test.go
@@ -406,12 +406,13 @@ func TestTemplate_UpdateWithoutWrapperNoop(t *testing.T) {
 // whose later update fails: a wrapped Template updates only an Element it rendered, so a
 // template that always fails could never establish the state slot to begin with.
 func TestTemplate_UpdateLogsExecuteError(t *testing.T) {
-	jw, rq := newCoreRequest(t)
 	logger := new(templateLogger)
-	jw.Logger = logger
-	_ = jw.AddTemplateLookuper(template.Must(template.New("badupdate").Parse(
+	jw, rq := newConfiguredCoreRequest(t, withLogger(logger))
+	if err := jw.AddTemplateLookuper(template.Must(template.New("badupdate").Parse(
 		`{{$.Dot.Check}}`,
-	)))
+	))); err != nil {
+		t.Fatal(err)
+	}
 
 	dot := &ownedDot{}
 	tpl := NewTemplate("div", "badupdate", dot)
@@ -432,10 +433,11 @@ func TestTemplate_UpdateLogsExecuteError(t *testing.T) {
 }
 
 func TestTemplate_UpdateLogsUnclaimedState(t *testing.T) {
-	jw, rq := newCoreRequest(t)
 	logger := new(templateLogger)
-	jw.Logger = logger
-	_ = jw.AddTemplateLookuper(template.Must(template.New("unclaimed").Parse(`ok`)))
+	jw, rq := newConfiguredCoreRequest(t, withLogger(logger))
+	if err := jw.AddTemplateLookuper(template.Must(template.New("unclaimed").Parse(`ok`))); err != nil {
+		t.Fatal(err)
+	}
 
 	// A wrapped Template has nothing to reconcile against on an Element it never
 	// rendered, so it executes nothing and reports it. This is a defensive diagnostic,

--- a/lib/ui/template_owned_benchmark_test.go
+++ b/lib/ui/template_owned_benchmark_test.go
@@ -30,9 +30,8 @@ func (d *benchOwnedDot) Names() []string { return d.names }
 // Jaws and Request, so an implementation that leaks Elements cannot accumulate them
 // across benchmark iterations and skew the result.
 //
-// The update is returned as a closure rather than the template and Element, so this
-// file also compiles against a revision where NewTemplate returns a value: only type
-// inference sees the difference.
+// The update is returned as a closure so benchmark callers do not depend on the
+// Template's concrete representation.
 func benchOwnedFixture(b *testing.B, nested int) (jw *jaws.Jaws, update func()) {
 	b.Helper()
 	var err error

--- a/lib/ui/template_owned_benchmark_test.go
+++ b/lib/ui/template_owned_benchmark_test.go
@@ -65,12 +65,23 @@ func benchOwnedFixture(b *testing.B, nested int) (jw *jaws.Jaws, update func()) 
 }
 
 // BenchmarkTemplateUpdateOwnedCleanup measures one update of a wrapped template with
-// many nested Elements: it renders a fresh generation and unregisters the replaced
-// one. It guards the batched unregister against regressing to a per-element
-// registry pass.
+// nested Elements: it renders a fresh generation and unregisters the replaced one. It
+// guards the batched unregister against regressing to a per-element registry pass.
+//
+// The 1000-child case dominates its own measurement, so the small cases are where any
+// fixed per-update cost — such as loading the widget state slot — is visible at all. They
+// rebuild the fixture per iteration with the timer stopped, which makes time-based
+// calibration wildly pessimistic: run this with an explicit -benchtime=Nx.
 func BenchmarkTemplateUpdateOwnedCleanup(b *testing.B) {
+	for _, nested := range []int{0, 8, 1000} {
+		b.Run("children="+strconv.Itoa(nested), func(b *testing.B) {
+			benchmarkTemplateUpdateOwnedCleanup(b, nested)
+		})
+	}
+}
+
+func benchmarkTemplateUpdateOwnedCleanup(b *testing.B, nested int) {
 	b.ReportAllocs()
-	const nested = 1000
 	for range b.N {
 		b.StopTimer()
 		jw, update := benchOwnedFixture(b, nested)

--- a/lib/ui/template_register_test.go
+++ b/lib/ui/template_register_test.go
@@ -27,10 +27,9 @@ func (d *registerDot) Updater() jaws.Updater { return d.updater }
 
 func newRegisterRequest(t *testing.T, logger *templateLogger) (*jaws.Jaws, *jaws.Request) {
 	t.Helper()
-	jw, rq := newCoreRequest(t)
-	// Logger has to be in place before the Request is created; changing it afterwards is
-	// unsupported.
-	jw.Logger = logger
+	// The Logger has to be in place before the Request is created; changing it afterwards
+	// is unsupported, so it goes in through the configure hook.
+	jw, rq := newConfiguredCoreRequest(t, withLogger(logger))
 	if err := jw.AddTemplateLookuper(template.Must(template.New("reg").Parse(templateRegisterTemplates))); err != nil {
 		t.Fatal(err)
 	}
@@ -58,8 +57,10 @@ func TestRegister_WrappedTemplateUpdaterReportsUnclaimed(t *testing.T) {
 	})
 
 	t.Run("direct call panics without a logger", func(t *testing.T) {
-		_, rq := newCoreRequest(t)
-		_ = rq.Jaws.AddTemplateLookuper(template.Must(template.New("reg-plain").Parse(`plain`)))
+		jw, rq := newCoreRequest(t)
+		if err := jw.AddTemplateLookuper(template.Must(template.New("reg-plain").Parse(`plain`))); err != nil {
+			t.Fatal(err)
+		}
 		var sb strings.Builder
 		rw := RequestWriter{Request: rq, Writer: &sb}
 
@@ -75,19 +76,22 @@ func TestRegister_WrappedTemplateUpdaterReportsUnclaimed(t *testing.T) {
 	})
 
 	t.Run("template action becomes a render error without a logger", func(t *testing.T) {
-		_, rq := newCoreRequest(t)
-		_ = rq.Jaws.AddTemplateLookuper(template.Must(template.New("reg").Parse(templateRegisterTemplates)))
+		jw, rq := newCoreRequest(t)
+		if err := jw.AddTemplateLookuper(template.Must(template.New("reg").Parse(templateRegisterTemplates))); err != nil {
+			t.Fatal(err)
+		}
 		var sb strings.Builder
 		rw := RequestWriter{Request: rq, Writer: &sb}
 
 		// html/template recovers a panic raised by a called method and returns it as an
-		// execution error, so this surfaces as a render error rather than escaping.
+		// execution error, so this surfaces as a render error rather than escaping. The
+		// wrapping preserves the sentinel, so match on that rather than on the text.
 		err := rw.Template("div", "reg-page", &registerDot{updater: wrapped})
 		if err == nil {
 			t.Fatal("expected a render error from the recovered panic")
 		}
-		if !strings.Contains(err.Error(), "did not render") {
-			t.Fatalf("render error = %v, want it to mention the unclaimed state", err)
+		if !errors.Is(err, ErrElementStateUnclaimed) {
+			t.Fatalf("render error = %v, want it to wrap %v", err, ErrElementStateUnclaimed)
 		}
 	})
 

--- a/lib/ui/template_register_test.go
+++ b/lib/ui/template_register_test.go
@@ -37,9 +37,9 @@ func newRegisterRequest(t *testing.T, logger *templateLogger) (*jaws.Jaws, *jaws
 	return jw, rq
 }
 
-// TestRegister_WrappedTemplateUpdaterReportsUnclaimed covers the compatibility narrowing:
-// Register never renders its Element, so a wrapped Template has no claim to update against.
-// The outcome differs by call path, which is what the matrix below pins.
+// TestRegister_WrappedTemplateUpdaterReportsUnclaimed checks every reporting path for a
+// wrapped Template updater. Register never renders its Element, so the Template has no state
+// claim to update against.
 func TestRegister_WrappedTemplateUpdaterReportsUnclaimed(t *testing.T) {
 	wrapped := NewTemplate("div", "reg-plain", tag.Tag("dot"))
 
@@ -139,7 +139,10 @@ func TestRegister_WrappedTemplateUpdaterOnTheRequestLoop(t *testing.T) {
 			go jw.Serve()
 
 			tr := jawstest.NewTestRequest(jw, nil)
-			t.Cleanup(tr.Close)
+			t.Cleanup(func() {
+				tr.Close()
+				<-tr.DoneCh
+			})
 			<-tr.ReadyCh
 
 			dirty := tag.Tag("registered")
@@ -155,20 +158,29 @@ func TestRegister_WrappedTemplateUpdaterOnTheRequestLoop(t *testing.T) {
 			tr.BcastCh <- wire.Message{Dest: dirty, What: what.Update}
 
 			if tt.wantAlive {
-				// Wake the loop and confirm it still serves afterwards.
-				tr.InCh <- wire.WsMsg{}
+				// BcastCh preserves send order. Receiving this Alert proves the loop
+				// processed the preceding failing update and kept serving afterwards.
+				const probe = "still alive"
+				tr.BcastCh <- wire.Message{What: what.Alert, Data: probe}
 				select {
+				case msg, ok := <-tr.OutCh:
+					if !ok {
+						t.Fatal("the request loop stopped although a logger was configured")
+					}
+					if msg.Jid != 0 || msg.What != what.Alert || msg.Data != probe {
+						t.Fatalf("liveness probe = %+v, want Alert %q", msg, probe)
+					}
 				case <-tr.DoneCh:
 					t.Fatal("the request loop stopped although a logger was configured")
-				case <-time.After(300 * time.Millisecond):
+				case <-time.After(2 * time.Second):
+					t.Fatal("timeout waiting for the request-loop liveness probe")
 				}
-				if len(logger.errors) == 0 {
-					t.Fatal("expected the diagnostic to be logged")
-				}
-				for _, err := range logger.errors {
-					if !errors.Is(err, ErrElementStateUnclaimed) {
-						t.Fatalf("logged %v, want %v", err, ErrElementStateUnclaimed)
-					}
+
+				// Join the request-loop goroutine before inspecting its logger writes.
+				tr.Close()
+				<-tr.DoneCh
+				if len(logger.errors) != 1 || !errors.Is(logger.errors[0], ErrElementStateUnclaimed) {
+					t.Fatalf("logged errors = %v, want one %v", logger.errors, ErrElementStateUnclaimed)
 				}
 				return
 			}

--- a/lib/ui/template_register_test.go
+++ b/lib/ui/template_register_test.go
@@ -37,8 +37,8 @@ func newRegisterRequest(t *testing.T, logger *templateLogger) (*jaws.Jaws, *jaws
 }
 
 // TestRegister_WrappedTemplateUpdaterReportsUnclaimed checks every reporting path for a
-// wrapped Template updater. Register never renders its Element, so the Template has no state
-// claim to update against.
+// wrapped Template updater. RequestWriter.Register never calls the Template's renderer,
+// so the Template has no state claim to update against.
 func TestRegister_WrappedTemplateUpdaterReportsUnclaimed(t *testing.T) {
 	wrapped := NewTemplate("div", "reg-plain", tag.Tag("dot"))
 

--- a/lib/ui/template_register_test.go
+++ b/lib/ui/template_register_test.go
@@ -1,0 +1,242 @@
+package ui
+
+import (
+	"errors"
+	"html/template"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/linkdata/jaws"
+	"github.com/linkdata/jaws/jawstest"
+	"github.com/linkdata/jaws/lib/tag"
+	"github.com/linkdata/jaws/lib/what"
+	"github.com/linkdata/jaws/lib/wire"
+)
+
+const templateRegisterTemplates = `
+{{define "reg-plain"}}plain{{end}}
+{{define "reg-page"}}<div id="{{$.RequestWriter.Register $.Dot.Updater}}"></div>{{end}}
+`
+
+// registerDot exposes a Template as an Updater to a template action.
+type registerDot struct{ updater jaws.Updater }
+
+func (d *registerDot) Updater() jaws.Updater { return d.updater }
+
+func newRegisterRequest(t *testing.T, logger *templateLogger) (*jaws.Jaws, *jaws.Request) {
+	t.Helper()
+	jw, rq := newCoreRequest(t)
+	// Logger has to be in place before the Request is created; changing it afterwards is
+	// unsupported.
+	jw.Logger = logger
+	if err := jw.AddTemplateLookuper(template.Must(template.New("reg").Parse(templateRegisterTemplates))); err != nil {
+		t.Fatal(err)
+	}
+	return jw, rq
+}
+
+// TestRegister_WrappedTemplateUpdaterReportsUnclaimed covers the compatibility narrowing:
+// Register never renders its Element, so a wrapped Template has no claim to update against.
+// The outcome differs by call path, which is what the matrix below pins.
+func TestRegister_WrappedTemplateUpdaterReportsUnclaimed(t *testing.T) {
+	wrapped := NewTemplate("div", "reg-plain", tag.Tag("dot"))
+
+	t.Run("direct call logs", func(t *testing.T) {
+		logger := new(templateLogger)
+		_, rq := newRegisterRequest(t, logger)
+		var sb strings.Builder
+		rw := RequestWriter{Request: rq, Writer: &sb}
+
+		if jid := rw.Register(wrapped); !jid.IsValid() {
+			t.Fatal("expected a valid Jid even though the update failed")
+		}
+		if len(logger.errors) != 1 || !errors.Is(logger.errors[0], ErrElementStateUnclaimed) {
+			t.Fatalf("logged errors = %v, want one %v", logger.errors, ErrElementStateUnclaimed)
+		}
+	})
+
+	t.Run("direct call panics without a logger", func(t *testing.T) {
+		_, rq := newCoreRequest(t)
+		_ = rq.Jaws.AddTemplateLookuper(template.Must(template.New("reg-plain").Parse(`plain`)))
+		var sb strings.Builder
+		rw := RequestWriter{Request: rq, Writer: &sb}
+
+		// Register runs the update immediately, so MustLog's panic escapes to the caller.
+		recovered := func() (recovered any) {
+			defer func() { recovered = recover() }()
+			rw.Register(wrapped)
+			return
+		}()
+		if err, ok := recovered.(error); !ok || !errors.Is(err, ErrElementStateUnclaimed) {
+			t.Fatalf("recovered = %v, want a panic wrapping %v", recovered, ErrElementStateUnclaimed)
+		}
+	})
+
+	t.Run("template action becomes a render error without a logger", func(t *testing.T) {
+		_, rq := newCoreRequest(t)
+		_ = rq.Jaws.AddTemplateLookuper(template.Must(template.New("reg").Parse(templateRegisterTemplates)))
+		var sb strings.Builder
+		rw := RequestWriter{Request: rq, Writer: &sb}
+
+		// html/template recovers a panic raised by a called method and returns it as an
+		// execution error, so this surfaces as a render error rather than escaping.
+		err := rw.Template("div", "reg-page", &registerDot{updater: wrapped})
+		if err == nil {
+			t.Fatal("expected a render error from the recovered panic")
+		}
+		if !strings.Contains(err.Error(), "did not render") {
+			t.Fatalf("render error = %v, want it to mention the unclaimed state", err)
+		}
+	})
+
+	t.Run("template action logs and keeps rendering", func(t *testing.T) {
+		logger := new(templateLogger)
+		_, rq := newRegisterRequest(t, logger)
+		var sb strings.Builder
+		rw := RequestWriter{Request: rq, Writer: &sb}
+
+		if err := rw.Template("div", "reg-page", &registerDot{updater: wrapped}); err != nil {
+			t.Fatalf("render = %v, want nil: the diagnostic is logged, not fatal", err)
+		}
+		if !strings.Contains(sb.String(), "</div>") {
+			t.Fatalf("rendering did not continue past the diagnostic: %q", sb.String())
+		}
+		if len(logger.errors) != 1 || !errors.Is(logger.errors[0], ErrElementStateUnclaimed) {
+			t.Fatalf("logged errors = %v, want one %v", logger.errors, ErrElementStateUnclaimed)
+		}
+	})
+}
+
+// TestRegister_WrappedTemplateUpdaterOnTheRequestLoop reaches the diagnostic from the
+// request loop, which RequestWriter.Register cannot do because it updates immediately: a
+// NewRegister child is rendered with a tag, then that tag is dirtied.
+func TestRegister_WrappedTemplateUpdaterOnTheRequestLoop(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		withLog   bool
+		wantAlive bool // does the request loop survive?
+	}{
+		{"with logger the loop continues", true, true},
+		// Request.process recovers the panic and tears the request down; its follow-up Log
+		// emits nothing and TestServe's callback sees nil, because process consumed it.
+		{"without logger the request is torn down", false, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			jw, err := jaws.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(jw.Close)
+			logger := new(templateLogger)
+			if tt.withLog {
+				jw.Logger = logger
+			}
+			if err = jw.AddTemplateLookuper(template.Must(template.New("reg-plain").Parse(`plain`))); err != nil {
+				t.Fatal(err)
+			}
+			go jw.Serve()
+
+			tr := jawstest.NewTestRequest(jw, nil)
+			t.Cleanup(tr.Close)
+			<-tr.ReadyCh
+
+			dirty := tag.Tag("registered")
+			wrapped := NewTemplate("div", "reg-plain", tag.Tag("dot"))
+			// Build the Register Element by hand: RequestWriter.Register would run the
+			// failing update immediately, and Register.JawsRender documents that it ignores
+			// params, so NewUI would not apply the tag. This leaves the first failing update
+			// to the request loop.
+			regElem := tr.NewElement(NewRegister(wrapped))
+			regElem.Tag(dirty)
+			regElem.Freeze()
+
+			tr.BcastCh <- wire.Message{Dest: dirty, What: what.Update}
+
+			if tt.wantAlive {
+				// Wake the loop and confirm it still serves afterwards.
+				tr.InCh <- wire.WsMsg{}
+				select {
+				case <-tr.DoneCh:
+					t.Fatal("the request loop stopped although a logger was configured")
+				case <-time.After(300 * time.Millisecond):
+				}
+				if len(logger.errors) == 0 {
+					t.Fatal("expected the diagnostic to be logged")
+				}
+				for _, err := range logger.errors {
+					if !errors.Is(err, ErrElementStateUnclaimed) {
+						t.Fatalf("logged %v, want %v", err, ErrElementStateUnclaimed)
+					}
+				}
+				return
+			}
+			select {
+			case <-tr.DoneCh:
+			case <-time.After(2 * time.Second):
+				t.Fatal("timeout waiting for the request loop to tear down")
+			}
+		})
+	}
+}
+
+// TestRegister_UnwrappedTemplateUpdaterStaysUsable covers the other half of the narrowing:
+// an unwrapped Template remains a valid Register updater because its updates are a
+// documented no-op — but only RequestWriter.Register also delivers its event handlers,
+// since Register embeds jaws.Updater and therefore promotes no handler methods.
+func TestRegister_UnwrappedTemplateUpdaterStaysUsable(t *testing.T) {
+	dot := &clickCountingDot{}
+	unwrapped := NewTemplate("", "reg-plain", dot)
+
+	// The UI value itself delegates nothing: Register embeds jaws.Updater, whose method set
+	// is JawsUpdate alone, so a Template's handler methods are never promoted onto it.
+	if _, ok := any(NewRegister(unwrapped)).(jaws.ClickHandler); ok {
+		t.Fatal("Register promoted a ClickHandler; it embeds only jaws.Updater")
+	}
+
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+	logger := new(templateLogger)
+	jw.Logger = logger
+	if err = jw.AddTemplateLookuper(template.Must(template.New("reg-plain").Parse(`plain`))); err != nil {
+		t.Fatal(err)
+	}
+	go jw.Serve()
+	tr := jawstest.NewTestRequest(jw, nil)
+	t.Cleanup(func() {
+		tr.Close()
+		<-tr.DoneCh
+	})
+	<-tr.ReadyCh
+
+	var sb strings.Builder
+	rw := RequestWriter{Request: tr.Request, Writer: &sb}
+	jid := rw.Register(unwrapped)
+	if len(logger.errors) != 0 {
+		t.Fatalf("logged errors = %v, want none for an unwrapped Template", logger.errors)
+	}
+
+	// RequestWriter.Register added the concrete updater to the Element's handler list, so a
+	// browser event reaches the Template and through it the Dot.
+	// Click data is "X Y kstate name"; a bare name does not parse.
+	tr.InCh <- wire.WsMsg{Jid: jid, What: what.Click, Data: "1 2 0 btn"}
+	deadline := time.Now().Add(2 * time.Second)
+	for dot.clicks.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := dot.clicks.Load(); got != 1 {
+		t.Fatalf("clicks delivered through the handler list = %d, want 1", got)
+	}
+}
+
+// clickCountingDot counts clicks delivered through a Template's event delegation.
+type clickCountingDot struct{ clicks atomic.Int32 }
+
+func (d *clickCountingDot) JawsClick(*jaws.Element, jaws.Click) error {
+	d.clicks.Add(1)
+	return nil
+}

--- a/lib/ui/template_state_test.go
+++ b/lib/ui/template_state_test.go
@@ -91,10 +91,10 @@ func (u *delegatingUI) JawsRender(elem *jaws.Element, w io.Writer, params []any)
 
 func (u *delegatingUI) JawsUpdate(elem *jaws.Element) { u.tmpl.JawsUpdate(elem) }
 
-// TestTemplate_DelegatedRenderKeepsTheDelegatorsChild is the case that decided this design:
-// the Template's rollback is scoped to the Elements it created, so a child the delegating
-// renderer made itself is untouched. The delegate creates a nested Element before failing,
-// so the assertion is about a non-empty generation.
+// TestTemplate_DelegatedRenderKeepsTheDelegatorsChild checks that Template rollback is scoped
+// to the Elements it created, leaving a child the delegating renderer made itself untouched.
+// The delegate creates a nested Element before failing, so the assertion covers a non-empty
+// generation.
 func TestTemplate_DelegatedRenderKeepsTheDelegatorsChild(t *testing.T) {
 	for _, tt := range []struct {
 		name   string

--- a/lib/ui/template_state_test.go
+++ b/lib/ui/template_state_test.go
@@ -6,9 +6,14 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/linkdata/jaws"
+	"github.com/linkdata/jaws/jawstest"
+	"github.com/linkdata/jaws/lib/jid"
 	"github.com/linkdata/jaws/lib/tag"
+	"github.com/linkdata/jaws/lib/what"
+	"github.com/linkdata/jaws/lib/wire"
 )
 
 const templateStateTemplates = `
@@ -22,16 +27,39 @@ const templateStateTemplates = `
 
 func newStateRequest(t *testing.T) (*jaws.Jaws, *jaws.Request) {
 	t.Helper()
-	jw, rq := newCoreRequest(t)
+	return newConfiguredStateRequest(t, nil)
+}
+
+// newConfiguredStateRequest configures the Jaws before the Request exists; see
+// newConfiguredCoreRequest for why that ordering matters.
+func newConfiguredStateRequest(t *testing.T, configure func(*jaws.Jaws)) (*jaws.Jaws, *jaws.Request) {
+	t.Helper()
+	jw, rq := newConfiguredCoreRequest(t, configure)
 	if err := jw.AddTemplateLookuper(template.Must(template.New("state").Parse(templateStateTemplates))); err != nil {
 		t.Fatal(err)
 	}
 	return jw, rq
 }
 
+// ownedGeneration returns the Elements currently tracked for elem, which is the generation
+// the next update will reclaim. It reads the slot's own mutex, like the Template does.
+func ownedGeneration(t *testing.T, elem *jaws.Element) []*jaws.Element {
+	t.Helper()
+	st := templateStateOf(elem)
+	if st == nil {
+		t.Fatalf("element %v has no Template state", elem.Jid())
+	}
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	return append([]*jaws.Element(nil), st.owned...)
+}
+
 // TestTemplate_EqualValuesKeepIndependentGenerations covers what the state slot buys: one
-// Template value may back several live Elements, each with its own generation, which was
-// impossible while the ownership set lived on the widget.
+// Template value backs several live Elements, each with its own generation.
+//
+// The assertions are on Element identity rather than on a registered count. A count alone
+// cannot tell a correct update from one that reclaims the wrong wrapper's child and creates
+// a replacement for it, since both leave the same number of Elements registered.
 func TestTemplate_EqualValuesKeepIndependentGenerations(t *testing.T) {
 	_, rq := newStateRequest(t)
 
@@ -45,15 +73,42 @@ func TestTemplate_EqualValuesKeepIndependentGenerations(t *testing.T) {
 		t.Fatalf("registered elements after two renders = %d, want 4", got)
 	}
 
-	// Updating one must reclaim only its own generation.
-	tmpl.JawsUpdate(first)
-	if got := countRegistered(t, rq); got != 4 {
-		t.Fatalf("registered elements after updating one = %d, want 4", got)
+	// updateAndCheck updates one wrapper and asserts the replacement is scoped to it: its
+	// own child is reclaimed and replaced, the other wrapper's child and tracked generation
+	// are untouched. It returns the updated wrapper's fresh generation.
+	updateAndCheck := func(name string, updated, other *jaws.Element, mine, theirs []*jaws.Element) []*jaws.Element {
+		t.Helper()
+		tmpl.JawsUpdate(updated)
+
+		if !mine[0].Deleted() {
+			t.Errorf("updating the %s wrapper left its previous child %v registered", name, mine[0].Jid())
+		}
+		if theirs[0].Deleted() {
+			t.Fatalf("updating the %s wrapper deleted the other wrapper's child %v", name, theirs[0].Jid())
+		}
+		fresh := ownedGeneration(t, updated)
+		if len(fresh) != 1 || fresh[0] == mine[0] {
+			t.Fatalf("%s wrapper's generation after the update = %v, want one fresh Element", name, fresh)
+		}
+		if got := ownedGeneration(t, other); len(got) != 1 || got[0] != theirs[0] {
+			t.Fatalf("the other wrapper's generation changed to %v, want %v", got, theirs[0].Jid())
+		}
+		if got := countRegistered(t, rq); got != 4 {
+			t.Fatalf("registered elements after updating the %s wrapper = %d, want 4", name, got)
+		}
+		return fresh
 	}
-	tmpl.JawsUpdate(second)
-	if got := countRegistered(t, rq); got != 4 {
-		t.Fatalf("registered elements after updating both = %d, want 4", got)
+
+	firstGen, secondGen := ownedGeneration(t, first), ownedGeneration(t, second)
+	if len(firstGen) != 1 || len(secondGen) != 1 {
+		t.Fatalf("wrappers own %d and %d Elements, want 1 each", len(firstGen), len(secondGen))
 	}
+	if firstGen[0] == secondGen[0] {
+		t.Fatal("the two wrappers share a nested Element; their generations are not independent")
+	}
+
+	firstGen = updateAndCheck("first", first, second, firstGen, secondGen)
+	updateAndCheck("second", second, first, secondGen, firstGen)
 }
 
 // delegatingUI renders a child Element of its own and then delegates to a Template on the
@@ -142,9 +197,8 @@ func TestTemplate_DelegatedRenderKeepsTheDelegatorsChild(t *testing.T) {
 // of claiming before any side effect: a handled render failure leaves the claim in place, so
 // a later update still runs.
 func TestTemplate_DelegatedRenderClaimSurvivesHandledError(t *testing.T) {
-	jw, rq := newStateRequest(t)
 	logger := new(templateLogger)
-	jw.Logger = logger
+	_, rq := newConfiguredStateRequest(t, withLogger(logger))
 
 	dot := &ownedDot{fail: errOwnedDotCheck}
 	ui := &delegatingUI{tmpl: NewTemplate("div", "state-failafter", dot), handle: true}
@@ -188,10 +242,86 @@ func (u *contendingUI) JawsRender(elem *jaws.Element, w io.Writer, params []any)
 
 func (u *contendingUI) JawsUpdate(elem *jaws.Element) { u.first.JawsUpdate(elem) }
 
+// TestTemplate_SecondClaimRegistersNoHandler covers the one side effect
+// TestTemplate_SecondClaimOnOneElementFails cannot reach: handlers are unexported, so the
+// only way to observe that the rejected Template registered none is to deliver an event
+// and watch it not arrive.
+//
+// A bare "the handler was not called" assertion would pass even if events were broken
+// entirely, so a control Element rendered by a Template that does claim carries the same
+// handler through the same params path, and its second click doubles as the barrier
+// proving the rejected Element's click was already processed.
+func TestTemplate_SecondClaimRegistersNoHandler(t *testing.T) {
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+	if err = jw.AddTemplateLookuper(template.Must(template.New("state").Parse(templateStateTemplates))); err != nil {
+		t.Fatal(err)
+	}
+	go jw.Serve()
+	tr := jawstest.NewTestRequest(jw, nil)
+	t.Cleanup(func() {
+		tr.Close()
+		<-tr.DoneCh
+	})
+	<-tr.ReadyCh
+
+	var sb strings.Builder
+	control := &clickCountingDot{}
+	controlElem := tr.NewElement(NewTemplate("div", "state-plain", tag.Tag("control")))
+	if err = controlElem.JawsRender(&sb, []any{control}); err != nil {
+		t.Fatal(err)
+	}
+
+	// contendingUI hands params to the second Template only, so this handler is offered
+	// exclusively to the Template whose claim is rejected.
+	rejected := &clickCountingDot{}
+	ui := &contendingUI{
+		first:  NewTemplate("div", "state-plain", tag.Tag("first")),
+		second: NewTemplate("div", "state-b", tag.Tag("second")),
+		handle: true,
+	}
+	elem := tr.NewElement(ui)
+	if err = elem.JawsRender(&sb, []any{rejected}); err != nil {
+		t.Fatal(err)
+	}
+	if !errors.Is(ui.secondErr, jaws.ErrElementStateClaimed) {
+		t.Fatalf("second render = %v, want %v", ui.secondErr, jaws.ErrElementStateClaimed)
+	}
+
+	// Click data is "X Y kstate name"; a bare name does not parse.
+	click := func(j jid.Jid) { tr.InCh <- wire.WsMsg{Jid: j, What: what.Click, Data: "1 2 0 btn"} }
+	awaitClicks := func(want int32) {
+		t.Helper()
+		for deadline := time.Now().Add(2 * time.Second); time.Now().Before(deadline); {
+			if control.clicks.Load() >= want {
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+		t.Fatalf("control clicks = %d, want %d", control.clicks.Load(), want)
+	}
+
+	click(controlElem.Jid())
+	awaitClicks(1) // the params handler path works at all
+
+	click(elem.Jid())
+	// InCh is unbuffered and the loop consumes it in order, so once this second control
+	// click has been handled the preceding one must already have been.
+	click(controlElem.Jid())
+	awaitClicks(2)
+
+	if got := rejected.clicks.Load(); got != 0 {
+		t.Fatalf("clicks delivered to the rejected Template's handler = %d, want 0", got)
+	}
+}
+
 // TestTemplate_SecondClaimOnOneElementFails covers the contention path through the
 // supported shape — one renderer delegating to two Templates — and proves the claim
-// precedes every side effect: the rejected Template writes nothing, registers no tag and
-// adds no handler.
+// precedes every side effect: the rejected Template writes nothing and registers no tag.
+// TestTemplate_SecondClaimRegistersNoHandler covers the handler list.
 func TestTemplate_SecondClaimOnOneElementFails(t *testing.T) {
 	for _, tt := range []struct {
 		name   string

--- a/lib/ui/template_state_test.go
+++ b/lib/ui/template_state_test.go
@@ -1,0 +1,279 @@
+package ui
+
+import (
+	"errors"
+	"html/template"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/linkdata/jaws"
+	"github.com/linkdata/jaws/lib/tag"
+)
+
+const templateStateTemplates = `
+{{define "state-parent"}}{{$.RequestWriter.Template "" "state-leaf" $.Dot}}{{end}}
+{{define "state-leaf"}}leaf{{end}}
+{{define "state-failafter"}}{{$.RequestWriter.Template "" "state-leaf" $.Dot}}{{$.Dot.Check}}{{end}}
+{{define "state-plain"}}plain{{end}}
+{{define "state-b"}}b{{end}}
+{{define "state-span"}}{{$.RequestWriter.Span "x"}}{{end}}
+`
+
+func newStateRequest(t *testing.T) (*jaws.Jaws, *jaws.Request) {
+	t.Helper()
+	jw, rq := newCoreRequest(t)
+	if err := jw.AddTemplateLookuper(template.Must(template.New("state").Parse(templateStateTemplates))); err != nil {
+		t.Fatal(err)
+	}
+	return jw, rq
+}
+
+// TestTemplate_EqualValuesKeepIndependentGenerations covers what the state slot buys: one
+// Template value may back several live Elements, each with its own generation, which was
+// impossible while the ownership set lived on the widget.
+func TestTemplate_EqualValuesKeepIndependentGenerations(t *testing.T) {
+	_, rq := newStateRequest(t)
+
+	dot := &ownedDot{}
+	tmpl := NewTemplate("div", "state-parent", dot)
+	first := renderOwned(t, rq, tmpl)
+	second := renderOwned(t, rq, NewTemplate("div", "state-parent", dot))
+
+	// wrappers plus one nested Element each
+	if got := countRegistered(t, rq); got != 4 {
+		t.Fatalf("registered elements after two renders = %d, want 4", got)
+	}
+
+	// Updating one must reclaim only its own generation.
+	tmpl.JawsUpdate(first)
+	if got := countRegistered(t, rq); got != 4 {
+		t.Fatalf("registered elements after updating one = %d, want 4", got)
+	}
+	tmpl.JawsUpdate(second)
+	if got := countRegistered(t, rq); got != 4 {
+		t.Fatalf("registered elements after updating both = %d, want 4", got)
+	}
+}
+
+// delegatingUI renders a child Element of its own and then delegates to a Template on the
+// same Element, which Renderer.JawsRender explicitly permits.
+type delegatingUI struct {
+	tmpl     Template
+	handle   bool          // capture the delegate's error instead of propagating it
+	child    *jaws.Element // the Element this renderer created itself
+	delegErr error         // the error the delegate returned
+}
+
+func (u *delegatingUI) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err error) {
+	u.child = elem.Request.NewElement(NewSpan(testHTMLGetter("mine")))
+	if err = u.child.JawsRender(w, nil); err != nil {
+		return
+	}
+	// Buffer the delegate's output so a handled failure discards its partial markup, and
+	// emit a wrapper carrying the delegate's Jid so a later update has a real target.
+	var sb strings.Builder
+	u.delegErr = u.tmpl.JawsRender(elem, &sb, params)
+	if u.delegErr != nil && u.handle {
+		b := elem.Jid().AppendStartTagAttr(nil, "div")
+		b = append(b, '>')
+		if _, err = w.Write(append(b, "</div>"...)); err != nil {
+			return
+		}
+		return nil
+	}
+	_, err = io.WriteString(w, sb.String())
+	if err == nil {
+		err = u.delegErr
+	}
+	return
+}
+
+func (u *delegatingUI) JawsUpdate(elem *jaws.Element) { u.tmpl.JawsUpdate(elem) }
+
+// TestTemplate_DelegatedRenderKeepsTheDelegatorsChild is the case that decided this design:
+// the Template's rollback is scoped to the Elements it created, so a child the delegating
+// renderer made itself is untouched. The delegate creates a nested Element before failing,
+// so the assertion is about a non-empty generation.
+func TestTemplate_DelegatedRenderKeepsTheDelegatorsChild(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		handle bool
+		want   int // registered elements afterwards
+	}{
+		// wrapper + the delegator's own child; the delegate's nested Element is gone
+		{"handled", true, 2},
+		// NewUI additionally deletes the failed root, leaving only the delegator's child:
+		// it was created outside the writer, so nothing owns it either way
+		{"propagated", false, 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, rq := newStateRequest(t)
+
+			dot := &ownedDot{fail: errOwnedDotCheck}
+			ui := &delegatingUI{tmpl: NewTemplate("div", "state-failafter", dot), handle: tt.handle}
+			var sb strings.Builder
+			rw := RequestWriter{Request: rq, Writer: &sb}
+			err := rw.NewUI(ui)
+
+			if !errors.Is(ui.delegErr, errOwnedDotCheck) {
+				t.Fatalf("delegate error = %v, want %v", ui.delegErr, errOwnedDotCheck)
+			}
+			if tt.handle {
+				if err != nil {
+					t.Fatalf("handled render returned %v, want nil", err)
+				}
+			} else if !errors.Is(err, errOwnedDotCheck) {
+				t.Fatalf("propagated render returned %v, want %v", err, errOwnedDotCheck)
+			}
+			// The delegator created its child outside the writer, so the Template's
+			// generation never contained it and neither rollback path can reach it.
+			if ui.child.Deleted() {
+				t.Fatal("the Template's rollback deleted a child the delegator created itself")
+			}
+			if got := countRegistered(t, rq); got != tt.want {
+				t.Fatalf("registered elements = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTemplate_DelegatedRenderClaimSurvivesHandledError checks the documented consequence
+// of claiming before any side effect: a handled render failure leaves the claim in place, so
+// a later update still runs.
+func TestTemplate_DelegatedRenderClaimSurvivesHandledError(t *testing.T) {
+	jw, rq := newStateRequest(t)
+	logger := new(templateLogger)
+	jw.Logger = logger
+
+	dot := &ownedDot{fail: errOwnedDotCheck}
+	ui := &delegatingUI{tmpl: NewTemplate("div", "state-failafter", dot), handle: true}
+	var sb strings.Builder
+	rw := RequestWriter{Request: rq, Writer: &sb}
+	if err := rw.NewUI(ui); err != nil {
+		t.Fatal(err)
+	}
+
+	// The claim persists, so this update executes rather than reporting an unclaimed slot.
+	dot.setFail(nil)
+	elem := rq.GetElementByJid(jaws.Jid(1))
+	ui.JawsUpdate(elem)
+	if len(logger.errors) != 0 {
+		t.Fatalf("logged errors = %v, want none: the claim should have survived", logger.errors)
+	}
+}
+
+// contendingUI delegates to two Templates on one Element, which the one-claimer rule
+// rejects for the second.
+type contendingUI struct {
+	first, second Template
+	secondErr     error
+	handle        bool
+}
+
+func (u *contendingUI) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err error) {
+	if err = u.first.JawsRender(elem, w, nil); err != nil {
+		return
+	}
+	var sb strings.Builder
+	u.secondErr = u.second.JawsRender(elem, &sb, params)
+	if sb.Len() > 0 {
+		return errors.New("the rejected Template wrote output")
+	}
+	if u.handle {
+		return nil
+	}
+	return u.secondErr
+}
+
+func (u *contendingUI) JawsUpdate(elem *jaws.Element) { u.first.JawsUpdate(elem) }
+
+// TestTemplate_SecondClaimOnOneElementFails covers the contention path through the
+// supported shape — one renderer delegating to two Templates — and proves the claim
+// precedes every side effect: the rejected Template writes nothing, registers no tag and
+// adds no handler.
+func TestTemplate_SecondClaimOnOneElementFails(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		handle bool
+	}{
+		{"handled", true},
+		{"propagated", false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, rq := newStateRequest(t)
+
+			firstDot := tag.Tag("first")
+			secondDot := tag.Tag("second")
+			ui := &contendingUI{
+				first:  NewTemplate("div", "state-plain", firstDot),
+				second: NewTemplate("div", "state-b", secondDot),
+				handle: tt.handle,
+			}
+			var sb strings.Builder
+			rw := RequestWriter{Request: rq, Writer: &sb}
+			err := rw.NewUI(ui, tag.Tag("param"))
+
+			if !errors.Is(ui.secondErr, jaws.ErrElementStateClaimed) {
+				t.Fatalf("second render = %v, want %v", ui.secondErr, jaws.ErrElementStateClaimed)
+			}
+			if tt.handle {
+				if err != nil {
+					t.Fatalf("handled render returned %v, want nil", err)
+				}
+				if got := len(rq.GetElements(firstDot)); got != 1 {
+					t.Fatalf("elements tagged by the first Template = %d, want 1", got)
+				}
+			} else if !errors.Is(err, jaws.ErrElementStateClaimed) {
+				t.Fatalf("propagated render returned %v, want %v", err, jaws.ErrElementStateClaimed)
+			}
+			// The rejected Template must not have registered its Dot tag or the params tag.
+			if got := len(rq.GetElements(secondDot)); got != 0 {
+				t.Fatalf("elements tagged by the rejected Template = %d, want 0", got)
+			}
+			if got := len(rq.GetElements(tag.Tag("param"))); got != 0 {
+				t.Fatalf("elements tagged from the rejected render's params = %d, want 0", got)
+			}
+		})
+	}
+}
+
+// TestTemplate_UpdateToleratesTypedNilElementState checks the cleanup walk against a state
+// slot holding a typed nil that satisfies elementOwner through a promoted method. Matching
+// the slot to *templateState rather than to elementOwner is what keeps this from
+// dereferencing a nil receiver.
+func TestTemplate_UpdateToleratesTypedNilElementState(t *testing.T) {
+	_, rq := newStateRequest(t)
+
+	// The nested child is a Span rather than a nested Template, whose Element would have
+	// claimed its own slot already.
+	dot := &ownedDot{}
+	tmpl := NewTemplate("div", "state-span", dot)
+	elem := renderOwned(t, rq, tmpl)
+	if got := countRegistered(t, rq); got != 2 {
+		t.Fatalf("registered elements after render = %d, want 2", got)
+	}
+
+	child := rq.GetElementByJid(elem.Jid() + 1)
+	if child == nil {
+		t.Fatal("expected the nested span Element")
+	}
+	if err := jaws.SetElementState(child, (*Container)(nil)); err != nil {
+		t.Fatal(err)
+	}
+
+	tmpl.JawsUpdate(elem) // must not panic walking the typed-nil state
+	if got := countRegistered(t, rq); got != 2 {
+		t.Fatalf("registered elements after update = %d, want 2", got)
+	}
+}
+
+// TestTemplate_UnwrappedUpdateStaysSilent pins the path the missing-claim diagnostic does
+// not apply to: an unwrapped Template returns before the state slot is consulted.
+func TestTemplate_UnwrappedUpdateStaysSilent(t *testing.T) {
+	_, rq := newStateRequest(t)
+
+	// No logger is configured, so MustLog would panic if this reported anything.
+	tmpl := NewTemplate("", "state-plain", tag.Tag("dot"))
+	tmpl.JawsUpdate(rq.NewElement(tmpl))
+}

--- a/lib/ui/testhelpers_test.go
+++ b/lib/ui/testhelpers_test.go
@@ -22,16 +22,34 @@ func mustMatch(t *testing.T, pattern, got string) {
 
 func newCoreRequest(t *testing.T) (*jaws.Jaws, *jaws.Request) {
 	t.Helper()
+	return newConfiguredCoreRequest(t, nil)
+}
+
+// newConfiguredCoreRequest runs configure against the fresh [jaws.Jaws] before the
+// [jaws.Request] exists, which the Jaws documentation requires of every exported
+// configuration field: they are ordinary fields, so setting one after Requests are
+// created is an unsynchronized write. Tests that need a Logger use this rather than
+// assigning jw.Logger to a Jaws that already has a Request.
+func newConfiguredCoreRequest(t *testing.T, configure func(*jaws.Jaws)) (*jaws.Jaws, *jaws.Request) {
+	t.Helper()
 	jw, err := jaws.New()
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(jw.Close)
+	if configure != nil {
+		configure(jw)
+	}
 	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
 	if rq == nil {
 		t.Fatal("nil request")
 	}
 	return jw, rq
+}
+
+// withLogger returns a configure func for [newConfiguredCoreRequest] that installs logger.
+func withLogger(logger *templateLogger) func(*jaws.Jaws) {
+	return func(jw *jaws.Jaws) { jw.Logger = logger }
 }
 
 func newCoreSessionBoundRequest(t *testing.T) (*jaws.Jaws, *jaws.Request) {


### PR DESCRIPTION
Fixes the container-reuse regression #221 introduced.

## The regression

`ContainerHelper.reconcile` keys its reuse pool on `childElem.UI()` — **value equality**. #221 gave `ui.Template` per-Element ownership state, which forced it to become a pointer, so a container whose `JawsContains` rebuilds `ui.NewTemplate(...)` children on every call stopped matching the pool. Every update removed and re-appended the entire collection: new Jids, full DOM churn, browser work proportional to the collection rather than to the change.

No test caught it, which is why it shipped. `TestContainer_RebuiltTemplateChildrenAreReused` is that test: it asserts child Jids are unchanged across updates and that an unchanged collection queues no `Append`/`Remove`/`Order`. Re-pointerising `NewTemplate` in a throwaway worktree fails it on the first update (`child 0 Jid = Jid.5, want Jid.2`).

## The fix

The Element is the natural home for state keyed to an Element, so core gains one slot for it and `Template` goes back to a plain comparable value.

```go
func ElementState(elem *Element) (state any)
func SetElementState(elem *Element, state any) error   // ErrElementStateClaimed / ErrElementStateNil
```

Design points that took some working out:

- **Loading and claiming are separate**, so contention is reported rather than absorbed. A get-or-create returning the occupant would silently let a second Template mutate the first's generation and delete Elements it doesn't own. A second claim fails even for state of the same dynamic type — same type is not the same owner.
- **Nil is rejected.** `data any` uses a nil interface to mean *unclaimed*, so accepting `SetElementState(elem, nil)` would report success while leaving the slot claimable, hollowing out claim-once. A typed nil is a non-nil interface and does claim the slot. The nil-argument check precedes the occupancy check.
- **Package-level, not methods.** `ui.With` embeds `*Element` and `ui.RequestWriter`, so any method returning a value is callable from a template; `{{$.Element.SetElementState $.Dot}}` would let a template claim the slot out from under its renderer. `html/template` cannot call a package-level function.
- **Claiming happens only in `JawsRender`**, before tag registration, handler registration and any write, so a contended Element fails having changed *nothing* — asserted, not just claimed.
- **`execute` takes the state as a parameter.** `pageTemplate.JawsRender` bypasses `render`, so without that the page's nested UI would have been tracked by nothing at all; making it a parameter means the compiler asks each entry point.
- **The ownership walk matches `*templateState` specifically**, not any `elementOwner`. The slot legitimately holds whatever a renderer put there, so a typed nil satisfying `elementOwner` through a promoted method — `(*ui.Container)(nil)` — would have been dereferenced during a parent Template's cleanup.

## Released behaviour that narrows

Both follow from `Template` previously being stateless, and both are in the commit message for release notes:

1. **Any repeated Template render on one Element** now fails the second claim with `ErrElementStateClaimed` — two distinct Templates, two equal ones, or the same value twice. `Renderer.JawsRender` permits delegation, so a composite renderer emitting several unwrapped partials this way was legitimate. Migration: combine the partials under one claiming Template, or give each its own Element, which a nested `{{$.Template ...}}` already does.
2. **A wrapped Template's `JawsUpdate` without a claim** reports `ErrElementStateUnclaimed` through `MustLog` — which **panics** when no `Jaws.Logger` is configured, not a silent no-op. So a wrapped Template cannot be a `Register`/`NewRegister`/`RequestWriter.Register` updater. An unwrapped one still can: its updates are a documented no-op, though only `RequestWriter.Register` also delivers its event handlers, since `Register` embeds `jaws.Updater` and promotes no handler methods.

Delegated rendering and updating must use the same UI widget. For `Template` values, that means values equal under `==`; using an unequal Template value for `JawsUpdate` is unsupported. Element state storage does not relax that lifecycle contract.

The `MustLog` outcome differs by call path and is tested per path: a template action has its panic recovered by `html/template` into a render error; a direct `rw.Register` call lets it escape; on the request loop `Request.process` consumes it and tears the request down, with `TestServe`'s callback seeing nil precisely because process already consumed it.

## Numbers

`-benchtime=200x -count=6`, arm64, baseline pinned to `9b02d46` and every benchmark name verified present in both outputs before benchstat:

```
ContainerOfTemplatesUpdate   (200 rebuilt children, unchanged collection)
  sec/op     1220.08µ ± 3%  ->  73.62µ ± 35%   -93.97% (p=0.002 n=6)
  B/op        194.93Ki ± 0%  ->  28.48Ki ±  0%  -85.39% (p=0.002 n=6)
  allocs/op     4046.0 ± 0%  ->    406.0 ±  0%  -89.97% (p=0.002 n=6)

ContainerOfStableChildrenUpdate  (already reusable before this change)
  sec/op        31.19µ ± 12%  ->  28.53µ ± 11%   ~ (p=0.132 n=6)
  allocs/op      205.0 ±  0%  ->   205.0 ±  0%   ~ (all equal)

ElementCreateBatch  (corrected timer; the cost every Element pays for the slot)
  sec/op         2.077µ       ->   2.240µ         +7.87% (p=0.002 n=6)
  B/op          4.000Ki       ->  5.000Ki        +25.00% (p=0.002 n=6)   # 16 B/Element
  allocs/op       64.00       ->     64.00          ~ (all equal)

TemplateUpdateOwnedCleanup/children=1000  (each rendered Template allocates its state)
  sec/op         3.650m ± 2%  ->  3.708m ±  2%   ~ (p=0.180 n=6)
  allocs/op      26.79k ± 0%  ->  27.79k ±  0%  +3.73% (p=0.002 n=6)
```

The two costs are real and measured rather than assumed: two words per Element for the slot, and one allocation per rendered Template for its state. Both are dwarfed by the container fix, and the cleanup path's *time* is unchanged. Small-generation cleanup variants (0 and 8 children) are included because the 1000-child case swamps any fixed per-update cost.

## Also

- `TestElementState_*` cover claim-once, both sentinels and their precedence, typed nil, per-Element independence, and concurrent claims under `-race` with exactly one winner.
- Rendering delegation tests verify that a delegator's own child survives the Template's rollback, and that a claim persists after a handled render error so an equal Template value can later update the Element. Delegating `JawsUpdate` to an unequal Template value is unsupported.
- Two existing tests needed real migration, not just an added render: `TestTemplate_UpdateLogsExecuteError`'s template always fails, so it moves to a render-succeeds-then-update-fails fixture, and `TestTemplate_RenderUpdateEventAndHelpers` updated an unrendered Template with no logger, which would now panic.
- Docs: `UI` multiplicity keeps its concrete-type opt-in rule (statelessness alone grants nothing), `Renderer.JawsRender` gains the delegation note, and `lib/ui/doc.go`'s canonical classification moves `Template` back to the value/multi-Element group. The public API, README and tracked jaws skill now state the same-widget update contract, exact `Dot` dynamic-type and nil-interface rules, `Register`'s updater-render behavior, and the unenforced `Element` provenance precondition.

Not addressed here, deliberately: tag resolution/snapshotting (#224) and generalising per-Element state to the other by-value widget candidates (#225).

Gate run locally in `build.yml` order: `go generate` (tree unchanged), `go vet`, `gofmt`, `staticcheck`, `golangci-lint` (0 issues), `gosec`, both test legs with `JAWS_REQUIRE_NODE=1`, coverage (`lib/ui` still 100%), `go build -v`, the debug-tag leg, and `go doc` on every symbol whose contract this touches. The 386 job cannot execute on this arm64 host, so it was verified by compiling.
