### PR TITLE
fix(named): keep Bool name as option value

### DIFF
--- a/lib/named/namedbooloption.go
+++ b/lib/named/namedbooloption.go
@@ -2,18 +2,24 @@ package named
 
 import (
 	"io"
+	"slices"
 
 	"github.com/linkdata/jaws"
 	"github.com/linkdata/jaws/lib/htmlio"
 )
 
 // RenderBoolOption renders nb as an HTML <option> element into w.
+//
+// The option value is always [Bool.Name] and takes precedence over any value
+// attribute in params.
 func RenderBoolOption(elem *jaws.Element, w io.Writer, nb *Bool, params []any) error {
 	// Single source of <option> markup, shared by BoolArray's options and by ui.Option,
 	// so attribute/escaping behavior cannot drift between them.
 	elem.Tag(nb)
+	// HTML parsing keeps the first duplicate attribute, so emit the canonical
+	// value before caller attributes.
 	attrs := elem.ApplyParams(params)
-	attrs = append(attrs, htmlio.Attr("value", nb.Name()))
+	attrs = slices.Insert(attrs, 0, htmlio.Attr("value", nb.Name()))
 	if nb.Checked() {
 		attrs = append(attrs, "selected")
 	}

--- a/lib/ui/html_widgets_test.go
+++ b/lib/ui/html_widgets_test.go
@@ -97,12 +97,24 @@ func TestOption_RenderAndUpdate(t *testing.T) {
 	nb := named.NewBool(nba, `escape"&copy=<me>'`, "<unescaped>", true)
 	ui := NewOption(nb)
 	elem, got := renderUI(t, rq, ui, "hidden")
-	mustMatch(t, `^<option id="Jid\.[0-9]+" hidden value="escape&#34;&amp;copy=&lt;me&gt;&#39;" selected><unescaped></option>$`, got)
+	mustMatch(t, `^<option id="Jid\.[0-9]+" value="escape&#34;&amp;copy=&lt;me&gt;&#39;" hidden selected><unescaped></option>$`, got)
 
 	nb.Set(false)
 	ui.JawsUpdate(elem)
 	nb.Set(true)
 	ui.JawsUpdate(elem)
+}
+
+func TestOption_RenderBoolNameTakesPrecedenceOverCallerValue(t *testing.T) {
+	_, rq := newCoreRequest(t)
+	nb := named.NewBool(nil, "canonical", "label", false)
+
+	_, got := renderUI(t, rq, NewOption(nb), template.HTMLAttr(`value="caller"`))
+	canonical := strings.Index(got, `value="canonical"`)
+	caller := strings.Index(got, `value="caller"`)
+	if canonical < 0 || (caller >= 0 && caller < canonical) {
+		t.Fatalf("Bool.Name value does not take precedence: %s", got)
+	}
 }
 
 func TestRegister_Render(t *testing.T) {

--- a/lib/ui/option.go
+++ b/lib/ui/option.go
@@ -9,6 +9,9 @@ import (
 
 // Option renders an HTML option element backed by a [named.Bool].
 //
+// The value attribute is always [named.Bool.Name] and takes precedence over a
+// value attribute passed as a render param.
+//
 // One Option value may back multiple live [jaws.Element] values. All of those
 // Elements reflect the shared Bool.
 type Option struct{ *named.Bool }


### PR DESCRIPTION
## Summary

- emit named.Bool option values before caller-provided render attributes
- document Bool.Name precedence for option rendering
- add regression coverage for conflicting value attributes

Fixes #218

## Testing

- go generate ./...
- gofmt and gofumpt
- go vet ./...
- staticcheck ./...
- golangci-lint run
- gosec ./...
- go build ./...
- JAWS_REQUIRE_NODE=1 go test -race ./...
- JAWS_REQUIRE_NODE=1 go test ./...