### PR TITLE
docs: clarify HasTag exact-key contract

### DIFF
--- a/element.go
+++ b/element.go
@@ -109,10 +109,11 @@ func (elem *Element) Tag(tags ...any) {
 	}
 }
 
-// HasTag returns true if this Element has the given tag.
+// HasTag reports whether this Element has tagValue.
 //
-// It reports false for a deleted Element. tagValue is not expanded; see
-// [Request.HasTag].
+// It reports false for a deleted Element. This is the advanced exact-key lookup
+// described by [Request.HasTag]: tagValue is not expanded or validated, and an
+// invalid value may panic.
 func (elem *Element) HasTag(tagValue any) bool {
 	return !elem.deleted.Load() && elem.Request.HasTag(elem, tagValue)
 }

--- a/request.go
+++ b/request.go
@@ -840,10 +840,14 @@ func (rq *Request) hasTagLocked(elem *Element, tagValue any) bool {
 
 // HasTag reports whether elem has tagValue in rq.
 //
-// tagValue is looked up as a single registered key and is not expanded, so passing a
-// [tag.TagGetter] or a tag slice reports false even when its expanded keys are
-// registered. Use [Request.GetElements], which expands, or [Request.TagsOf] to see the
-// registered keys themselves.
+// HasTag is an advanced operation for inspecting one already-expanded tag key.
+// It uses tagValue directly as a map key without expanding or validating it. Callers
+// should normally pass a key returned by [Request.TagsOf] or [tag.TagExpand]. Invalid
+// values may panic; in particular, a value that is not comparable at runtime panics.
+//
+// Passing a [tag.TagGetter] tests that value itself, not the keys returned by
+// [tag.TagGetter.JawsGetTag]. Use [Request.GetElements] when tagValue should be
+// expanded.
 func (rq *Request) HasTag(elem *Element, tagValue any) (yes bool) {
 	rq.mu.RLock()
 	yes = rq.hasTagLocked(elem, tagValue)


### PR DESCRIPTION
## Summary

- document `Request.HasTag` as an advanced exact-key inspection operation
- state that it skips tag expansion and validation, including the panic risk for runtime-non-comparable values
- align `Element.HasTag` with the same contract and direct expanding lookups to `GetElements`

All in-tree call sites were audited: each is safe for direct map lookup. One test deliberately passes a comparable unexpanded `TagGetter` to verify exact-key behavior; all other calls use expanded keys.

## Verification

- `go generate ./...`
- `go vet ./...`
- `gofmt -l .`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`
- `JAWS_REQUIRE_NODE=1 go test -race -coverprofile=coverage.out ./...`
- `JAWS_REQUIRE_NODE=1 go test ./...`
- `go build -v ./...`

The CI-only 386 test was attempted locally but cannot execute an x86 binary on this ARM64 host; the amd64 GitHub runner covers that leg.