### PR TITLE
fix(bind): support uintptr in MakeSetterFloat64

### DIFF
--- a/lib/bind/setterfloat64.go
+++ b/lib/bind/setterfloat64.go
@@ -18,7 +18,7 @@ var (
 type numeric interface {
 	~float32 | ~float64 |
 		~int | ~int8 | ~int16 | ~int32 | ~int64 |
-		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
 }
 
 type setterFloat64[T numeric] struct {
@@ -37,10 +37,10 @@ type setterFloat64[T numeric] struct {
 // untyped-constant (arbitrary-precision) arithmetic evaluated before the single
 // float64 conversion, so it avoids the float64(MaxInt64) rounding pitfall (that
 // conversion rounds up to 2^63). MinIntN is exactly representable for every width,
-// so comparing the truncated value against it is safe. The int and uint bounds use
-// math.MinInt, math.MaxInt and math.MaxUint, which track the target word size, so a
-// 32-bit build rejects magnitudes that only fit a 64-bit word instead of letting
-// T(value) wrap.
+// so comparing the truncated value against it is safe. The int, uint, and uintptr
+// bounds use math.MinInt, math.MaxInt, and math.MaxUint, which track the target word
+// size, so a 32-bit build rejects magnitudes that only fit a 64-bit word instead of
+// letting T(value) wrap.
 //
 // The type switch matches predeclared types by exact type, so callers must
 // instantiate T only with the predeclared numeric types. A named (defined) type
@@ -70,7 +70,7 @@ func sanitizeFloatForT[T numeric](value float64) error {
 		lo, hiExcl = 0, math.MaxUint16+1
 	case uint32:
 		lo, hiExcl = 0, math.MaxUint32+1
-	case uint: // math.MaxUint tracks the target word size
+	case uint, uintptr: // math.MaxUint tracks both target types' word size
 		lo, hiExcl = 0, math.MaxUint+1
 	case uint64:
 		lo, hiExcl = 0, math.MaxUint64+1
@@ -169,7 +169,7 @@ func makeSetterFloat64for[T numeric](s *Setter[float64], value any) bool {
 // v may be a float64 setter/getter/static value, or a setter/getter/static value
 // of another supported numeric type (the predeclared signed and unsigned integer
 // types and float32), which is bridged to float64 by ordinary Go conversion. That
-// bridge can lose precision: int64/uint64 magnitudes beyond 2^53 are not exactly
+// bridge can lose precision: not every integer magnitude beyond 2^53 is exactly
 // representable as float64.
 //
 // If conversion changes value but the converted value already matches the
@@ -199,6 +199,7 @@ func MakeSetterFloat64(value any) (s Setter[float64]) {
 		ok = ok || makeSetterFloat64for[uint64](&s, v)
 		ok = ok || makeSetterFloat64for[int](&s, v)
 		ok = ok || makeSetterFloat64for[uint](&s, v)
+		ok = ok || makeSetterFloat64for[uintptr](&s, v)
 		ok = ok || makeSetterFloat64for[int32](&s, v)
 		ok = ok || makeSetterFloat64for[uint32](&s, v)
 		ok = ok || makeSetterFloat64for[int8](&s, v)

--- a/lib/bind/setterfloat64_test.go
+++ b/lib/bind/setterfloat64_test.go
@@ -22,6 +22,7 @@ func (tg testGetter[T]) JawsGet(elem *jaws.Element) T {
 
 func Test_makeSetterFloat64types(t *testing.T) {
 	tsint := newTestSetter(int(0))
+	tsuintptr := newTestSetter(uintptr(0))
 	tests := []struct {
 		name  string
 		v     any
@@ -57,6 +58,21 @@ func Test_makeSetterFloat64types(t *testing.T) {
 			v:     int(0),
 			wantS: setterFloat64Static[int]{0},
 		},
+		{
+			name:  "Setter[uintptr]",
+			v:     tsuintptr,
+			wantS: setterFloat64[uintptr]{tsuintptr},
+		},
+		{
+			name:  "Getter[uintptr]",
+			v:     testGetter[uintptr]{},
+			wantS: setterFloat64ReadOnly[uintptr]{testGetter[uintptr]{}},
+		},
+		{
+			name:  "uintptr",
+			v:     uintptr(0),
+			wantS: setterFloat64Static[uintptr]{0},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -80,6 +96,40 @@ func Test_makeSetterFloat64_int(t *testing.T) {
 	tg := gotS.(tag.TagGetter)
 	if x := tg.JawsGetTag(); x != tsint {
 		t.Error(x)
+	}
+}
+
+func TestMakeSetterFloat64AcceptsUintptr(t *testing.T) {
+	ts := newTestSetter(uintptr(42))
+	tests := []struct {
+		name     string
+		value    any
+		settable bool
+	}{
+		{name: "static", value: uintptr(42)},
+		{name: "getter", value: testGetter[uintptr]{v: 42}},
+		{name: "setter", value: ts, settable: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := MakeSetterFloat64(tt.value)
+			if got := s.JawsGet(nil); got != 42 {
+				t.Fatalf("JawsGet() = %v, want 42", got)
+			}
+			err := s.JawsSet(nil, 43)
+			if tt.settable {
+				if err != nil {
+					t.Fatalf("JawsSet(43): %v", err)
+				}
+				if got := ts.Get(); got != 43 {
+					t.Fatalf("stored value = %v, want 43", got)
+				}
+				return
+			}
+			if !errors.Is(err, ErrValueNotSettable) {
+				t.Fatalf("JawsSet(43) = %v, want ErrValueNotSettable", err)
+			}
+		})
 	}
 }
 
@@ -230,9 +280,10 @@ func Test_setterFloat64_coversNumericTypes(t *testing.T) {
 	assertIntTypeGuard[int](t, "int", 1, 9223372036854775808.0)     // 2^63
 	assertIntTypeGuard[uint8](t, "uint8", 1, 256)
 	assertIntTypeGuard[uint16](t, "uint16", 1, 65536)
-	assertIntTypeGuard[uint32](t, "uint32", 1, 4294967296)             // 2^32
-	assertIntTypeGuard[uint64](t, "uint64", 1, 18446744073709551616.0) // 2^64
-	assertIntTypeGuard[uint](t, "uint", 1, 18446744073709551616.0)     // 2^64
+	assertIntTypeGuard[uint32](t, "uint32", 1, 4294967296)               // 2^32
+	assertIntTypeGuard[uint64](t, "uint64", 1, 18446744073709551616.0)   // 2^64
+	assertIntTypeGuard[uint](t, "uint", 1, 18446744073709551616.0)       // 2^64
+	assertIntTypeGuard[uintptr](t, "uintptr", 1, 18446744073709551616.0) // 2^64
 
 	// float32 rejects non-finite values and finite values that overflow the float32
 	// range (they would otherwise convert to ±Inf); an in-range value is accepted.
@@ -251,20 +302,25 @@ func Test_setterFloat64_coversNumericTypes(t *testing.T) {
 	}
 }
 
-// Test_setterFloat64_intBoundsTrackWordSize pins that the int and uint guards
-// follow the target word size rather than assuming 64 bits. 2^31 fits a 64-bit
-// int but overflows a 32-bit int, and 2^32 fits a 64-bit uint but overflows a
-// 32-bit uint; on a 32-bit build these must be rejected instead of silently
-// wrapping in the float->int conversion, and on a 64-bit build they stay in range.
+// Test_setterFloat64_intBoundsTrackWordSize pins that the int, uint, and uintptr
+// guards follow the target word size rather than assuming 64 bits. 2^31 fits a
+// 64-bit int but overflows a 32-bit int, and 2^32 fits 64-bit uint and uintptr
+// but overflows their 32-bit forms; on a 32-bit build these must be rejected
+// instead of silently wrapping in the float->int conversion, and on a 64-bit
+// build they stay in range.
 func Test_setterFloat64_intBoundsTrackWordSize(t *testing.T) {
-	intErr := sanitizeFloatForT[int](1 << 31)   // 2^31 = MaxInt32 + 1
-	uintErr := sanitizeFloatForT[uint](1 << 32) // 2^32 = MaxUint32 + 1
+	intErr := sanitizeFloatForT[int](1 << 31)         // 2^31 = MaxInt32 + 1
+	uintErr := sanitizeFloatForT[uint](1 << 32)       // 2^32 = MaxUint32 + 1
+	uintptrErr := sanitizeFloatForT[uintptr](1 << 32) // 2^32 = MaxUint32 + 1
 	if strconv.IntSize == 32 {
 		if !errors.Is(intErr, ErrFloatOutOfRange) {
 			t.Errorf("32-bit int 2^31: got %v, want ErrFloatOutOfRange", intErr)
 		}
 		if !errors.Is(uintErr, ErrFloatOutOfRange) {
 			t.Errorf("32-bit uint 2^32: got %v, want ErrFloatOutOfRange", uintErr)
+		}
+		if !errors.Is(uintptrErr, ErrFloatOutOfRange) {
+			t.Errorf("32-bit uintptr 2^32: got %v, want ErrFloatOutOfRange", uintptrErr)
 		}
 		return
 	}
@@ -273,6 +329,9 @@ func Test_setterFloat64_intBoundsTrackWordSize(t *testing.T) {
 	}
 	if uintErr != nil {
 		t.Errorf("64-bit uint 2^32: got %v, want nil", uintErr)
+	}
+	if uintptrErr != nil {
+		t.Errorf("64-bit uintptr 2^32: got %v, want nil", uintptrErr)
 	}
 }
 


### PR DESCRIPTION
## Summary

- accept static, getter, and setter `uintptr` values in `MakeSetterFloat64`
- validate float-to-`uintptr` conversion using the platform word-size bound
- cover adapter behavior, sanitization, and 32-/64-bit bounds

Closes #219

## Verification

- `go test -race ./...`
- `go test ./...`
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`
- `gofmt -l .`
- `gofumpt -l .`
- `GOARCH=386 CGO_ENABLED=0 go test -exec=/bin/true ./lib/bind/...` (cross-compile on aarch64)