### PR TITLE
docs(bind): require strictly comparable bound types

### DIFF
--- a/.agents/skills/jaws/SKILL.md
+++ b/.agents/skills/jaws/SKILL.md
@@ -83,7 +83,7 @@ These are the two usual building blocks for widget handlers passed to `$.Button`
 ### `bind.New[T comparable](l sync.Locker, p *T) Binder[T]`
 
 - Signature: `func New[T comparable](l sync.Locker, p *T) Binder[T]`. If `l` also satisfies `RWLocker` (has `RLock`/`RUnlock`), the binder takes the read lock for reads; otherwise it upgrades to the write lock.
-- `T` must be strictly comparable. The predeclared type `any`, all other interface types, and structs or arrays containing interface-typed components are unsupported regardless of their current values. The default setter comparison may panic for those types despite the broader `comparable` constraint.
+- `T` must be strictly comparable. Interface types, including `any`, are unsupported; an array's element type and every struct field type must also be strictly comparable, regardless of the bound values. The default setter comparison may panic when `T` satisfies the `comparable` constraint but is not strictly comparable.
 - The binder's tag is always `p` (the pointer itself). Chaining never changes tag identity — `bind.New(&mu, &field).Clicked(...).Success(...)` still reports `&field` as its tag, so dirty targeting via `&field` keeps working through refactors.
 - Default `JawsSetLocked` assigns `*p = v` only when the value changed and returns `jaws.ErrValueUnchanged` when it did not. This is what lets the input-widget family skip redundant updates.
 - Chain builders return a new `Binder[T]`:

--- a/.agents/skills/jaws/SKILL.md
+++ b/.agents/skills/jaws/SKILL.md
@@ -83,6 +83,7 @@ These are the two usual building blocks for widget handlers passed to `$.Button`
 ### `bind.New[T comparable](l sync.Locker, p *T) Binder[T]`
 
 - Signature: `func New[T comparable](l sync.Locker, p *T) Binder[T]`. If `l` also satisfies `RWLocker` (has `RLock`/`RUnlock`), the binder takes the read lock for reads; otherwise it upgrades to the write lock.
+- `T` must be strictly comparable. The predeclared type `any`, all other interface types, and structs or arrays containing interface-typed components are unsupported regardless of their current values. The default setter comparison may panic for those types despite the broader `comparable` constraint.
 - The binder's tag is always `p` (the pointer itself). Chaining never changes tag identity — `bind.New(&mu, &field).Clicked(...).Success(...)` still reports `&field` as its tag, so dirty targeting via `&field` keeps working through refactors.
 - Default `JawsSetLocked` assigns `*p = v` only when the value changed and returns `jaws.ErrValueUnchanged` when it did not. This is what lets the input-widget family skip redundant updates.
 - Chain builders return a new `Binder[T]`:

