### PR TITLE
fix(ui): keep getter src as initial Img source

### DIFF
--- a/lib/ui/html_widgets_test.go
+++ b/lib/ui/html_widgets_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"html/template"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/linkdata/jaws"
@@ -72,9 +73,30 @@ func TestImg_RenderAndUpdate(t *testing.T) {
 	src := newTestSetter("image.png")
 	ui := NewImg(src)
 	elem, got := renderUI(t, rq, ui, "hidden")
-	mustMatch(t, `^<img id="Jid\.[0-9]+" hidden src="image\.png">$`, got)
+	mustMatch(t, `^<img id="Jid\.[0-9]+" src="image\.png" hidden>$`, got)
 	src.Set("image2.jpg")
 	ui.JawsUpdate(elem)
+}
+
+func TestImg_RenderGetterSrcTakesPrecedence(t *testing.T) {
+	_, rq := newCoreRequest(t)
+	var mu sync.Mutex
+	src := "getter.png"
+	getter := bind.New(&mu, &src).InitialHTMLAttr(func(bind.Binder[string], *jaws.Element) (attr template.HTMLAttr) {
+		attr = `src="hook.png" data-getter="yes"`
+		return
+	})
+
+	_, got := renderUI(t, rq, NewImg(getter), template.HTMLAttr(`src="caller.png" data-caller="yes"`))
+	canonical := strings.Index(got, `src="getter.png"`)
+	caller := strings.Index(got, `src="caller.png"`)
+	hook := strings.Index(got, `src="hook.png"`)
+	if canonical < 0 || caller < 0 || hook < 0 || caller < canonical || hook < canonical {
+		t.Fatalf("getter src does not take precedence: %s", got)
+	}
+	if !strings.Contains(got, `data-caller="yes"`) || !strings.Contains(got, `data-getter="yes"`) {
+		t.Fatalf("rendered image missing non-src attributes: %s", got)
+	}
 }
 
 func TestImg_RenderEscapesSrcAttr(t *testing.T) {

--- a/lib/ui/img.go
+++ b/lib/ui/img.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"io"
+	"slices"
 
 	"github.com/linkdata/jaws"
 	"github.com/linkdata/jaws/lib/bind"
@@ -9,6 +10,9 @@ import (
 )
 
 // Img renders an HTML img element whose src is read from a string getter.
+//
+// The getter-derived src takes precedence over any src attribute passed as a
+// render param or returned by the getter's [jaws.InitialHTMLAttrHandler].
 //
 // One Img value may back multiple live [jaws.Element] values. Its getter is
 // shared by those Elements and must be safe for their render, update and event
@@ -23,7 +27,9 @@ func (u *Img) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err err
 	_, getterAttrs := elem.ApplyGetter(u.Getter)
 	srcAttr := htmlio.Attr("src", u.JawsGet(elem))
 	attrs := append(elem.ApplyParams(params), getterAttrs...)
-	attrs = append(attrs, srcAttr)
+	// HTML parsing keeps the first duplicate attribute, so emit the canonical
+	// src before caller and getter attributes.
+	attrs = slices.Insert(attrs, 0, srcAttr)
 	err = htmlio.WriteHTMLInner(w, elem.Jid(), "img", "", "", attrs...)
 	return
 }


### PR DESCRIPTION
## Summary

- emit the getter-backed Img src before caller and getter-hook attributes so browser parsing keeps the canonical initial source
- document getter src precedence
- add regression coverage for both duplicate-src paths and preservation of unrelated attributes

Fixes #250

## Verification

- `go generate ./...`
- `go vet ./...`
- `gofmt -l .`
- `gofumpt -l lib/ui/img.go lib/ui/html_widgets_test.go`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`
- `JAWS_REQUIRE_NODE=1 go test -race -coverprofile=coverage.out ./...`
- `JAWS_REQUIRE_NODE=1 go test ./...`
- `go build -v ./...`
- `GOOS=linux GOARCH=386 CGO_ENABLED=0 go test -exec=/usr/bin/true ./lib/bind/...`