### PR TITLE
fix(bind): preserve canonical integer round trips

### DIFF
--- a/lib/bind/setterfloat64.go
+++ b/lib/bind/setterfloat64.go
@@ -26,27 +26,10 @@ type setterFloat64[T numeric] struct {
 	Setter[T]
 }
 
-func float64MayAliasInteger[T numeric](value float64) bool {
-	// Keep the read-before-write check out of adapters that cannot hide integer
-	// bits. This preserves wrapped Getter and Setter call behavior everywhere
-	// outside the precision-loss case handled by the check.
-	const exactIntegerLimit = 1 << 53
-	if value > -exactIntegerLimit && value < exactIntegerLimit {
-		return false
-	}
-	switch any(T(0)).(type) {
-	case int64, uint64:
-		return true
-	case int, uint, uintptr:
-		return strconv.IntSize == 64
-	default:
-		return false
-	}
-}
-
-// sanitizeFloatForT validates value before it is converted to T. It rejects
-// non-finite values for every numeric T, and for integer T also rejects values
-// whose truncation toward zero falls outside the type's representable range.
+// sanitizeFloatForT validates value before it is converted to T and reports
+// whether it may be the canonical float64 view of more than one T integer. It
+// rejects non-finite values for every numeric T, and for integer T also rejects
+// values whose truncation toward zero falls outside the representable range.
 //
 // The conversion T(value) truncates toward zero, so the lower bound is compared
 // against math.Trunc(value): a fractional value like -128.5 truncates to the valid