--- a/lib/bind/bind.go
+++ b/lib/bind/bind.go
@@ -6,6 +6,12 @@ import (
 
 // New returns a [Binder] with l protecting the value pointed to by p.
 //
+// T must be strictly comparable. The predeclared type any, all other interface
+// types, and structs or arrays containing interface-typed components are
+// unsupported, regardless of their current values. The default
+// [Binder.JawsSetLocked] comparison may panic for those types despite the
+// broader comparable constraint.
+//
 // If l implements [RWLocker], reads use its read lock. Otherwise reads and
 // writes both use l. The pointer p is also exposed as the UI tag.
 //

--- a/lib/bind/bind.go
+++ b/lib/bind/bind.go
@@ -6,11 +6,11 @@ import (
 
 // New returns a [Binder] with l protecting the value pointed to by p.
 //
-// T must be strictly comparable. The predeclared type any, all other interface
-// types, and structs or arrays containing interface-typed components are
-// unsupported, regardless of their current values. The default
-// [Binder.JawsSetLocked] comparison may panic for those types despite the
-// broader comparable constraint.
+// T must be strictly comparable. Interface types, including any, are
+// unsupported; an array's element type and every struct field type must also be
+// strictly comparable, regardless of the bound values. The default
+// [Binder.JawsSetLocked] comparison may panic when T satisfies the comparable
+// constraint but is not strictly comparable.
 //
 // If l implements [RWLocker], reads use its read lock. Otherwise reads and
 // writes both use l. The pointer p is also exposed as the UI tag.

--- a/lib/bind/binder.go
+++ b/lib/bind/binder.go
@@ -76,8 +76,13 @@ type Formatter interface {
 	Format(string) string
 }
 
-// Binder binds a comparable Go value to JaWS getter, setter, tag and event
-// interfaces.
+// Binder binds a Go value to JaWS getter, setter, tag and event interfaces.
+//
+// T must be strictly comparable. The predeclared type any, all other interface
+// types, and structs or arrays containing interface-typed components are
+// unsupported, regardless of their current values. The default
+// [Binder.JawsSetLocked] comparison may panic for those types despite the
+// broader comparable constraint.
 //
 // Binder methods are safe for concurrent use when the locker passed to [New]
 // is safe for concurrent use.
@@ -104,8 +109,12 @@ type Binder[T comparable] interface {
 	//
 	// Callers must already hold the write lock; the method does not lock or
 	// unlock and must not be called (nor [Setter.JawsSet] called) from within a
-	// hook. It applies this chain's [SetHook]s and returns
-	// [jaws.ErrValueUnchanged] when the stored value already equals value.
+	// hook. It applies this chain's [SetHook]s.
+	//
+	// The default implementation returned by [New] compares value with the stored
+	// value using !=, stores it when different, and returns
+	// [jaws.ErrValueUnchanged] when equal. T must be strictly comparable as
+	// documented by [Binder]; otherwise the comparison may panic.
 	JawsSetLocked(elem *jaws.Element, value T) (err error)
 
 	// JawsInitialHTMLAttrLocked returns the initial HTML attribute while the

--- a/lib/bind/binder.go
+++ b/lib/bind/binder.go
@@ -78,11 +78,11 @@ type Formatter interface {
 
 // Binder binds a Go value to JaWS getter, setter, tag and event interfaces.
 //
-// T must be strictly comparable. The predeclared type any, all other interface
-// types, and structs or arrays containing interface-typed components are
-// unsupported, regardless of their current values. The default
-// [Binder.JawsSetLocked] comparison may panic for those types despite the
-// broader comparable constraint.
+// T must be strictly comparable. Interface types, including any, are
+// unsupported; an array's element type and every struct field type must also be
+// strictly comparable, regardless of the bound values. The default
+// [Binder.JawsSetLocked] comparison may panic when T satisfies the comparable
+// constraint but is not strictly comparable.
 //
 // Binder methods are safe for concurrent use when the locker passed to [New]
 // is safe for concurrent use.
@@ -111,10 +111,9 @@ type Binder[T comparable] interface {
 	// unlock and must not be called (nor [Setter.JawsSet] called) from within a
 	// hook. It applies this chain's [SetHook]s.
 	//
-	// The default implementation returned by [New] compares value with the stored
-	// value using !=, stores it when different, and returns
-	// [jaws.ErrValueUnchanged] when equal. T must be strictly comparable as
-	// documented by [Binder]; otherwise the comparison may panic.
+	// The [Binder] returned by [New] stores value when it differs from the stored
+	// value and returns [jaws.ErrValueUnchanged] otherwise. This comparison may
+	// panic unless T is strictly comparable.
 	JawsSetLocked(elem *jaws.Element, value T) (err error)
 
 	// JawsInitialHTMLAttrLocked returns the initial HTML attribute while the


### PR DESCRIPTION
## Summary

- document that `bind.New` and `Binder` support only strictly comparable `T`
- identify `any`, other interface types, and interface-containing structs or arrays as unsupported regardless of their current values
- describe the direct equality and panic behavior of the default `JawsSetLocked` implementation
- align the repository JaWS skill guidance without changing runtime behavior

Closes #246

## Verification

- `go doc ./lib/bind New`
- `go doc ./lib/bind Binder`
- `go doc ./lib/bind Binder.JawsSetLocked`
- `go generate ./...`
- `go vet ./...`
- `gofmt -l .`
- `gofumpt -l .`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`
- `go test -race ./lib/bind/...`
- `JAWS_REQUIRE_NODE=1 go test -race -coverprofile=coverage.out ./...`
- `JAWS_REQUIRE_NODE=1 go test ./...`
- `go build -v ./...`
- `GOOS=linux GOARCH=386 CGO_ENABLED=0 go test -exec=/usr/bin/true ./lib/bind/...`