### PR TITLE
docs: add tag design and lifecycle guide

### DIFF
--- a/element.go
+++ b/element.go
@@ -458,15 +458,15 @@ func (elem *Element) validChildElement(operation string, child *Element) (ok boo
 	return false
 }
 
-// ApplyParams parses the parameters passed to UI() when creating a new [Element],
-// adding UI tags, adding any additional event handlers found.
+// ApplyParams applies UI-helper parameters to elem.
 //
-// Returns the list of HTML attributes found, if any.
+// For a live Element, it registers tags and event handlers and returns any HTML
+// attributes found by [ParseParams]. A deleted Element applies nothing and returns nil.
 //
-// On a live frozen Element, event-handler params are logged and dropped in production
-// with a configured [Jaws.Logger], while tags and attributes are still processed.
-// Debug builds and servers without a Logger panic first. Params without event handlers
-// continue processing normally.
+// On a live, frozen Element, handler params are logged and dropped in production when
+// [Jaws.Logger] is configured, after which tags and attributes are processed. Debug
+// builds and servers without a Logger panic first. Params without handlers continue
+// normally.
 func (elem *Element) ApplyParams(params []any) (attrs []template.HTMLAttr) {
 	tags, handlers, rawAttrs := ParseParams(params)
 	if !elem.deleted.Load() {
@@ -480,32 +480,32 @@ func (elem *Element) ApplyParams(params []any) (attrs []template.HTMLAttr) {
 	return
 }
 
-// ApplyGetter examines getter and resolves its tag candidate.
+// ApplyGetter applies the tag and handler interfaces exposed by getter to elem.
 //
 // If getter implements [tag.TagGetter], the candidate is the value returned by
 // [tag.TagGetter.JawsGetTag]; otherwise the candidate is getter itself. Eligible
 // candidates — TagGetter values, supported tag slices and runtime-comparable
 // values — are passed to [Element.Tag] for normal expansion and validation.
 // That expansion may invoke JawsGetTag again when the candidate is itself a
-// TagGetter or contains one. Other non-comparable candidates are not automatically
-// tagged, matching [ParseParams].
+// TagGetter or a []any containing one. Other non-comparable candidates are not
+// automatically tagged.
 //
-// If getter is an [InputHandler], [ClickHandler], [ContextMenuHandler] or
-// [InitialHTMLAttrHandler], relevant values are added to the [Element].
+// If getter implements [InputHandler], [ClickHandler], or [ContextMenuHandler], it is
+// added as an event handler. attrs contains any non-empty attribute returned by
+// [InitialHTMLAttrHandler].
 //
-// The returned value is the candidate considered for tagging, not confirmation that
-// any expanded key was registered. It is nil if getter or its candidate is a nil
-// interface, or if the candidate is ineligible for tag expansion. A non-nil candidate
-// accepted by [tag.TagExpand] may be retained for later dirtying; TagGetter-derived
-// candidates rely on [tag.TagGetter]'s stable tag identity. attrs holds any initial
-// HTML attributes provided by InitialHTMLAttrHandler.
+// The returned tagValue does not confirm registration. It is nil if getter or its
+// candidate is a nil interface, or if the candidate is ineligible for expansion. A
+// successfully expandable tagValue may be retained for later dirtying only while it
+// expands to the same keys. Retained slices must not be mutated concurrently with
+// expansion; candidates derived from a [tag.TagGetter] rely on its stable-identity
+// contract.
 //
 // If the [Element] is already frozen and getter is an event handler, the handler
 // is not added: in production with a [Jaws.Logger] configured this is logged and
 // initial-attribute and tag processing still occur, while debug builds and servers
-// without a Logger panic via reportMisuse, aborting before them. A non-event-handler
-// getter never calls reportMisuse, so its initial-attribute and tag processing always
-// occur.
+// without a Logger panic before that processing. For a non-event-handler getter,
+// initial-attribute and tag processing still occur after freezing.
 func (elem *Element) ApplyGetter(getter any) (tagValue any, attrs []template.HTMLAttr) {
 	if getter != nil {
 		tagValue = getter

--- a/element.go
+++ b/element.go
@@ -102,7 +102,10 @@ func (elem *Element) AddHandlers(h ...any) {
 	elem.appendHandlers(h...)
 }
 
-// Tag adds the given tags to the [Element].
+// Tag associates elem with tags.
+//
+// It is shorthand for [Request.Tag]. A deleted Element ignores the call without
+// expanding tags.
 func (elem *Element) Tag(tags ...any) {
 	if !elem.deleted.Load() {
 		elem.Request.Tag(elem, tags...)
@@ -460,10 +463,10 @@ func (elem *Element) validChildElement(operation string, child *Element) (ok boo
 //
 // Returns the list of HTML attributes found, if any.
 //
-// Handlers found in params are added only while the [Element] is mutable; after
-// it is frozen ([Element.JawsRender] returning or [Element.Freeze]) they are
-// dropped (debug builds panic), though tags and HTML attributes are still
-// processed.
+// On a live frozen Element, event-handler params are logged and dropped in production
+// with a configured [Jaws.Logger], while tags and attributes are still processed.
+// Debug builds and servers without a Logger panic first. Params without event handlers
+// continue processing normally.
 func (elem *Element) ApplyParams(params []any) (attrs []template.HTMLAttr) {
 	tags, handlers, rawAttrs := ParseParams(params)
 	if !elem.deleted.Load() {
@@ -490,11 +493,12 @@ func (elem *Element) ApplyParams(params []any) (attrs []template.HTMLAttr) {
 // If getter is an [InputHandler], [ClickHandler], [ContextMenuHandler] or
 // [InitialHTMLAttrHandler], relevant values are added to the [Element].
 //
-// The returned value is the candidate that was passed for tagging, not confirmation
-// that every expanded key was registered; it is nil if getter was nil or its candidate
-// was not usable as a tag. Callers may retain it for later dirtying; what makes that
-// safe is [tag.TagGetter]'s idempotent tag identity. attrs holds any initial HTML
-// attributes provided by InitialHTMLAttrHandler.
+// The returned value is the candidate considered for tagging, not confirmation that
+// any expanded key was registered. It is nil if getter or its candidate is a nil
+// interface, or if the candidate is ineligible for tag expansion. A non-nil candidate
+// accepted by [tag.TagExpand] may be retained for later dirtying; TagGetter-derived
+// candidates rely on [tag.TagGetter]'s stable tag identity. attrs holds any initial
+// HTML attributes provided by InitialHTMLAttrHandler.
 //
 // If the [Element] is already frozen and getter is an event handler, the handler
 // is not added: in production with a [Jaws.Logger] configured this is logged and

--- a/jaws.go
+++ b/jaws.go
@@ -10,6 +10,13 @@
 // methods live in [github.com/linkdata/jaws/lib/ui], and value binding lives in
 // [github.com/linkdata/jaws/lib/bind].
 //
+// # Tags
+//
+// Tags associate [Element] values with application data and logical signals, and
+// address those Elements for dirtying, broadcasts and lookup. See
+// [github.com/linkdata/jaws/lib/tag] for tag selection, expansion, registration
+// and lifetime.
+//
 // # Locking
 //
 // The package uses a single, acyclic lock hierarchy. When more than one of these

--- a/jaws.go
+++ b/jaws.go
@@ -12,9 +12,9 @@
 //
 // # Tags
 //
-// Tags associate [Element] values with application data and logical signals, and
-// address those Elements for dirtying, broadcasts and lookup. See
-// [github.com/linkdata/jaws/lib/tag] for tag selection, expansion, registration
+// Tags associate [Element] values with application data or logical signals for
+// targeted dirtying, broadcasts, and lookup. See
+// [github.com/linkdata/jaws/lib/tag] for tag selection, expansion, registration,
 // and lifetime.
 //
 // # Locking

--- a/lib/tag/doc.go
+++ b/lib/tag/doc.go
@@ -43,13 +43,13 @@
 // and equal to themselves; see [TagExpand] for the accepted inputs and error behavior.
 //
 // [TagGetter] defines expansion only; implementing it does not by itself register an
-// Element. [TagGetter.JawsGetTag] may return nil during an explicitly documented
-// initialization phase. After its first non-nil result, later calls must expand to
-// the same set of keys. Expansion receives no rendering or Request context, may occur
-// before a widget renders, and has no call-count guarantee. Nil expands to no keys.
-// Passing a nil-phase value through the normal expanding registration, dirtying or
-// broadcast APIs has no later effect when initialization completes. See [TagGetter]
-// for returned-container and concurrency requirements.
+// Element. [TagGetter.JawsGetTag] may return a nil interface during an explicitly
+// documented initialization phase. After its first non-nil result, later calls must
+// expand to the same set of keys. Expansion receives no rendering or Request context,
+// may occur before a widget renders, and has no call-count guarantee. A nil interface
+// expands to no keys. Passing a nil-phase value through the normal expanding
+// registration, dirtying or broadcast APIs has no later effect when initialization
+// completes. See [TagGetter] for returned-container and concurrency requirements.
 //
 // [github.com/linkdata/jaws.Request.Tag] and the normal targeting APIs apply the same
 // expansion. A shared group key returned by [TagGetter.JawsGetTag] therefore also
@@ -60,10 +60,10 @@
 //
 // [github.com/linkdata/jaws.Request.Tag] and
 // [github.com/linkdata/jaws.Element.Tag] expand and register tags. Registration is
-// additive: tags may be added during rendering or updating and remain until the
-// Element is removed or its Request ends. Prefer registering known dependencies
-// during initial rendering. Add one during an update only when it is discovered
-// later and remains valid for the Element's lifetime.
+// additive: tags may be added during rendering or updating and remain active until
+// the Element is removed or its Request ends. Prefer registering known dependencies
+// during initial rendering. Add one during an update only when it is discovered later
+// and remains valid for the Element's lifetime.
 //
 // Adding a tag does not schedule an update or change an operation whose targets were
 // already selected. Register a required dependency before calling Dirty or Broadcast;

--- a/lib/tag/doc.go
+++ b/lib/tag/doc.go
@@ -13,9 +13,9 @@
 //
 // Prefer stable identities derived from the authoritative application data being
 // rendered. Use a pointer to that data when a widget depends on the object as a
-// whole. Use a distinct comparable wrapper type when independently changing aspects
-// of one object need separate keys. When no data object provides an identity, use a
-// named empty struct for a shared signal.
+// whole. Use distinct comparable wrapper types for independently changing parts of
+// one object. When no data object provides an identity, use a named empty struct for
+// a shared signal.
 //
 // For example, a widget displaying a user's name can listen both to the user and
 // specifically to the name:
@@ -42,19 +42,18 @@
 // [TagGetter] values into unique, usable keys. Keys must be comparable at runtime
 // and equal to themselves; see [TagExpand] for the accepted inputs and error behavior.
 //
-// [TagGetter] defines expansion only; implementing it does not by itself register an
-// Element. [TagGetter.JawsGetTag] may return a nil interface during an explicitly
-// documented initialization phase. After its first non-nil result, later calls must
-// expand to the same set of keys. Expansion receives no rendering or Request context,
-// may occur before a widget renders, and has no call-count guarantee. A nil interface
-// expands to no keys. Passing a nil-phase value through the normal expanding
-// registration, dirtying or broadcast APIs has no later effect when initialization
-// completes. See [TagGetter] for returned-container and concurrency requirements.
+// [TagGetter] controls how a value expands; implementing it does not register an
+// Element. [TagGetter.JawsGetTag] may return a nil interface during a documented
+// initialization phase. A nil result expands to no keys, and later initialization
+// does not affect earlier registration, dirtying, or broadcasts. After the first
+// non-nil result, every call must expand to the same key set. Expansion receives no
+// Request or rendering context, has no call-count guarantee, and may occur before
+// rendering. See [TagGetter] for requirements on returned values and concurrency.
 //
-// [github.com/linkdata/jaws.Request.Tag] and the normal targeting APIs apply the same
-// expansion. A shared group key returned by [TagGetter.JawsGetTag] therefore also
-// broadens Dirty(value) to that group. Register group dependencies separately when
-// item-level dirtying must remain narrow.
+// [github.com/linkdata/jaws.Request.Tag] and the normal targeting APIs expand inputs
+// in the same way. Returning a shared group key from [TagGetter.JawsGetTag] therefore
+// causes dirtying that value to target the group too. Register group dependencies
+// separately when item-level dirtying must remain narrow.
 //
 // # Registration and use
 //
@@ -70,8 +69,8 @@
 // do not rely on a later registration observing an earlier operation.
 //
 // JaWS does not remove individual tag associations. Design each registered key to
-// remain a valid dependency for the Element's lifetime. Removing or unregistering the
-// Element removes all of its associations.
+// remain a valid dependency for the Element's lifetime. Removing the Element removes
+// all of its associations.
 //
 // [github.com/linkdata/jaws.Request.TagsOf] returns an Element's registered keys.
 // [github.com/linkdata/jaws.Request.HasTag] is an advanced test for one

--- a/lib/tag/doc.go
+++ b/lib/tag/doc.go
@@ -1,13 +1,80 @@
-// Package tag expands JaWS tag values into comparable keys that identify
-// elements during dirtying, broadcasts and event routing.
+// Package tag expands JaWS tag values into keys used to associate elements with
+// application dependencies.
 //
-// [TagExpand] rejects expanded key values that cannot be matched reliably as
-// tags, including values whose static type is comparable but whose runtime
-// contents are not, and otherwise admissible values containing NaN that do not
-// equal themselves.
+// Tags associate [github.com/linkdata/jaws.Element] values with the application
+// state and logical signals on which their output or tag-addressed behavior
+// depends. After changing state, applications pass the corresponding keys to
+// [github.com/linkdata/jaws.Request.Dirty] to schedule updates of matching Elements
+// across live Requests, or use them as destinations for
+// [github.com/linkdata/jaws.Jaws.Broadcast] and its helpers. A tag does not observe
+// application state or cause an update by itself.
 //
-// [TagGetter] defines the contract an object implements to report its own tags,
-// including the idempotent tag identity every implementation owes while its tags are
-// registered on a live element. Expansion takes no request context: a tag value
-// expands the same way regardless of which request or goroutine expands it.
+// # Choosing tags
+//
+// Prefer stable identities derived from the authoritative application data being
+// rendered. Use a pointer to that data when a widget depends on the object as a
+// whole. Use a distinct comparable wrapper type when independently changing aspects
+// of one object need separate keys. When no data object provides an identity, use a
+// named empty struct for a shared signal.
+//
+// For example, a widget displaying a user's name can listen both to the user and
+// specifically to the name:
+//
+//	type UserData struct {
+//		Name string
+//	}
+//	type userNameTag struct{ User *UserData }
+//	type clockTag struct{}
+//
+//	nameElem.Tag(user, userNameTag{User: user})
+//	clockElem.Tag(clockTag{})
+//
+//	rq.Dirty(userNameTag{User: user}) // the name changed
+//	rq.Dirty(user)                    // the user was deleted or changed as a whole
+//	rq.Dirty(clockTag{})               // the displayed time changed
+//
+// Name a tag for the dependency it identifies, not the event that dirties it;
+// prefer userNameTag to userDataNameChange.
+//
+// # Expansion and TagGetter
+//
+// [TagExpand] recursively flattens tag keys, []Tag and []any collections, and
+// [TagGetter] values into unique, usable keys. Keys must be comparable at runtime
+// and equal to themselves; see [TagExpand] for the accepted inputs and error behavior.
+//
+// [TagGetter] defines expansion only; implementing it does not by itself register an
+// Element. [TagGetter.JawsGetTag] may return nil during an explicitly documented
+// initialization phase. After its first non-nil result, later calls must expand to
+// the same set of keys. Expansion receives no rendering or Request context, may occur
+// before a widget renders, and has no call-count guarantee. Nil expands to no keys.
+// Passing a nil-phase value through the normal expanding registration, dirtying or
+// broadcast APIs has no later effect when initialization completes. See [TagGetter]
+// for returned-container and concurrency requirements.
+//
+// [github.com/linkdata/jaws.Request.Tag] and the normal targeting APIs apply the same
+// expansion. A shared group key returned by [TagGetter.JawsGetTag] therefore also
+// broadens Dirty(value) to that group. Register group dependencies separately when
+// item-level dirtying must remain narrow.
+//
+// # Registration and use
+//
+// [github.com/linkdata/jaws.Request.Tag] and
+// [github.com/linkdata/jaws.Element.Tag] expand and register tags. Registration is
+// additive: tags may be added during rendering or updating and remain until the
+// Element is removed or its Request ends. Prefer registering known dependencies
+// during initial rendering. Add one during an update only when it is discovered
+// later and remains valid for the Element's lifetime.
+//
+// Adding a tag does not schedule an update or change an operation whose targets were
+// already selected. Register a required dependency before calling Dirty or Broadcast;
+// do not rely on a later registration observing an earlier operation.
+//
+// JaWS does not remove individual tag associations. Design each registered key to
+// remain a valid dependency for the Element's lifetime. Removing or unregistering the
+// Element removes all of its associations.
+//
+// [github.com/linkdata/jaws.Request.TagsOf] returns an Element's registered keys.
+// [github.com/linkdata/jaws.Request.HasTag] is an advanced test for one
+// already-expanded key; it does not expand or validate its argument, and invalid
+// values may panic. [github.com/linkdata/jaws.Request.GetElements] expands its input.
 package tag

--- a/lib/tag/tag.go
+++ b/lib/tag/tag.go
@@ -181,6 +181,8 @@ func expand(depth int, tagValue any, result []any, active []any) ([]any, error) 
 		int, int8, int16, int32, int64,
 		uint, uint8, uint16, uint32, uint64, key.Key,
 		float32, float64, bool:
+		// Reject these exact types to catch common accidental tags while still
+		// allowing named domain types with the same underlying representation.
 		return result, errIllegalTagType{tag: tagValue}
 	default:
 		return addTag(result, data)
@@ -189,30 +191,30 @@ func expand(depth int, tagValue any, result []any, active []any) ([]any, error) 
 
 // TagExpand expands tagValue into a flat list of unique, usable tag keys.
 //
-// tagValue may be nil, a [Tag], []Tag, []any, a [TagGetter] or another value that is
+// tagValue may be nil, a [Tag], []Tag, []any, a [TagGetter], or another value that is
 // comparable at runtime and equals itself. A nil interface contributes no keys. A
 // typed nil is a non-nil interface and follows the normal rules for its dynamic type,
-// including JawsGetTag dispatch when it implements [TagGetter]. The predeclared string,
-// bool, signed integer, unsigned integer other than uintptr, and floating-point types
-// are rejected with [ErrIllegalTagType], as are [template.HTML], [template.HTMLAttr],
-// [jid.Jid] and [key.Key]. This catches common accidental tags. An expanded key value
-// that is not comparable at runtime or does not equal itself is rejected with
-// [ErrNotUsableAsTag] (which also matches [ErrNotComparable] via [errors.Is]). Expansion
-// that exceeds the nesting-depth or total-count limits is rejected with [ErrTooManyTags].
+// including dispatch to [TagGetter.JawsGetTag] when it implements [TagGetter].
+//
+// The predeclared string, bool, signed integer, unsigned integer other than uintptr,
+// and floating-point types are rejected with [ErrIllegalTagType], as are
+// [template.HTML], [template.HTMLAttr], [jid.Jid] and [key.Key]. An unusable expanded
+// key is rejected with [ErrNotUsableAsTag], which also matches [ErrNotComparable]
+// under errors.Is. Expansion that exceeds the nesting-depth or total-count limits is
+// rejected with [ErrTooManyTags].
 //
 // On error, result contains the tags expanded before the failure. If an expanded
 // value is not usable as a tag key, result is nil and err matches
 // [ErrNotUsableAsTag].
 //
-// A single call may invoke a [TagGetter] more than once when the same value is
-// reached at several points in the graph, and the same value may be expanded again by
-// any later call. When a cycle is closed, its participating [TagGetter] values are
-// treated as candidate keys and must themselves be usable as tags. Implementations
-// must therefore satisfy [TagGetter]'s idempotent tag identity requirement.
+// A single call may invoke a [TagGetter] more than once, and later calls may expand
+// the same value again. When expansion encounters a cyclic TagGetter graph, it uses
+// the participating TagGetter values themselves as keys; they must therefore be
+// usable as tags. Implementations must satisfy [TagGetter]'s stable-identity contract.
 //
-// Expansion reads tagValue and any values returned by [TagGetter.JawsGetTag] by
-// reference and never writes to them, so those values must not be mutated
-// concurrently with the call.
+// TagExpand does not copy input slices or slices returned by
+// [TagGetter.JawsGetTag] before traversing them. They must not be mutated concurrently
+// with expansion.
 //
 // Errors are returned rather than logged. Use
 // [github.com/linkdata/jaws.Jaws.MustTagExpand] to report them through a configured

--- a/lib/tag/tag.go
+++ b/lib/tag/tag.go
@@ -189,15 +189,16 @@ func expand(depth int, tagValue any, result []any, active []any) ([]any, error) 
 
 // TagExpand expands tagValue into a flat list of unique, usable tag keys.
 //
-// tagValue may be nil, a [Tag], a slice of tags, a [TagGetter] or another value that
-// is comparable at runtime and equals itself. The predeclared string, bool, signed
-// integer, unsigned integer other than uintptr, and floating-point types are
-// rejected with [ErrIllegalTagType], as are [template.HTML], [template.HTMLAttr],
-// [jid.Jid] and [key.Key]. This catches common accidental tags. An expanded key
-// value that is not comparable at runtime or does not equal itself is rejected with
-// [ErrNotUsableAsTag] (which also matches [ErrNotComparable] via [errors.Is]).
-// Expansion that exceeds the nesting-depth or total-count limits is rejected with
-// [ErrTooManyTags].
+// tagValue may be nil, a [Tag], []Tag, []any, a [TagGetter] or another value that is
+// comparable at runtime and equals itself. A nil interface contributes no keys. A
+// typed nil is a non-nil interface and follows the normal rules for its dynamic type,
+// including JawsGetTag dispatch when it implements [TagGetter]. The predeclared string,
+// bool, signed integer, unsigned integer other than uintptr, and floating-point types
+// are rejected with [ErrIllegalTagType], as are [template.HTML], [template.HTMLAttr],
+// [jid.Jid] and [key.Key]. This catches common accidental tags. An expanded key value
+// that is not comparable at runtime or does not equal itself is rejected with
+// [ErrNotUsableAsTag] (which also matches [ErrNotComparable] via [errors.Is]). Expansion
+// that exceeds the nesting-depth or total-count limits is rejected with [ErrTooManyTags].
 //
 // On error, result contains the tags expanded before the failure. If an expanded
 // value is not usable as a tag key, result is nil and err matches
@@ -205,9 +206,9 @@ func expand(depth int, tagValue any, result []any, active []any) ([]any, error) 
 //
 // A single call may invoke a [TagGetter] more than once when the same value is
 // reached at several points in the graph, and the same value may be expanded again by
-// any later call. The [TagGetter] values emitted when a cycle is closed become keys
-// themselves. Implementations must therefore satisfy [TagGetter]'s idempotent tag
-// identity requirement.
+// any later call. When a cycle is closed, its participating [TagGetter] values are
+// treated as candidate keys and must themselves be usable as tags. Implementations
+// must therefore satisfy [TagGetter]'s idempotent tag identity requirement.
 //
 // Expansion reads tagValue and any values returned by [TagGetter.JawsGetTag] by
 // reference and never writes to them, so those values must not be mutated

--- a/lib/tag/taggetter.go
+++ b/lib/tag/taggetter.go
@@ -1,6 +1,6 @@
 package tag
 
-// TagGetter exposes an object's lazily resolved tags to [TagExpand].
+// TagGetter exposes an object's tags to [TagExpand].
 //
 // JawsGetTag is the canonical public accessor for an object's tags, and application
 // code may call it directly. Callers needing flattened, validated keys should pass the
@@ -9,17 +9,20 @@ package tag
 // [github.com/linkdata/jaws.Element.ApplyGetter] invokes JawsGetTag to obtain a tag
 // candidate, then expands that candidate for registration. This expansion may invoke
 // JawsGetTag again when the candidate is itself a TagGetter or contains one. Standard
-// getter-backed widgets invoke ApplyGetter once during an Element's initial render.
-// [TagExpand], dirtying, broadcasts, and application code may make further calls;
-// there is no call-count guarantee.
+// getter-backed widgets invoke ApplyGetter once during an Element's initial render,
+// but [TagExpand], dirtying, broadcasts, and application code may invoke JawsGetTag
+// before or after that. Expansion supplies no Request or rendering context, and there
+// is no call-count guarantee.
 //
-// Except for an explicitly documented initialization phase that returns nil, a
-// TagGetter must be idempotent in tag identity. After its first non-nil result, every
-// call must return a value that [TagExpand] expands to the same set of keys. Previously
-// returned containers must continue expanding to the key set they produced when
-// returned and must be treated as read-only. Fresh containers and equivalent
-// representations are allowed. Non-idempotent TagGetter implementations are
-// unsupported.
+// An explicitly documented initialization phase may return a nil interface, which
+// expands to no keys. A typed nil is a non-nil interface and follows [TagExpand]'s
+// normal rules for its dynamic type. Later initialization does not replay earlier
+// expanding registration, dirtying, or broadcast operations. After its first non-nil
+// result, every call must return a value that [TagExpand] expands to the same set of
+// keys. Previously returned containers must continue expanding to the key set they
+// produced when returned and must be treated as read-only. Fresh containers and
+// equivalent representations are allowed. Non-idempotent TagGetter implementations
+// are unsupported.
 //
 // JaWS does not serialize JawsGetTag calls. A getter used concurrently must synchronize
 // its state and safely publish any returned containers.
@@ -27,6 +30,6 @@ package tag
 // [github.com/linkdata/jaws.Request.TagsOf] reports every tag actually registered on an
 // Element, including tags added separately from the UI object.
 type TagGetter interface {
-	// JawsGetTag returns the tag or tags for the implementing object.
+	// JawsGetTag returns the value that [TagExpand] interprets as the object's tags.
 	JawsGetTag() any
 }

--- a/lib/tag/taggetter.go
+++ b/lib/tag/taggetter.go
@@ -2,33 +2,24 @@ package tag
 
 // TagGetter exposes an object's tags to [TagExpand].
 //
-// JawsGetTag is the canonical public accessor for an object's tags, and application
-// code may call it directly. Callers needing flattened, validated keys should pass the
-// object to [TagExpand] rather than interpret the raw return value.
-//
-// [github.com/linkdata/jaws.Element.ApplyGetter] invokes JawsGetTag to obtain a tag
-// candidate, then expands that candidate for registration. This expansion may invoke
-// JawsGetTag again when the candidate is itself a TagGetter or contains one. Standard
-// getter-backed widgets invoke ApplyGetter once during an Element's initial render,
-// but [TagExpand], dirtying, broadcasts, and application code may invoke JawsGetTag
-// before or after that. Expansion supplies no Request or rendering context, and there
-// is no call-count guarantee.
+// [github.com/linkdata/jaws.Element.ApplyGetter], [TagExpand], and APIs that use
+// TagExpand for registration, dirtying, or broadcast destinations may call JawsGetTag
+// before or after rendering and more than once. Application code may also call it
+// directly. The method receives no Request or rendering context. Callers needing
+// flattened, validated keys should use [TagExpand] rather than interpret the raw return
+// value.
 //
 // An explicitly documented initialization phase may return a nil interface, which
 // expands to no keys. A typed nil is a non-nil interface and follows [TagExpand]'s
-// normal rules for its dynamic type. Later initialization does not replay earlier
-// expanding registration, dirtying, or broadcast operations. After its first non-nil
-// result, every call must return a value that [TagExpand] expands to the same set of
-// keys. Previously returned containers must continue expanding to the key set they
-// produced when returned and must be treated as read-only. Fresh containers and
-// equivalent representations are allowed. Non-idempotent TagGetter implementations
-// are unsupported.
+// normal rules for its dynamic type. Initialization is not retroactive: it does not
+// affect earlier registration, dirtying, or broadcasts. After its first non-nil result,
+// every call must return a value that [TagExpand] expands to the same set of keys.
+// Previously returned containers must continue expanding to the key set they produced
+// when returned and must be treated as read-only. Fresh containers and equivalent
+// representations are allowed.
 //
 // JaWS does not serialize JawsGetTag calls. A getter used concurrently must synchronize
 // its state and safely publish any returned containers.
-//
-// [github.com/linkdata/jaws.Request.TagsOf] reports every tag actually registered on an
-// Element, including tags added separately from the UI object.
 type TagGetter interface {
 	// JawsGetTag returns the value that [TagExpand] interprets as the object's tags.
 	JawsGetTag() any

--- a/request.go
+++ b/request.go
@@ -871,17 +871,16 @@ func (rq *Request) appendDirtyTags(tags []any) {
 	rq.mu.Unlock()
 }
 
-// TagExpanded adds already-expanded tags to the given [Element].
+// TagExpanded registers already-expanded keys with elem.
 //
-// TagExpanded is an advanced API that adds keys without expanding or validating them.
-// Callers should normally use [Request.Tag]. expandedTags must contain only keys that
-// [tag.TagExpand] can emit, either from a successful expansion or from a partial
-// result whose error the caller handled. Other values may panic or create
-// registrations that the canonical tag APIs cannot retrieve.
-// Like [Request.Tag], registration is additive and does not schedule an update.
+// TagExpanded is an advanced, additive API that neither expands nor validates keys and
+// does not schedule an update. Callers should normally use [Request.Tag]. expandedTags
+// must contain only keys that [tag.TagExpand] can emit, either from a successful
+// expansion or from a partial result whose error the caller handled. Passing other
+// values may panic or create registrations unreachable through the expanding lookup,
+// dirtying, and broadcast APIs.
 //
-// It is a no-op for a nil, deleted, or foreign [Element], and after the [Request] has
-// released its tag map.
+// It is a no-op for a nil, deleted, or foreign [Element].
 func (rq *Request) TagExpanded(elem *Element, expandedTags []any) {
 	if elem != nil && elem.Request == rq {
 		rq.mu.Lock()
@@ -905,33 +904,31 @@ func (rq *Request) TagExpanded(elem *Element, expandedTags []any) {
 //
 // Registration is additive and does not schedule an update. Calling Tag during
 // rendering or updating is supported, but known dependencies should normally be
-// registered during initial rendering. Associations registered while rq is live
-// remain active until elem is removed or rq ends; individual associations cannot be
-// removed. See package [github.com/linkdata/jaws/lib/tag] for tag selection and
-// lifetime guidance.
+// registered during initial rendering. Associations remain active until elem is
+// removed or rq ends; individual associations cannot be removed. See package
+// [github.com/linkdata/jaws/lib/tag] for tag selection and lifetime guidance.
 //
-// tagItems are expanded through [Jaws.MustTagExpand], so an expansion error is logged
-// and the partial result still registered when a [Jaws.Logger] is configured, and
-// panics before anything is registered when one is not. Use [Request.TagExpanded] to
-// register keys you expanded yourself.
+// Tag expands tagItems through [Jaws.MustTagExpand]. With a [Jaws.Logger] configured,
+// it logs an expansion error and registers the partial result. Without a Logger, an
+// expansion error causes Tag to panic before registering anything. Use
+// [Request.TagExpanded] to register keys you expanded yourself.
 //
-// Tag ignores a nil or foreign elem and an empty tagItems list without expansion. It
-// still expands tagItems for a deleted elem, but registers nothing.
+// Tag does not expand tagItems when elem is nil or foreign, or when tagItems is empty.
+// For a deleted elem, it still expands non-empty tagItems but registers nothing.
 func (rq *Request) Tag(elem *Element, tagItems ...any) {
 	if elem != nil && len(tagItems) > 0 && elem.Request == rq {
 		rq.TagExpanded(elem, rq.Jaws.MustTagExpand(tagItems))
 	}
 }
 
-// GetElements returns the Elements in rq registered under at least one key expanded
-// from tagValue.
+// GetElements returns the Elements in rq associated with tagValue.
 //
-// tagValue is expanded through [Jaws.MustTagExpand], so an expansion error is logged
-// and the partial result still used for the lookup when a [Jaws.Logger] is configured,
-// and panics before the lookup when one is not.
+// GetElements expands tagValue through [Jaws.MustTagExpand]. With a [Jaws.Logger]
+// configured, it logs an expansion error and uses the partial result. Without a Logger,
+// an expansion error causes GetElements to panic before the lookup.
 //
-// Each Element appears at most once. The returned slice is a caller-owned snapshot in
-// unspecified order.
+// Each Element registered under at least one resulting key is returned once. The
+// returned slice is a caller-owned snapshot in unspecified order.
 func (rq *Request) GetElements(tagValue any) (elems []*Element) {
 	expanded := rq.Jaws.MustTagExpand(tagValue)
 	rq.mu.RLock()

--- a/request.go
+++ b/request.go
@@ -715,9 +715,10 @@ func (rq *Request) tryTagsOf(elem *Element) (tags []any, ok bool) {
 	return
 }
 
-// TagsOf returns the tags currently associated with elem in this Request, or nil
-// if elem is nil. The returned slice is a newly allocated snapshot and may be
-// retained and modified by the caller.
+// TagsOf returns a snapshot of the exact keys registered for elem in rq.
+//
+// It returns nil if elem is nil or has no registered keys. The returned slice is
+// caller-owned and has unspecified order.
 func (rq *Request) TagsOf(elem *Element) (tags []any) {
 	if elem != nil {
 		rq.mu.RLock()
@@ -877,6 +878,7 @@ func (rq *Request) appendDirtyTags(tags []any) {
 // [tag.TagExpand] can emit, either from a successful expansion or from a partial
 // result whose error the caller handled. Other values may panic or create
 // registrations that the canonical tag APIs cannot retrieve.
+// Like [Request.Tag], registration is additive and does not schedule an update.
 //
 // It is a no-op for a nil, deleted, or foreign [Element], and after the [Request] has
 // released its tag map.
@@ -899,23 +901,37 @@ func (rq *Request) TagExpanded(elem *Element, expandedTags []any) {
 	}
 }
 
-// Tag adds the given tags to the given [Element].
+// Tag expands and registers tagItems with elem.
+//
+// Registration is additive and does not schedule an update. Calling Tag during
+// rendering or updating is supported, but known dependencies should normally be
+// registered during initial rendering. Associations registered while rq is live
+// remain active until elem is removed or rq ends; individual associations cannot be
+// removed. See package [github.com/linkdata/jaws/lib/tag] for tag selection and
+// lifetime guidance.
 //
 // tagItems are expanded through [Jaws.MustTagExpand], so an expansion error is logged
 // and the partial result still registered when a [Jaws.Logger] is configured, and
 // panics before anything is registered when one is not. Use [Request.TagExpanded] to
 // register keys you expanded yourself.
+//
+// Tag ignores a nil or foreign elem and an empty tagItems list without expansion. It
+// still expands tagItems for a deleted elem, but registers nothing.
 func (rq *Request) Tag(elem *Element, tagItems ...any) {
 	if elem != nil && len(tagItems) > 0 && elem.Request == rq {
 		rq.TagExpanded(elem, rq.Jaws.MustTagExpand(tagItems))
 	}
 }
 
-// GetElements returns a list of the UI elements in the [Request] that have the given tags.
+// GetElements returns the Elements in rq registered under at least one key expanded
+// from tagValue.
 //
 // tagValue is expanded through [Jaws.MustTagExpand], so an expansion error is logged
 // and the partial result still used for the lookup when a [Jaws.Logger] is configured,
 // and panics before the lookup when one is not.
+//
+// Each Element appears at most once. The returned slice is a caller-owned snapshot in
+// unspecified order.
 func (rq *Request) GetElements(tagValue any) (elems []*Element) {
 	expanded := rq.Jaws.MustTagExpand(tagValue)
 	rq.mu.RLock()


### PR DESCRIPTION
## Summary

- expand the lib/tag package documentation around tags as dependency and tag-addressing keys
- recommend stable data pointers, typed aspect wrappers, and named empty structs, with a compact example
- document TagGetter stability and nil-phase behavior, pre-render expansion, additive registration during render or update, timing, inspection, and the absence of individual removal
- align the relevant symbol docs for TagGetter, TagExpand, Element.Tag, Request.Tag, Request.TagExpanded, Request.TagsOf, Request.GetElements, Element.ApplyGetter, and Element.ApplyParams
- keep the main jaws package documentation brief and link it to the detailed guide

The HasTag exact-key contract landed separately in #228 and is referenced here rather than duplicated.

## Verification

- go generate ./...
- gofmt -l .
- go vet ./...
- staticcheck ./...
- golangci-lint run
- gosec ./...
- JAWS_REQUIRE_NODE=1 go test -race ./...
- JAWS_REQUIRE_NODE=1 go test ./...
- go build ./...
- go doc on the updated packages and symbols

The CI-only 386 test cannot execute an x86 binary on this ARM64 host; the amd64 GitHub runner covers that leg.