### PR TITLE
fix: replace duplicate-cookie sessions in NewSession

### DIFF
--- a/session.go
+++ b/session.go
@@ -290,15 +290,20 @@ func (jw *Jaws) Sessions() (sessions []*Session) {
 	return
 }
 
-func (jw *Jaws) getSessionLocked(sessionIDs []key.Key, remoteIP netip.Addr) *Session {
+func (jw *Jaws) getSessionByIDLocked(sessionID key.Key, remoteIP netip.Addr) (sess *Session) {
+	if found, ok := jw.sessions[sessionID]; ok && equalIP(remoteIP, found.remoteIP) && !found.isDead() {
+		sess = found
+	}
+	return
+}
+
+func (jw *Jaws) getSessionLocked(sessionIDs []key.Key, remoteIP netip.Addr) (sess *Session) {
 	for _, sessionID := range sessionIDs {
-		if sess, ok := jw.sessions[sessionID]; ok && equalIP(remoteIP, sess.remoteIP) {
-			if !sess.isDead() {
-				return sess
-			}
+		if sess = jw.getSessionByIDLocked(sessionID, remoteIP); sess != nil {
+			break
 		}
 	}
-	return nil
+	return
 }
 
 func getCookieSessionsIDs(h http.Header, wanted string) (cookies []key.Key) {
@@ -346,9 +351,10 @@ func (jw *Jaws) GetSession(r *http.Request) (sess *Session) {
 
 // NewSession creates a new [Session].
 //
-// Any pre-existing [Session] will be cleared and closed.
-// This may call [Session.Close] on an existing session and therefore requires
-// the JaWS processing loop ([Jaws.Serve] or [Jaws.ServeWithTimeout]) to be running.
+// All live pre-existing [Session] values referenced by matching cookies and
+// bound to the request's client IP are cleared and closed. Each is closed with
+// [Session.Close], so the JaWS processing loop ([Jaws.Serve] or
+// [Jaws.ServeWithTimeout]) must be running.
 //
 // Subsequent [Request] values created with [Jaws.NewRequest] that have the
 // cookie set and originate from the same IP will be able to access the [Session].
@@ -364,9 +370,17 @@ func (jw *Jaws) GetSession(r *http.Request) (sess *Session) {
 // ID, which does not happen on supported platforms.
 func (jw *Jaws) NewSession(w http.ResponseWriter, r *http.Request) (sess *Session) {
 	if r != nil {
-		if oldSess := jw.GetSession(r); oldSess != nil {
-			oldSess.Clear()
-			oldSess.Close()
+		if sessionIDs := getCookieSessionsIDs(r.Header, jw.CookieName); len(sessionIDs) > 0 {
+			remoteIP := jw.clientIP(r)
+			for _, sessionID := range sessionIDs {
+				jw.mu.RLock()
+				oldSess := jw.getSessionByIDLocked(sessionID, remoteIP)
+				jw.mu.RUnlock()
+				if oldSess != nil {
+					oldSess.Clear()
+					oldSess.Close()
+				}
+			}
 		}
 		sess = jw.newSession(w, r)
 	}

--- a/session_test.go
+++ b/session_test.go
@@ -175,33 +175,20 @@ func TestSession_NewSessionReplacesDuplicateCookieSessions(t *testing.T) {
 	other, otherCookie := newSession(otherIP)
 	unknown, unknownCookie := newSession(sameIP)
 	unknown.Close()
-	expired, expiredCookie := newSession(sameIP)
 	first.Set("stale", "first")
 	second.Set("stale", "second")
 	other.Set("keep", "other")
-	expired.Set("keep", "expired")
 
 	// A tab on each duplicate session. Rotation must detach and reload both, not
 	// just the one named by the first matching cookie.
 	firstRequest := attach(sameIP, firstCookie, first)
 	secondRequest := attach(sameIP, secondCookie, second)
 
-	// Expire the last session without running maintenance cleanup, so its cookie
-	// names a session that is dead but still mapped. It has no attached Request,
-	// so the elapsed deadline alone makes it dead.
-	expired.mu.Lock()
-	expired.deadline = time.Now().Add(-time.Second)
-	expired.mu.Unlock()
-	if !expired.isDead() {
-		t.Fatal("expected expired session to be dead")
-	}
-
 	r := makeRequest(sameIP)
-	// Invalid, unknown, dead, and other-IP cookies stay ignored while every
+	// Invalid, unknown, and other-IP cookies stay ignored while every
 	// distinct live same-IP session is closed, regardless of duplicates or ordering.
 	r.AddCookie(&http.Cookie{Name: jw.CookieName, Value: first.CookieValue() + "/junk"})
 	r.AddCookie(unknownCookie)
-	r.AddCookie(expiredCookie)
 	r.AddCookie(otherCookie)
 	r.AddCookie(firstCookie)
 	r.AddCookie(firstCookie) // repeated ID
@@ -244,17 +231,6 @@ func TestSession_NewSessionReplacesDuplicateCookieSessions(t *testing.T) {
 			t.Errorf("%s attached request queue = %v, want one Reload", old.name, queued)
 		}
 	}
-	// The dead-but-mapped session is skipped rather than rotated: NewSession
-	// neither cleared it nor handed it out. Whether maintenance has already reaped
-	// it from jw.sessions does not matter, since reaping never clears session data.
-	if got := expired.Get("keep"); got != "expired" {
-		t.Fatalf("dead session data = %v, want unchanged", got)
-	}
-	expiredRequest := makeRequest(sameIP)
-	expiredRequest.AddCookie(expiredCookie)
-	if got := jw.GetSession(expiredRequest); got != nil {
-		t.Fatalf("dead-session GetSession() = %p, want nil", got)
-	}
 	if got := other.Get("keep"); got != "other" {
 		t.Fatalf("other-IP session data = %v, want unchanged", got)
 	}
@@ -285,9 +261,6 @@ func TestSession_NewSessionReplacesDuplicateCookieSessions(t *testing.T) {
 	if !mapped[fresh] || !mapped[other] {
 		t.Fatalf("mapped fresh = %v, other-IP = %v, want both retained", mapped[fresh], mapped[other])
 	}
-	// Drop the dead session before counting: a maintenance tick may or may not
-	// have reaped it by now, but nothing else may remain.
-	delete(mapped, expired)
 	if len(mapped) != 2 {
 		t.Fatalf("mapped sessions = %d, want only the fresh and other-IP sessions", len(mapped))
 	}
@@ -297,6 +270,53 @@ func TestSession_NewSessionReplacesDuplicateCookieSessions(t *testing.T) {
 	}
 	if got := responseCookies[0]; got.Name != jw.CookieName || got.Value != fresh.CookieValue() {
 		t.Fatalf("replacement cookie = %s=%s, want %s=%s", got.Name, got.Value, jw.CookieName, fresh.CookieValue())
+	}
+}
+
+func TestSession_NewSessionIgnoresDeadMappedSession(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+
+	makeRequest := func() *http.Request {
+		r := httptest.NewRequest(http.MethodGet, "http://example.test/login", nil)
+		r.RemoteAddr = "203.0.113.10:1234"
+		return r
+	}
+	expired := jw.NewSession(httptest.NewRecorder(), makeRequest())
+	if expired == nil {
+		t.Fatal("NewSession returned nil")
+	}
+	expiredCookie := expired.Cookie()
+	expired.Set("keep", "expired")
+	expired.mu.Lock()
+	expired.deadline = time.Now().Add(-time.Second)
+	expired.mu.Unlock()
+	if !expired.isDead() {
+		t.Fatal("expected expired session to be dead")
+	}
+	if !slices.Contains(jw.Sessions(), expired) {
+		t.Fatal("expected dead session to remain mapped before rotation")
+	}
+
+	// Do not start the processing loop: without maintenance the cookie is
+	// guaranteed to name a dead-but-still-mapped session when NewSession reads it.
+	r := makeRequest()
+	r.AddCookie(expiredCookie)
+	fresh := jw.NewSession(httptest.NewRecorder(), r)
+	if fresh == nil {
+		t.Fatal("NewSession returned nil")
+	}
+	if got := expired.Get("keep"); got != "expired" {
+		t.Fatalf("dead session data = %v, want unchanged", got)
+	}
+	if !slices.Contains(jw.Sessions(), expired) {
+		t.Fatal("dead session was removed during rotation")
+	}
+	if got := jw.GetSession(r); got != fresh {
+		t.Fatalf("GetSession() = %p, want fresh session %p", got, fresh)
 	}
 }
 

--- a/session_test.go
+++ b/session_test.go
@@ -154,6 +154,17 @@ func TestSession_NewSessionReplacesDuplicateCookieSessions(t *testing.T) {
 		cookie = sess.Cookie()
 		return
 	}
+	// attach binds a new Request to the session named by cookie, modelling a
+	// browser tab already using it.
+	attach := func(remoteAddr string, cookie *http.Cookie, want *Session) (rq *Request) {
+		t.Helper()
+		r := makeRequest(remoteAddr)
+		r.AddCookie(cookie)
+		if rq = jw.NewRequest(r); rq.Session() != want {
+			t.Fatalf("attached request session = %p, want %p", rq.Session(), want)
+		}
+		return
+	}
 
 	const (
 		sameIP  = "203.0.113.10:1234"
@@ -164,15 +175,33 @@ func TestSession_NewSessionReplacesDuplicateCookieSessions(t *testing.T) {
 	other, otherCookie := newSession(otherIP)
 	unknown, unknownCookie := newSession(sameIP)
 	unknown.Close()
+	expired, expiredCookie := newSession(sameIP)
 	first.Set("stale", "first")
 	second.Set("stale", "second")
 	other.Set("keep", "other")
+	expired.Set("keep", "expired")
+
+	// A tab on each duplicate session. Rotation must detach and reload both, not
+	// just the one named by the first matching cookie.
+	firstRequest := attach(sameIP, firstCookie, first)
+	secondRequest := attach(sameIP, secondCookie, second)
+
+	// Expire the last session without running maintenance cleanup, so its cookie
+	// names a session that is dead but still mapped. It has no attached Request,
+	// so the elapsed deadline alone makes it dead.
+	expired.mu.Lock()
+	expired.deadline = time.Now().Add(-time.Second)
+	expired.mu.Unlock()
+	if !expired.isDead() {
+		t.Fatal("expected expired session to be dead")
+	}
 
 	r := makeRequest(sameIP)
-	// Invalid, unknown, and other-IP cookies stay ignored while every distinct
-	// live same-IP session is closed, regardless of duplicates or ordering.
+	// Invalid, unknown, dead, and other-IP cookies stay ignored while every
+	// distinct live same-IP session is closed, regardless of duplicates or ordering.
 	r.AddCookie(&http.Cookie{Name: jw.CookieName, Value: first.CookieValue() + "/junk"})
 	r.AddCookie(unknownCookie)
+	r.AddCookie(expiredCookie)
 	r.AddCookie(otherCookie)
 	r.AddCookie(firstCookie)
 	r.AddCookie(firstCookie) // repeated ID
@@ -192,9 +221,10 @@ func TestSession_NewSessionReplacesDuplicateCookieSessions(t *testing.T) {
 	for _, old := range []struct {
 		name string
 		sess *Session
+		rq   *Request
 	}{
-		{name: "first", sess: first},
-		{name: "second", sess: second},
+		{name: "first", sess: first, rq: firstRequest},
+		{name: "second", sess: second, rq: secondRequest},
 	} {
 		if got := old.sess.Get("stale"); got != nil {
 			t.Errorf("%s old session retained stale data %v", old.name, got)
@@ -202,6 +232,28 @@ func TestSession_NewSessionReplacesDuplicateCookieSessions(t *testing.T) {
 		if cookie := old.sess.Cookie(); cookie == nil || cookie.MaxAge != -1 {
 			t.Errorf("%s old session cookie = %#v, want deletion cookie", old.name, cookie)
 		}
+		// Close detaches the attached Request and arms a reload on it, so the tab
+		// that was using the replaced session reloads instead of keeping it.
+		if got := old.rq.Session(); got != nil {
+			t.Errorf("%s attached request still bound to session %p", old.name, got)
+		}
+		old.rq.muQueue.Lock()
+		queued := slices.Clone(old.rq.wsQueue)
+		old.rq.muQueue.Unlock()
+		if len(queued) != 1 || queued[0].What != what.Reload {
+			t.Errorf("%s attached request queue = %v, want one Reload", old.name, queued)
+		}
+	}
+	// The dead-but-mapped session is skipped rather than rotated: NewSession
+	// neither cleared it nor handed it out. Whether maintenance has already reaped
+	// it from jw.sessions does not matter, since reaping never clears session data.
+	if got := expired.Get("keep"); got != "expired" {
+		t.Fatalf("dead session data = %v, want unchanged", got)
+	}
+	expiredRequest := makeRequest(sameIP)
+	expiredRequest.AddCookie(expiredCookie)
+	if got := jw.GetSession(expiredRequest); got != nil {
+		t.Fatalf("dead-session GetSession() = %p, want nil", got)
 	}
 	if got := other.Get("keep"); got != "other" {
 		t.Fatalf("other-IP session data = %v, want unchanged", got)
@@ -214,8 +266,30 @@ func TestSession_NewSessionReplacesDuplicateCookieSessions(t *testing.T) {
 	if got := jw.GetSession(otherRequest); got != other {
 		t.Fatalf("other-IP GetSession() = %p, want %p", got, other)
 	}
-	if got := jw.SessionCount(); got != 2 {
-		t.Fatalf("SessionCount() = %d, want fresh and other-IP sessions", got)
+	mapped := map[*Session]bool{}
+	for _, sess := range jw.Sessions() {
+		mapped[sess] = true
+	}
+	for _, closed := range []struct {
+		name string
+		sess *Session
+	}{
+		{name: "first", sess: first},
+		{name: "second", sess: second},
+		{name: "unknown", sess: unknown},
+	} {
+		if mapped[closed.sess] {
+			t.Errorf("%s session still mapped after being closed", closed.name)
+		}
+	}
+	if !mapped[fresh] || !mapped[other] {
+		t.Fatalf("mapped fresh = %v, other-IP = %v, want both retained", mapped[fresh], mapped[other])
+	}
+	// Drop the dead session before counting: a maintenance tick may or may not
+	// have reaped it by now, but nothing else may remain.
+	delete(mapped, expired)
+	if len(mapped) != 2 {
+		t.Fatalf("mapped sessions = %d, want only the fresh and other-IP sessions", len(mapped))
 	}
 	responseCookies := rr.Result().Cookies()
 	if len(responseCookies) != 1 {

--- a/session_test.go
+++ b/session_test.go
@@ -132,6 +132,100 @@ func TestSession_NewSessionCallsResponseWriterOutsideLock(t *testing.T) {
 	}
 }
 
+func TestSession_NewSessionReplacesDuplicateCookieSessions(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	go jw.Serve()
+	t.Cleanup(jw.Close)
+
+	makeRequest := func(remoteAddr string) *http.Request {
+		r := httptest.NewRequest(http.MethodGet, "http://example.test/login", nil)
+		r.RemoteAddr = remoteAddr
+		return r
+	}
+	newSession := func(remoteAddr string) (sess *Session, cookie *http.Cookie) {
+		t.Helper()
+		sess = jw.NewSession(httptest.NewRecorder(), makeRequest(remoteAddr))
+		if sess == nil {
+			t.Fatal("NewSession returned nil")
+		}
+		cookie = sess.Cookie()
+		return
+	}
+
+	const (
+		sameIP  = "203.0.113.10:1234"
+		otherIP = "198.51.100.20:5678"
+	)
+	first, firstCookie := newSession(sameIP)
+	second, secondCookie := newSession(sameIP)
+	other, otherCookie := newSession(otherIP)
+	unknown, unknownCookie := newSession(sameIP)
+	unknown.Close()
+	first.Set("stale", "first")
+	second.Set("stale", "second")
+	other.Set("keep", "other")
+
+	r := makeRequest(sameIP)
+	// Invalid, unknown, and other-IP cookies stay ignored while every distinct
+	// live same-IP session is closed, regardless of duplicates or ordering.
+	r.AddCookie(&http.Cookie{Name: jw.CookieName, Value: first.CookieValue() + "/junk"})
+	r.AddCookie(unknownCookie)
+	r.AddCookie(otherCookie)
+	r.AddCookie(firstCookie)
+	r.AddCookie(firstCookie) // repeated ID
+	r.AddCookie(secondCookie)
+	rr := httptest.NewRecorder()
+	fresh := jw.NewSession(rr, r)
+	if fresh == nil {
+		t.Fatal("NewSession returned nil")
+	}
+
+	if got := jw.GetSession(r); got != fresh {
+		t.Fatalf("GetSession() = %p, want fresh session %p", got, fresh)
+	}
+	if got := jw.NewRequest(r).Session(); got != fresh {
+		t.Fatalf("NewRequest().Session() = %p, want fresh session %p", got, fresh)
+	}
+	for _, old := range []struct {
+		name string
+		sess *Session
+	}{
+		{name: "first", sess: first},
+		{name: "second", sess: second},
+	} {
+		if got := old.sess.Get("stale"); got != nil {
+			t.Errorf("%s old session retained stale data %v", old.name, got)
+		}
+		if cookie := old.sess.Cookie(); cookie == nil || cookie.MaxAge != -1 {
+			t.Errorf("%s old session cookie = %#v, want deletion cookie", old.name, cookie)
+		}
+	}
+	if got := other.Get("keep"); got != "other" {
+		t.Fatalf("other-IP session data = %v, want unchanged", got)
+	}
+	if cookie := other.Cookie(); cookie == nil || cookie.MaxAge < 0 {
+		t.Fatalf("other-IP session cookie = %#v, want live cookie", cookie)
+	}
+	otherRequest := makeRequest(otherIP)
+	otherRequest.AddCookie(otherCookie)
+	if got := jw.GetSession(otherRequest); got != other {
+		t.Fatalf("other-IP GetSession() = %p, want %p", got, other)
+	}
+	if got := jw.SessionCount(); got != 2 {
+		t.Fatalf("SessionCount() = %d, want fresh and other-IP sessions", got)
+	}
+	responseCookies := rr.Result().Cookies()
+	if len(responseCookies) != 1 {
+		t.Fatalf("response cookies = %d, want one replacement cookie", len(responseCookies))
+	}
+	if got := responseCookies[0]; got.Name != jw.CookieName || got.Value != fresh.CookieValue() {
+		t.Fatalf("replacement cookie = %s=%s, want %s=%s", got.Name, got.Value, jw.CookieName, fresh.CookieValue())
+	}
+}
+
 func TestSession_CookieSecureMatchesRequest(t *testing.T) {
 	jw, _ := New()
 	defer jw.Close()


### PR DESCRIPTION
## Summary

- parse matching session-cookie IDs once during rotation
- clear and close every live same-IP session before creating the replacement
- preserve malformed, unknown, dead, and foreign-IP cookie behavior
- document that `NewSession` replaces all matching live sessions

## Tests

- `go test -race ./... -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec -quiet ./...`
- `go build ./...`

Fixes #234