@@ -65,13 +48,15 @@ func float64MayAliasInteger[T numeric](value float64) bool {
 // instantiate T only with the predeclared numeric types. A named (defined) type
 // such as "type Celsius float64" falls through to the float default branch and is
 // range-checked as if it were its predeclared underlying type.
-func sanitizeFloatForT[T numeric](value float64) error {
+func sanitizeFloatForT[T numeric](value float64) (mayAlias bool, err error) {
 	// Non-finite values, typically from the untrusted browser, corrupt the bound value;
 	// NaN in particular defeats the equality-based update dedup (NaN != NaN). Reject them.
 	if math.IsNaN(value) || math.IsInf(value, 0) {
-		return ErrFloatNotFinite
+		err = ErrFloatNotFinite
+		return
 	}
 	var lo, hiExcl float64
+	var wideInteger bool
 	switch any(T(0)).(type) {
 	case int8:
 		lo, hiExcl = math.MinInt8, math.MaxInt8+1
@@ -81,8 +66,10 @@ func sanitizeFloatForT[T numeric](value float64) error {
 		lo, hiExcl = math.MinInt32, math.MaxInt32+1
 	case int: // math.MinInt/math.MaxInt track the target word size
 		lo, hiExcl = math.MinInt, math.MaxInt+1
+		wideInteger = strconv.IntSize == 64
 	case int64:
 		lo, hiExcl = math.MinInt64, math.MaxInt64+1
+		wideInteger = true
 	case uint8:
 		lo, hiExcl = 0, math.MaxUint8+1
 	case uint16:
@@ -91,24 +78,30 @@ func sanitizeFloatForT[T numeric](value float64) error {
 		lo, hiExcl = 0, math.MaxUint32+1
 	case uint, uintptr: // math.MaxUint tracks both target types' word size
 		lo, hiExcl = 0, math.MaxUint+1
+		wideInteger = strconv.IntSize == 64
 	case uint64:
 		lo, hiExcl = 0, math.MaxUint64+1
+		wideInteger = true
 	default:
 		// float32 or float64: reject a finite value that overflows the target type.
 		// A float64 that exceeds the float32 range converts to ±Inf and silently
 		// corrupts the bound value (reachable from browser input via NewNumber and
 		// NewRange); float64 never overflows here, so this is a no-op for it.
 		if math.IsInf(float64(T(value)), 0) {
-			return ErrFloatOutOfRange
+			err = ErrFloatOutOfRange
 		}
-		return nil
+		return
 	}
 	// The float-to-int conversion of an out-of-range value is implementation-defined and
 	// silently wraps, so reject it rather than perform it.
 	if math.Trunc(value) < lo || value >= hiExcl {
-		return ErrFloatOutOfRange
+		err = ErrFloatOutOfRange
 	}
-	return nil
+	const exactIntegerLimit = 1 << 53
+	mayAlias = wideInteger &&
+		(value <= -exactIntegerLimit || value >= exactIntegerLimit) &&
+		(err == nil || value == hiExcl)
+	return
 }
 
 func (s setterFloat64[T]) JawsGet(elem *jaws.Element) float64 {
@@ -117,8 +110,9 @@ func (s setterFloat64[T]) JawsGet(elem *jaws.Element) float64 {
 }
 
 func (s setterFloat64[T]) JawsSet(elem *jaws.Element, value float64) (err error) {
-	err = sanitizeFloatForT[T](value)
-	if (err == nil || errors.Is(err, ErrFloatOutOfRange)) && float64MayAliasInteger[T](value) {
+	var mayAlias bool
+	mayAlias, err = sanitizeFloatForT[T](value)
+	if mayAlias {
 		current := s.Setter.JawsGet(elem)
 		if float64(current) == value && (err != nil || current != T(value)) {
 			err = jaws.ErrValueUnchanged

--- a/lib/bind/setterfloat64.go
+++ b/lib/bind/setterfloat64.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strconv"
 
 	"github.com/linkdata/jaws"
 )
@@ -23,6 +24,24 @@ type numeric interface {
 
 type setterFloat64[T numeric] struct {
 	Setter[T]
+}
+
+func float64MayAliasInteger[T numeric](value float64) bool {
+	// Keep the read-before-write check out of adapters that cannot hide integer
+	// bits. This preserves wrapped Getter and Setter call behavior everywhere
+	// outside the precision-loss case handled by the check.
+	const exactIntegerLimit = 1 << 53
+	if value > -exactIntegerLimit && value < exactIntegerLimit {
+		return false
+	}
+	switch any(T(0)).(type) {
+	case int64, uint64:
+		return true
+	case int, uint, uintptr:
+		return strconv.IntSize == 64
+	default:
+		return false
+	}
 }
 
 // sanitizeFloatForT validates value before it is converted to T. It rejects
@@ -98,7 +117,15 @@ func (s setterFloat64[T]) JawsGet(elem *jaws.Element) float64 {
 }
 
 func (s setterFloat64[T]) JawsSet(elem *jaws.Element, value float64) (err error) {
-	if err = sanitizeFloatForT[T](value); err == nil {
+	err = sanitizeFloatForT[T](value)
+	if (err == nil || errors.Is(err, ErrFloatOutOfRange)) && float64MayAliasInteger[T](value) {
+		current := s.Setter.JawsGet(elem)
+		if float64(current) == value && (err != nil || current != T(value)) {
+			err = jaws.ErrValueUnchanged
+			return
+		}
+	}
+	if err == nil {
 		converted := T(value)
 		err = s.Setter.JawsSet(elem, converted)
 		// ErrValueUnchanged is accurate for the underlying T setter, but not for
@@ -171,6 +198,12 @@ func makeSetterFloat64for[T numeric](s *Setter[float64], value any) bool {
 // types and float32), which is bridged to float64 by ordinary Go conversion. That
 // bridge can lose precision: not every integer magnitude beyond 2^53 is exactly
 // representable as float64.
+//
+// When an integer loses precision in that conversion, writing the canonical
+// float64 returned by [Getter.JawsGet] back through [Setter.JawsSet] preserves
+// the underlying integer and returns [jaws.ErrValueUnchanged]. This also applies
+// when a maximum integer's canonical float64 is the target type's exclusive
+// upper bound.
 //
 // If conversion changes value but the converted value already matches the
 // underlying setter's current value, the adapter reports a successful set

--- a/lib/bind/setterfloat64_test.go
+++ b/lib/bind/setterfloat64_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/linkdata/jaws"
@@ -190,6 +191,114 @@ func Test_setterFloat64_conversionSignalsCanonicalChange(t *testing.T) {
 			t.Fatalf("JawsSet(2) = %v, want ErrValueUnchanged", err)
 		}
 	})
+}
+
+type setterFloat64RoundTrip[T numeric] struct {
+	name      string
+	original  T
+	canonical float64
+}
+
+func assertSetterFloat64CanonicalRoundTrips[T numeric](t *testing.T, tests []setterFloat64RoundTrip[T]) {
+	t.Helper()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mu sync.Mutex
+			value := tt.original
+			bind := New(&mu, &value)
+			setter := MakeSetterFloat64(bind)
+			if got := setter.JawsGet(nil); got != tt.canonical {
+				t.Fatalf("JawsGet() = %v, want %v", got, tt.canonical)
+			}
+			if err := setter.JawsSet(nil, tt.canonical); !errors.Is(err, jaws.ErrValueUnchanged) {
+				t.Fatalf("JawsSet(JawsGet()) = %v, want ErrValueUnchanged", err)
+			}
+			if got := bind.JawsGet(nil); got != tt.original {
+				t.Fatalf("stored value = %v, want unchanged %v", got, tt.original)
+			}
+		})
+	}
+}
+
+func TestMakeSetterFloat64CanonicalIntegerRoundTrip(t *testing.T) {
+	const exactLimit = 1 << 53
+
+	t.Run("int64", func(t *testing.T) {
+		assertSetterFloat64CanonicalRoundTrips(t, []setterFloat64RoundTrip[int64]{
+			{name: "exact limit", original: exactLimit, canonical: exactLimit},
+			{name: "rounds down", original: exactLimit + 1, canonical: exactLimit},
+			{name: "rounds up", original: exactLimit + 3, canonical: exactLimit + 4},
+			{name: "negative rounds up", original: -exactLimit - 1, canonical: -exactLimit},
+			{name: "minimum", original: math.MinInt64, canonical: math.MinInt64},
+			{name: "maximum", original: math.MaxInt64, canonical: math.MaxInt64 + 1},
+		})
+	})
+
+	t.Run("uint64", func(t *testing.T) {
+		assertSetterFloat64CanonicalRoundTrips(t, []setterFloat64RoundTrip[uint64]{
+			{name: "exact limit", original: exactLimit, canonical: exactLimit},
+			{name: "rounds down", original: exactLimit + 1, canonical: exactLimit},
+			{name: "rounds up", original: exactLimit + 3, canonical: exactLimit + 4},
+			{name: "maximum", original: math.MaxUint64, canonical: math.MaxUint64 + 1},
+		})
+	})
+
+	if strconv.IntSize == 64 {
+		largeSigned := int64(exactLimit + 1)
+		largeUnsigned := uint64(exactLimit + 1)
+		maxSigned := int64(math.MaxInt64)
+		maxUnsigned := uint64(math.MaxUint64)
+		t.Run("int", func(t *testing.T) {
+			assertSetterFloat64CanonicalRoundTrips(t, []setterFloat64RoundTrip[int]{
+				{name: "rounds down", original: int(largeSigned), canonical: exactLimit},
+				{name: "maximum", original: int(maxSigned), canonical: math.MaxInt64 + 1},
+			})
+		})
+		t.Run("uint", func(t *testing.T) {
+			assertSetterFloat64CanonicalRoundTrips(t, []setterFloat64RoundTrip[uint]{
+				{name: "rounds down", original: uint(largeUnsigned), canonical: exactLimit},
+				{name: "maximum", original: uint(maxUnsigned), canonical: math.MaxUint64 + 1},
+			})
+		})
+		t.Run("uintptr", func(t *testing.T) {
+			assertSetterFloat64CanonicalRoundTrips(t, []setterFloat64RoundTrip[uintptr]{
+				{name: "rounds down", original: uintptr(largeUnsigned), canonical: exactLimit},
+				{name: "maximum", original: uintptr(maxUnsigned), canonical: math.MaxUint64 + 1},
+			})
+		})
+	}
+}
+
+func TestMakeSetterFloat64SetsNeighboringLargeInteger(t *testing.T) {
+	var mu sync.Mutex
+	value := int64(1<<53 + 1)
+	bind := New(&mu, &value)
+	setter := MakeSetterFloat64(bind)
+	want := int64(1<<53 + 2)
+	if err := setter.JawsSet(nil, float64(want)); err != nil {
+		t.Fatalf("JawsSet(%v): %v", want, err)
+	}
+	if got := bind.JawsGet(nil); got != want {
+		t.Fatalf("stored value = %v, want %v", got, want)
+	}
+}
+
+func TestMakeSetterFloat64DelegatesExactLargeInteger(t *testing.T) {
+	var mu sync.Mutex
+	value := int64(1 << 53)
+	wantErr := errors.New("set rejected")
+	var calls int
+	bind := New(&mu, &value).SetLocked(func(Binder[int64], *jaws.Element, int64) error {
+		calls++
+		return wantErr
+	})
+	setter := MakeSetterFloat64(bind)
+	if err := setter.JawsSet(nil, float64(value)); !errors.Is(err, wantErr) {
+		t.Fatalf("JawsSet(%v) = %v, want %v", value, err, wantErr)
+	}
+	if calls != 1 {
+		t.Fatalf("wrapped JawsSet called %d times, want 1", calls)
+	}
 }
 
 // Test_setterFloat64_sanitizesUntrustedInput covers the float-from-client guard:

--- a/lib/bind/setterfloat64_test.go
+++ b/lib/bind/setterfloat64_test.go
@@ -377,6 +377,11 @@ func assertIntTypeGuard[T numeric](t *testing.T, name string, inRange, tooBig fl
 	}
 }
 
+func sanitizeFloatForTErr[T numeric](value float64) (err error) {
+	_, err = sanitizeFloatForT[T](value)
+	return
+}
+
 // Test_setterFloat64_coversNumericTypes exercises every case of the type switch in
 // sanitizeFloatForT: each integer type rejects out-of-range values, float32 rejects
 // non-finite and finite-but-overflowing values, and float64 takes the
@@ -418,9 +423,9 @@ func Test_setterFloat64_coversNumericTypes(t *testing.T) {
 // instead of silently wrapping in the float->int conversion, and on a 64-bit
 // build they stay in range.
 func Test_setterFloat64_intBoundsTrackWordSize(t *testing.T) {
-	intErr := sanitizeFloatForT[int](1 << 31)         // 2^31 = MaxInt32 + 1
-	uintErr := sanitizeFloatForT[uint](1 << 32)       // 2^32 = MaxUint32 + 1
-	uintptrErr := sanitizeFloatForT[uintptr](1 << 32) // 2^32 = MaxUint32 + 1
+	intErr := sanitizeFloatForTErr[int](1 << 31)         // 2^31 = MaxInt32 + 1
+	uintErr := sanitizeFloatForTErr[uint](1 << 32)       // 2^32 = MaxUint32 + 1
+	uintptrErr := sanitizeFloatForTErr[uintptr](1 << 32) // 2^32 = MaxUint32 + 1
 	if strconv.IntSize == 32 {
 		if !errors.Is(intErr, ErrFloatOutOfRange) {
 			t.Errorf("32-bit int 2^31: got %v, want ErrFloatOutOfRange", intErr)
@@ -459,20 +464,20 @@ func Test_setterFloat64_truncationBoundarySymmetry(t *testing.T) {
 			t.Errorf("%s: low boundary rejected (truncates to a valid value): %v", name, errLo)
 		}
 	}
-	assertSym(t, "int8", sanitizeFloatForT[int8](math.MaxInt8+0.5), sanitizeFloatForT[int8](math.MinInt8-0.5))
-	assertSym(t, "int16", sanitizeFloatForT[int16](math.MaxInt16+0.5), sanitizeFloatForT[int16](math.MinInt16-0.5))
-	assertSym(t, "int32", sanitizeFloatForT[int32](math.MaxInt32+0.5), sanitizeFloatForT[int32](math.MinInt32-0.5))
+	assertSym(t, "int8", sanitizeFloatForTErr[int8](math.MaxInt8+0.5), sanitizeFloatForTErr[int8](math.MinInt8-0.5))
+	assertSym(t, "int16", sanitizeFloatForTErr[int16](math.MaxInt16+0.5), sanitizeFloatForTErr[int16](math.MinInt16-0.5))
+	assertSym(t, "int32", sanitizeFloatForTErr[int32](math.MaxInt32+0.5), sanitizeFloatForTErr[int32](math.MinInt32-0.5))
 
 	// A whole value one below MinIntN truncates out of range and must be rejected.
-	if err := sanitizeFloatForT[int8](math.MinInt8 - 1); !errors.Is(err, ErrFloatOutOfRange) {
+	if err := sanitizeFloatForTErr[int8](math.MinInt8 - 1); !errors.Is(err, ErrFloatOutOfRange) {
 		t.Errorf("int8 %v: got %v, want ErrFloatOutOfRange", math.MinInt8-1, err)
 	}
 	// MinInt64 is exactly representable and in range; it must remain acceptable, while
 	// the next float64 below it (2048 lower) is out of range.
-	if err := sanitizeFloatForT[int64](math.MinInt64); err != nil {
+	if err := sanitizeFloatForTErr[int64](math.MinInt64); err != nil {
 		t.Errorf("int64 MinInt64: got %v, want nil", err)
 	}
-	if err := sanitizeFloatForT[int64](math.Nextafter(math.MinInt64, math.Inf(-1))); !errors.Is(err, ErrFloatOutOfRange) {
+	if err := sanitizeFloatForTErr[int64](math.Nextafter(math.MinInt64, math.Inf(-1))); !errors.Is(err, ErrFloatOutOfRange) {
 		t.Errorf("int64 below MinInt64: got %v, want ErrFloatOutOfRange", err)
 	}
 


### PR DESCRIPTION
## Summary

- recognize canonical float64 echoes of lossy 64-bit integer views before conversion
- preserve hidden integer bits and treat rounded maximum-bound views as unchanged
- keep exact writes, neighboring large-value updates, and the #176 browser reconciliation path unchanged
- document the canonical round-trip behavior

## Tests

- `go test -race ./...`
- `go test ./...`
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec -quiet ./...`
- `go build ./...`
- 32-bit `lib/bind` test build (`GOOS=linux GOARCH=386 CGO_ENABLED=0`)

Fixes #233
