### PR TITLE
ui: specialize typed numeric bindings

### DIFF
--- a/lib/ui/number.go
+++ b/lib/ui/number.go
@@ -40,12 +40,13 @@ func NewNumber[T Numeric](source bind.Getter[T]) *Number {
 
 // JawsRender renders the Number as an HTML number input.
 func (u *Number) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err error) {
+	source := u.binding.sourceValue()
 	if u.binding.writable() {
-		if err = validateEditableNumericSource(u.binding.source); err != nil {
+		if err = validateEditableNumericSource(source); err != nil {
 			return
 		}
 	}
-	getterAttrs := u.applyGetterAttrs(elem, u.binding.source)
+	getterAttrs := u.applyGetterAttrs(elem, source)
 	text, err := u.binding.getText(elem)
 	if err != nil {
 		elem.Cancel(err)

--- a/lib/ui/number_range_test.go
+++ b/lib/ui/number_range_test.go
@@ -303,12 +303,7 @@ func TestRequestWriterRangeRendersExplicitBounds(t *testing.T) {
 	if err := rw.Range(newNumberRangeSource(150.0), `min="0"`, `max="200"`, `step="0.5"`); err != nil {
 		t.Fatal(err)
 	}
-	got := rendered.String()
-	for _, want := range []string{` min="0"`, ` max="200"`, ` step="0.5"`} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("Range markup %q does not contain %q", got, want)
-		}
-	}
+	mustMatch(t, `^<input id="Jid\.[0-9]+" type="range" value="150" min="0" max="200" step="0.5">$`, rendered.String())
 }
 
 func TestNumberRangeSourceCapabilities(t *testing.T) {

--- a/lib/ui/numeric.go
+++ b/lib/ui/numeric.go
@@ -36,6 +36,15 @@ func (nb numericBinding) getText(elem *jaws.Element) (text string, err error) {
 	return
 }
 
+func (nb numericBinding) acceptText(input *Input, elem *jaws.Element, text string) (accepted bool, err error) {
+	var value any
+	if value, accepted = nb.ops.parse(text); accepted {
+		input.Last.Store(text)
+		err = nb.setValue(elem, value)
+	}
+	return
+}
+
 func updateNumericInput(input *Input, binding numericBinding, elem *jaws.Element, name string) {
 	if input.Last.Load() == nil {
 		elem.Request.MustLog(fmt.Errorf("ui.%s.JawsUpdate called before successful rendering", name))
@@ -55,7 +64,7 @@ func handleNumericInput(input *Input, binding numericBinding, elem *jaws.Element
 	if !binding.writable() {
 		return
 	}
-	value, accepted := binding.ops.parse(text)
+	accepted, err := binding.acceptText(input, elem, text)
 	if !accepted {
 		// A formatter can never produce empty text, so empty forces the next
 		// update to restore the canonical value.
@@ -65,8 +74,6 @@ func handleNumericInput(input *Input, binding numericBinding, elem *jaws.Element
 		elem.Dirty(elem)
 		return
 	}
-	input.Last.Store(text)
-	err = binding.setValue(elem, value)
 	if errors.Is(err, jaws.ErrValueUnchanged) {
 		// The accepted text may still differ from the source's formatting.
 		elem.Dirty(elem)

--- a/lib/ui/numeric.go
+++ b/lib/ui/numeric.go
@@ -20,27 +20,36 @@ type Numeric interface {
 		~float32 | ~float64
 }
 
-type numericBinding struct {
-	source   any
-	ops      numericOps
-	getValue func(*jaws.Element) any
-	setValue func(*jaws.Element, any) error
+type numericBinding interface {
+	sourceValue() any
+	writable() bool
+	getText(*jaws.Element) (string, error)
+	acceptText(*Input, *jaws.Element, string) (bool, error)
 }
 
-func (nb numericBinding) writable() bool {
-	return nb.setValue != nil
+type numericTyped[T Numeric] struct {
+	source bind.Getter[T]
+	setter bind.Setter[T]
+	bits   int
 }
 
-func (nb numericBinding) getText(elem *jaws.Element) (text string, err error) {
-	text, err = nb.ops.format(nb.getValue(elem))
-	return
+func (nb *numericTyped[T]) sourceValue() any {
+	return nb.source
 }
 
-func (nb numericBinding) acceptText(input *Input, elem *jaws.Element, text string) (accepted bool, err error) {
-	var value any
-	if value, accepted = nb.ops.parse(text); accepted {
+func (nb *numericTyped[T]) writable() bool {
+	return nb.setter != nil
+}
+
+func (nb *numericTyped[T]) getText(elem *jaws.Element) (text string, err error) {
+	return formatNumeric(nb.source.JawsGet(elem), nb.bits)
+}
+
+func (nb *numericTyped[T]) acceptText(input *Input, elem *jaws.Element, text string) (accepted bool, err error) {
+	var value T
+	if value, accepted = parseNumeric[T](text, nb.bits); accepted {
 		input.Last.Store(text)
-		err = nb.setValue(elem, value)
+		err = nb.setter.JawsSet(elem, value)
 	}
 	return
 }
@@ -84,54 +93,129 @@ func handleNumericInput(input *Input, binding numericBinding, elem *jaws.Element
 	return
 }
 
-func newNumericBinding[T Numeric](source bind.Getter[T]) (nb numericBinding) {
-	nb.ops, _ = newNumericOps(reflect.TypeFor[T]())
-	nb.source = source
-	nb.getValue = func(elem *jaws.Element) any {
-		return source.JawsGet(elem)
-	}
+func newNumericBinding[T Numeric](source bind.Getter[T]) numericBinding {
+	nb := &numericTyped[T]{source: source, bits: reflect.TypeFor[T]().Bits()}
 	if setter, ok := any(source).(bind.Setter[T]); ok {
-		nb.setValue = func(elem *jaws.Element, value any) error {
-			return setter.JawsSet(elem, value.(T))
-		}
+		nb.setter = setter
 	}
 	return nb
+}
+
+type numericClass uint8
+
+const (
+	numericUnsigned numericClass = iota
+	numericSigned
+	numericFloat
+)
+
+func numericClassOf[T Numeric]() numericClass {
+	// Float comes first because subtraction is negative for signed integers and
+	// floats. Conversions to T make these non-constant expressions, so unsigned
+	// subtraction wraps instead of causing a constant-overflow error.
+	switch {
+	case T(1)/T(2) != T(0):
+		return numericFloat
+	case T(0)-T(1) < T(0):
+		return numericSigned
+	default:
+		return numericUnsigned
+	}
+}
+
+func formatNumeric[T Numeric](value T, bits int) (text string, err error) {
+	switch numericClassOf[T]() {
+	case numericFloat:
+		text, err = formatNumericFloat(float64(value), bits)
+	case numericSigned:
+		text = strconv.FormatInt(int64(value), 10)
+	case numericUnsigned:
+		text = strconv.FormatUint(uint64(value), 10)
+	}
+	return
+}
+
+func parseNumeric[T Numeric](text string, bits int) (value T, ok bool) {
+	switch numericClassOf[T]() {
+	case numericFloat:
+		var parsed float64
+		if parsed, ok = parseNumericFloat(text, bits); ok {
+			value = T(parsed)
+		}
+	case numericSigned:
+		var parsed int64
+		if parsed, ok = parseNumericInt(text); ok {
+			value = T(parsed)
+			ok = int64(value) == parsed
+		}
+	case numericUnsigned:
+		var parsed uint64
+		if parsed, ok = parseNumericUint(text); ok {
+			value = T(parsed)
+			ok = uint64(value) == parsed
+		}
+	}
+	return
 }
 
 // makeNumericBinding converts template Number and Range sources to the shared
 // type-erased representation. It accepts reflected numeric Getter/Setter
 // implementations and static built-in or named numeric values.
-func makeNumericBinding(source any) (nb numericBinding, ok bool) {
+func makeNumericBinding(source any) (binding numericBinding, ok bool) {
 	rv := reflect.ValueOf(source)
 	if !rv.IsValid() {
-		return numericBinding{}, false
+		return
 	}
 	if getter, ops, yes := reflectedNumericGetter(rv); yes {
-		nb.ops = ops
-		nb.source = source
-		nb.getValue = func(elem *jaws.Element) any {
-			out := getter.Call([]reflect.Value{reflect.ValueOf(elem)})
-			return out[0].Interface()
-		}
+		reflected := &numericReflected{source: source, getter: getter, ops: ops}
 		if setter, yes := reflectedNumericSetter(rv, ops.typ); yes {
-			nb.setValue = func(elem *jaws.Element, value any) (err error) {
-				out := setter.Call([]reflect.Value{reflect.ValueOf(elem), reflect.ValueOf(value)})
-				if !out[0].IsNil() {
-					err = out[0].Interface().(error)
-				}
-				return
-			}
+			reflected.setter = setter
 		}
-		return nb, true
+		binding = reflected
+		ok = true
+		return
 	}
 	if ops, yes := newNumericOps(rv.Type()); yes {
-		nb.ops = ops
-		nb.getValue = func(*jaws.Element) any {
-			return source
-		}
-		return nb, true
+		binding = &numericReflected{value: rv, ops: ops}
+		ok = true
 	}
-	return numericBinding{}, false
+	return
+}
+
+type numericReflected struct {
+	source any
+	value  reflect.Value
+	getter reflect.Value
+	setter reflect.Value
+	ops    numericOps
+}
+
+func (nb *numericReflected) sourceValue() any {
+	return nb.source
+}
+
+func (nb *numericReflected) writable() bool {
+	return nb.setter.IsValid()
+}
+
+func (nb *numericReflected) getText(elem *jaws.Element) (text string, err error) {
+	value := nb.value
+	if nb.getter.IsValid() {
+		value = nb.getter.Call([]reflect.Value{reflect.ValueOf(elem)})[0]
+	}
+	return nb.ops.formatValue(value)
+}
+
+func (nb *numericReflected) acceptText(input *Input, elem *jaws.Element, text string) (accepted bool, err error) {
+	var value reflect.Value
+	if value, accepted = nb.ops.parseValue(text); accepted {
+		input.Last.Store(text)
+		out := nb.setter.Call([]reflect.Value{reflect.ValueOf(elem), value})
+		if !out[0].IsNil() {
+			err = out[0].Interface().(error)
+		}
+	}
+	return
 }
 
 var (
@@ -187,52 +271,70 @@ func newNumericOps(typ reflect.Type) (ops numericOps, ok bool) {
 	return
 }
 
-func (ops numericOps) format(value any) (text string, err error) {
-	rv := reflect.ValueOf(value)
+func (ops numericOps) formatValue(value reflect.Value) (text string, err error) {
 	switch ops.kind {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		text = strconv.FormatInt(rv.Int(), 10)
+		text = strconv.FormatInt(value.Int(), 10)
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		text = strconv.FormatUint(rv.Uint(), 10)
+		text = strconv.FormatUint(value.Uint(), 10)
 	case reflect.Float32, reflect.Float64:
-		value := rv.Float()
-		if math.IsNaN(value) || math.IsInf(value, 0) {
-			err = fmt.Errorf("%w: %g", jaws.ErrValueNotFinite, value)
-			return
-		}
-		text = strconv.FormatFloat(value, 'f', -1, ops.bits)
+		text, err = formatNumericFloat(value.Float(), ops.bits)
 	}
 	return
 }
 
-func (ops numericOps) parse(text string) (value any, ok bool) {
-	rv := reflect.New(ops.typ).Elem()
+func (ops numericOps) parseValue(text string) (value reflect.Value, ok bool) {
+	value = reflect.New(ops.typ).Elem()
 	switch ops.kind {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		if n, err := strconv.ParseInt(text, 10, ops.bits); err == nil {
-			rv.SetInt(n)
-			value = rv.Interface()
+		if parsed, yes := parseNumericInt(text); yes && !value.OverflowInt(parsed) {
+			value.SetInt(parsed)
 			ok = true
 			return
 		}
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		if n, err := strconv.ParseUint(text, 10, ops.bits); err == nil {
-			rv.SetUint(n)
-			value = rv.Interface()
+		if parsed, yes := parseNumericUint(text); yes && !value.OverflowUint(parsed) {
+			value.SetUint(parsed)
 			ok = true
 			return
 		}
 	case reflect.Float32, reflect.Float64:
-		// Browsers sanitize number and range values before jaws.js reads them.
-		// Forged finite Go spellings add no values and accepted input is canonicalized.
-		if n, err := strconv.ParseFloat(text, ops.bits); err == nil && !math.IsNaN(n) && !math.IsInf(n, 0) {
-			rv.SetFloat(n)
-			value = rv.Interface()
+		if parsed, yes := parseNumericFloat(text, ops.bits); yes {
+			value.SetFloat(parsed)
 			ok = true
 			return
 		}
 	}
 	// Numeric widgets restore rejected input without turning validation into a
 	// handler error.
-	return nil, false
+	return reflect.Value{}, false
+}
+
+func parseNumericInt(text string) (value int64, ok bool) {
+	value, err := strconv.ParseInt(text, 10, 64)
+	ok = err == nil
+	return
+}
+
+func parseNumericUint(text string) (value uint64, ok bool) {
+	value, err := strconv.ParseUint(text, 10, 64)
+	ok = err == nil
+	return
+}
+
+func formatNumericFloat(value float64, bits int) (text string, err error) {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		err = fmt.Errorf("%w: %g", jaws.ErrValueNotFinite, value)
+		return
+	}
+	text = strconv.FormatFloat(value, 'f', -1, bits)
+	return
+}
+
+func parseNumericFloat(text string, bits int) (value float64, ok bool) {
+	// Browsers sanitize number and range values before jaws.js reads them.
+	// Forged finite Go spellings add no values and accepted input is canonicalized.
+	value, err := strconv.ParseFloat(text, bits)
+	ok = err == nil && !math.IsNaN(value) && !math.IsInf(value, 0)
+	return
 }

--- a/lib/ui/numeric.go
+++ b/lib/ui/numeric.go
@@ -20,13 +20,24 @@ type Numeric interface {
 		~float32 | ~float64
 }
 
+// numericBinding lets Number and Range share logic across two source paths.
+// NewNumber and NewRange retain T, so numericTyped can call typed getters and
+// setters directly. RequestWriter receives any for template use, and a finite
+// type switch cannot cover arbitrary named numeric types, so numericReflected
+// discovers their methods at runtime. Both paths share the parsing and
+// formatting helpers below.
 type numericBinding interface {
 	sourceValue() any
 	writable() bool
 	getText(*jaws.Element) (string, error)
+	// acceptText is called only when writable reports true. It stores accepted
+	// text in Input.Last before invoking the setter because a setter hook may
+	// dirty the Element and allow JawsUpdate to read Last concurrently. Its
+	// error is meaningful only when accepted is true.
 	acceptText(*Input, *jaws.Element, string) (bool, error)
 }
 
+// numericTyped preserves the compile-time numeric type used by constructors.
 type numericTyped[T Numeric] struct {
 	source bind.Getter[T]
 	setter bind.Setter[T]
@@ -73,8 +84,9 @@ func handleNumericInput(input *Input, binding numericBinding, elem *jaws.Element
 	if !binding.writable() {
 		return
 	}
-	accepted, err := binding.acceptText(input, elem, text)
+	accepted, setErr := binding.acceptText(input, elem, text)
 	if !accepted {
+		// Rejected browser text is validation, not a handler error.
 		// A formatter can never produce empty text, so empty forces the next
 		// update to restore the canonical value.
 		input.Last.Store("")
@@ -83,6 +95,7 @@ func handleNumericInput(input *Input, binding numericBinding, elem *jaws.Element
 		elem.Dirty(elem)
 		return
 	}
+	err = setErr
 	if errors.Is(err, jaws.ErrValueUnchanged) {
 		// The accepted text may still differ from the source's formatting.
 		elem.Dirty(elem)
@@ -101,6 +114,7 @@ func newNumericBinding[T Numeric](source bind.Getter[T]) numericBinding {
 	return nb
 }
 
+// numericClass selects the parser and formatter family for a numeric type.
 type numericClass uint8
 
 const (
@@ -182,6 +196,7 @@ func makeNumericBinding(source any) (binding numericBinding, ok bool) {
 	return
 }
 
+// numericReflected adapts a numeric source known only at runtime.
 type numericReflected struct {
 	source any
 	value  reflect.Value

--- a/lib/ui/numeric_benchmark_test.go
+++ b/lib/ui/numeric_benchmark_test.go
@@ -54,6 +54,31 @@ func BenchmarkNumericBindingGetText(b *testing.B) {
 	benchmarkNumericBindingGetText(b, "float32", numericBenchmarkFloat32(0.1))
 }
 
+func benchmarkNumericBindingReflectedGetText[T Numeric](b *testing.B, name string, value T) {
+	b.Helper()
+	b.Run(name, func(b *testing.B) {
+		source := &numericBenchmarkSource[T]{value: value}
+		binding, ok := makeNumericBinding(source)
+		if !ok {
+			b.Fatalf("makeNumericBinding(%T) rejected numeric source", source)
+		}
+		var text string
+		var err error
+		b.ReportAllocs()
+		for b.Loop() {
+			text, err = binding.getText(nil)
+		}
+		numericBenchmarkTextSink = text
+		numericBenchmarkErrorSink = err
+	})
+}
+
+func BenchmarkNumericBindingReflectedGetText(b *testing.B) {
+	benchmarkNumericBindingReflectedGetText(b, "int16", numericBenchmarkInt(-12345))
+	benchmarkNumericBindingReflectedGetText(b, "uint64", numericBenchmarkUint(12345678901234567890))
+	benchmarkNumericBindingReflectedGetText(b, "float32", numericBenchmarkFloat32(0.1))
+}
+
 func benchmarkNumericBindingAcceptText[T Numeric](b *testing.B, name, text string, value T) {
 	b.Helper()
 	b.Run(name, func(b *testing.B) {
@@ -77,6 +102,32 @@ func BenchmarkNumericBindingAcceptText(b *testing.B) {
 	benchmarkNumericBindingAcceptText(b, "float32", "0.1", numericBenchmarkFloat32(0))
 }
 
+func benchmarkNumericBindingReflectedAcceptText[T Numeric](b *testing.B, name, text string, value T) {
+	b.Helper()
+	b.Run(name, func(b *testing.B) {
+		source := &numericBenchmarkSource[T]{value: value}
+		binding, ok := makeNumericBinding(source)
+		if !ok {
+			b.Fatalf("makeNumericBinding(%T) rejected numeric source", source)
+		}
+		input := &Input{}
+		var accepted bool
+		var err error
+		b.ReportAllocs()
+		for b.Loop() {
+			accepted, err = binding.acceptText(input, nil, text)
+		}
+		numericBenchmarkBoolSink = accepted
+		numericBenchmarkErrorSink = err
+	})
+}
+
+func BenchmarkNumericBindingReflectedAcceptText(b *testing.B) {
+	benchmarkNumericBindingReflectedAcceptText(b, "int16", "-12345", numericBenchmarkInt(0))
+	benchmarkNumericBindingReflectedAcceptText(b, "uint64", "12345678901234567890", numericBenchmarkUint(0))
+	benchmarkNumericBindingReflectedAcceptText(b, "float32", "0.1", numericBenchmarkFloat32(0))
+}
+
 func benchmarkNumericBindingConstruction[T Numeric](b *testing.B, name string, value T) {
 	b.Helper()
 	b.Run(name, func(b *testing.B) {
@@ -92,4 +143,23 @@ func BenchmarkNumericBindingConstruction(b *testing.B) {
 	benchmarkNumericBindingConstruction(b, "int16", numericBenchmarkInt(-12345))
 	benchmarkNumericBindingConstruction(b, "uint64", numericBenchmarkUint(12345678901234567890))
 	benchmarkNumericBindingConstruction(b, "float32", numericBenchmarkFloat32(0.1))
+}
+
+func benchmarkNumericBindingReflectedConstruction[T Numeric](b *testing.B, name string, value T) {
+	b.Helper()
+	b.Run(name, func(b *testing.B) {
+		source := &numericBenchmarkSource[T]{value: value}
+		var ok bool
+		b.ReportAllocs()
+		for b.Loop() {
+			numericBenchmarkBindingSink, ok = makeNumericBinding(source)
+		}
+		numericBenchmarkBoolSink = ok
+	})
+}
+
+func BenchmarkNumericBindingReflectedConstruction(b *testing.B) {
+	benchmarkNumericBindingReflectedConstruction(b, "int16", numericBenchmarkInt(-12345))
+	benchmarkNumericBindingReflectedConstruction(b, "uint64", numericBenchmarkUint(12345678901234567890))
+	benchmarkNumericBindingReflectedConstruction(b, "float32", numericBenchmarkFloat32(0.1))
 }

--- a/lib/ui/numeric_benchmark_test.go
+++ b/lib/ui/numeric_benchmark_test.go
@@ -1,0 +1,95 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/linkdata/jaws"
+)
+
+type numericBenchmarkSource[T comparable] struct {
+	value T
+}
+
+func (source *numericBenchmarkSource[T]) JawsGet(*jaws.Element) T {
+	return source.value
+}
+
+func (source *numericBenchmarkSource[T]) JawsSet(_ *jaws.Element, value T) error {
+	source.value = value
+	return nil
+}
+
+type (
+	numericBenchmarkInt     int16
+	numericBenchmarkUint    uint64
+	numericBenchmarkFloat32 float32
+)
+
+var (
+	numericBenchmarkBindingSink numericBinding
+	numericBenchmarkTextSink    string
+	numericBenchmarkBoolSink    bool
+	numericBenchmarkErrorSink   error
+)
+
+func benchmarkNumericBindingGetText[T Numeric](b *testing.B, name string, value T) {
+	b.Helper()
+	b.Run(name, func(b *testing.B) {
+		source := &numericBenchmarkSource[T]{value: value}
+		binding := newNumericBinding[T](source)
+		var text string
+		var err error
+		b.ReportAllocs()
+		for b.Loop() {
+			text, err = binding.getText(nil)
+		}
+		numericBenchmarkTextSink = text
+		numericBenchmarkErrorSink = err
+	})
+}
+
+func BenchmarkNumericBindingGetText(b *testing.B) {
+	benchmarkNumericBindingGetText(b, "int16", numericBenchmarkInt(-12345))
+	benchmarkNumericBindingGetText(b, "uint64", numericBenchmarkUint(12345678901234567890))
+	benchmarkNumericBindingGetText(b, "float32", numericBenchmarkFloat32(0.1))
+}
+
+func benchmarkNumericBindingAcceptText[T Numeric](b *testing.B, name, text string, value T) {
+	b.Helper()
+	b.Run(name, func(b *testing.B) {
+		source := &numericBenchmarkSource[T]{value: value}
+		binding := newNumericBinding[T](source)
+		input := &Input{}
+		var accepted bool
+		var err error
+		b.ReportAllocs()
+		for b.Loop() {
+			accepted, err = binding.acceptText(input, nil, text)
+		}
+		numericBenchmarkBoolSink = accepted
+		numericBenchmarkErrorSink = err
+	})
+}
+
+func BenchmarkNumericBindingAcceptText(b *testing.B) {
+	benchmarkNumericBindingAcceptText(b, "int16", "-12345", numericBenchmarkInt(0))
+	benchmarkNumericBindingAcceptText(b, "uint64", "12345678901234567890", numericBenchmarkUint(0))
+	benchmarkNumericBindingAcceptText(b, "float32", "0.1", numericBenchmarkFloat32(0))
+}
+
+func benchmarkNumericBindingConstruction[T Numeric](b *testing.B, name string, value T) {
+	b.Helper()
+	b.Run(name, func(b *testing.B) {
+		source := &numericBenchmarkSource[T]{value: value}
+		b.ReportAllocs()
+		for b.Loop() {
+			numericBenchmarkBindingSink = newNumericBinding[T](source)
+		}
+	})
+}
+
+func BenchmarkNumericBindingConstruction(b *testing.B) {
+	benchmarkNumericBindingConstruction(b, "int16", numericBenchmarkInt(-12345))
+	benchmarkNumericBindingConstruction(b, "uint64", numericBenchmarkUint(12345678901234567890))
+	benchmarkNumericBindingConstruction(b, "float32", numericBenchmarkFloat32(0.1))
+}

--- a/lib/ui/numeric_test.go
+++ b/lib/ui/numeric_test.go
@@ -10,21 +10,65 @@ import (
 	"github.com/linkdata/jaws"
 )
 
+func testNumericOpsFormat[T Numeric](ops numericOps, value T) (string, error) {
+	return ops.formatValue(reflect.ValueOf(value))
+}
+
+func testNumericOpsParse[T Numeric](ops numericOps, text string) (value T, ok bool) {
+	if parsed, yes := ops.parseValue(text); yes {
+		return parsed.Interface().(T), true
+	}
+	return
+}
+
 func testNumericParse[T Numeric](t *testing.T, text string, want T, wantOK bool) {
 	t.Helper()
-	ops, ok := newNumericOps(reflect.TypeFor[T]())
+	typ := reflect.TypeFor[T]()
+	bits := typ.Bits()
+	typed, typedOK := parseNumeric[T](text, bits)
+	if typedOK != wantOK {
+		t.Fatalf("parseNumeric[%v](%q) ok = %v, want %v", typ, text, typedOK, wantOK)
+	}
+	if typedOK && typed != want {
+		t.Fatalf("parseNumeric[%v](%q) = %v, want %v", typ, text, typed, want)
+	}
+
+	ops, ok := newNumericOps(typ)
 	if !ok {
 		t.Fatalf("newNumericOps(%T) rejected numeric type", want)
 	}
-	value, gotOK := ops.parse(text)
+	value, gotOK := testNumericOpsParse[T](ops, text)
 	if gotOK != wantOK {
-		t.Fatalf("parse(%q) ok = %v, want %v", text, gotOK, wantOK)
+		t.Fatalf("numericOps(%v).parse(%q) ok = %v, want %v", typ, text, gotOK, wantOK)
 	}
-	if gotOK {
-		if got := value.(T); got != want {
-			t.Fatalf("parse(%q) = %v, want %v", text, got, want)
+	if gotOK && value != want {
+		t.Fatalf("numericOps(%v).parse(%q) = %v, want %v", typ, text, value, want)
+	}
+}
+
+func testNumericFormat[T Numeric](t *testing.T, name string, value T, wantText string, wantErr error) {
+	t.Helper()
+	t.Run(name, func(t *testing.T) {
+		typ := reflect.TypeFor[T]()
+		ops, ok := newNumericOps(typ)
+		if !ok {
+			t.Fatalf("newNumericOps(%v) rejected numeric type", typ)
 		}
-	}
+		typedText, typedErr := formatNumeric(value, typ.Bits())
+		reflectedText, reflectedErr := testNumericOpsFormat(ops, value)
+		for _, result := range []struct {
+			name string
+			text string
+			err  error
+		}{
+			{"typed", typedText, typedErr},
+			{"reflected", reflectedText, reflectedErr},
+		} {
+			if result.text != wantText || !errors.Is(result.err, wantErr) {
+				t.Errorf("%s format = (%q, %v), want (%q, %v)", result.name, result.text, result.err, wantText, wantErr)
+			}
+		}
+	})
 }
 
 func TestNumericParseIntegerSyntax(t *testing.T) {
@@ -90,71 +134,65 @@ func TestNumericParseIntegerBoundaries(t *testing.T) {
 		testNumericParse(t, "9223372036854775807", maxInt, true)
 		testNumericParse(t, "9223372036854775808", int(0), false)
 		testNumericParse(t, "18446744073709551615", maxUint, true)
+		testNumericParse(t, "18446744073709551616", uint(0), false)
 		testNumericParse(t, "18446744073709551615", maxUintptr, true)
+		testNumericParse(t, "18446744073709551616", uintptr(0), false)
 	} else {
 		testNumericParse(t, "-2147483648", minInt, true)
 		testNumericParse(t, "2147483647", maxInt, true)
 		testNumericParse(t, "2147483648", int(0), false)
 		testNumericParse(t, "4294967295", maxUint, true)
+		testNumericParse(t, "4294967296", uint(0), false)
 		testNumericParse(t, "4294967295", maxUintptr, true)
+		testNumericParse(t, "4294967296", uintptr(0), false)
 	}
 }
 
 type (
-	numericNamedInt   int16
-	numericNamedUint  uint64
-	numericNamedFloat float32
+	numericNamedInt       int16
+	numericNamedUint      uint64
+	numericNamedSmallUint uint16
+	numericNamedFloat     float32
 )
 
 func TestNumericNamedTypes(t *testing.T) {
 	testNumericParse(t, "-32768", numericNamedInt(-32768), true)
+	testNumericParse(t, "-32769", numericNamedInt(0), false)
 	testNumericParse(t, "18446744073709551615", numericNamedUint(math.MaxUint64), true)
+	testNumericParse(t, "65536", numericNamedSmallUint(0), false)
 	testNumericParse(t, "0.1", numericNamedFloat(0.1), true)
+	testNumericParse(t, "3.4028236e38", numericNamedFloat(0), false)
 }
 
-func TestNumericFloatParsingAndFormatting(t *testing.T) {
-	ops32, _ := newNumericOps(reflect.TypeFor[float32]())
-	text, err := ops32.format(float32(0.1))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if text != "0.1" {
-		t.Fatalf("float32(0.1) formatted as %q", text)
-	}
-	value, ok := ops32.parse("1e-46")
-	if !ok || value.(float32) != 0 {
-		t.Fatalf("float32 underflow = (%v, %v), want (0, true)", value, ok)
-	}
-	if _, ok = ops32.parse("3.4028236e38"); ok {
-		t.Fatal("float32 overflow was accepted")
-	}
-	if _, ok = ops32.parse("NaN"); ok {
-		t.Fatal("NaN was accepted")
-	}
-	if _, ok = ops32.parse("not a number"); ok {
-		t.Fatal("malformed float was accepted")
-	}
-	if _, err = ops32.format(float32(math.Inf(1))); !errors.Is(err, jaws.ErrValueNotFinite) {
-		t.Fatalf("format(+Inf) error = %v, want ErrValueNotFinite", err)
-	}
-	if _, err = ops32.format(float32(math.NaN())); !errors.Is(err, jaws.ErrValueNotFinite) {
-		t.Fatalf("format(NaN) error = %v, want ErrValueNotFinite", err)
-	}
+func TestNumericFormatting(t *testing.T) {
+	testNumericFormat(t, "signed", numericNamedInt(-12345), "-12345", nil)
+	testNumericFormat(t, "unsigned", numericNamedUint(math.MaxUint64), "18446744073709551615", nil)
+	testNumericFormat(t, "float32", numericNamedFloat(0.1), "0.1", nil)
+	testNumericFormat(t, "float64", float64(1.25), "1.25", nil)
+	testNumericFormat(t, "negative zero", math.Copysign(0, -1), "-0", nil)
+	testNumericFormat(t, "infinity", math.Inf(1), "", jaws.ErrValueNotFinite)
+	testNumericFormat(t, "NaN", float32(math.NaN()), "", jaws.ErrValueNotFinite)
+}
+
+func TestNumericFloatParsing(t *testing.T) {
+	testNumericParse(t, "1e-46", float32(0), true)
+	testNumericParse(t, "3.4028236e38", float32(0), false)
+	testNumericParse(t, "NaN", float32(0), false)
+	testNumericParse(t, "not a number", float32(0), false)
+	testNumericParse(t, "1.0000000596046448", math.Float32frombits(0x3f800001), true)
 
 	ops64, _ := newNumericOps(reflect.TypeFor[float64]())
-	negativeZero := math.Copysign(0, -1)
-	text, err = ops64.format(negativeZero)
-	if err != nil {
-		t.Fatal(err)
-	}
-	value, ok = ops64.parse(text)
-	if !ok || !math.Signbit(value.(float64)) {
-		t.Fatalf("negative zero round trip = (%v, %v)", value, ok)
+	typed, typedOK := parseNumeric[float64]("-0", 64)
+	reflected, reflectedOK := testNumericOpsParse[float64](ops64, "-0")
+	if !typedOK || !math.Signbit(typed) || !reflectedOK || !math.Signbit(reflected) {
+		t.Fatalf("negative zero parse = typed(%v, %v), reflected(%v, %v)", typed, typedOK, reflected, reflectedOK)
 	}
 }
 
 type numericTestSource[T comparable] struct {
-	value T
+	value    T
+	input    *Input
+	seenLast any
 }
 
 func (source *numericTestSource[T]) JawsGet(*jaws.Element) T {
@@ -162,8 +200,24 @@ func (source *numericTestSource[T]) JawsGet(*jaws.Element) T {
 }
 
 func (source *numericTestSource[T]) JawsSet(_ *jaws.Element, value T) error {
+	if source.input != nil {
+		source.seenLast = source.input.Last.Load()
+	}
 	source.value = value
 	return nil
+}
+
+func TestTypedNumericBindingStoresLastBeforeSet(t *testing.T) {
+	input := &Input{}
+	source := &numericTestSource[numericNamedInt]{input: input}
+	binding := newNumericBinding[numericNamedInt](source)
+	accepted, err := binding.acceptText(input, nil, "-123")
+	if !accepted || err != nil || source.value != -123 {
+		t.Fatalf("typed accept = (%v, %v), value = %v", accepted, err, source.value)
+	}
+	if source.seenLast != "-123" {
+		t.Fatalf("Last observed by typed setter = %v, want -123", source.seenLast)
+	}
 }
 
 type numericBadGetterArity struct{}
@@ -189,37 +243,41 @@ func (numericBadSetter) JawsSet(*jaws.Element, int) bool {
 }
 
 type numericErrorSetter struct {
-	err error
+	err      error
+	input    *Input
+	seenLast any
 }
 
-func (numericErrorSetter) JawsGet(*jaws.Element) int {
+func (*numericErrorSetter) JawsGet(*jaws.Element) int {
 	return 1
 }
 
-func (source numericErrorSetter) JawsSet(*jaws.Element, int) error {
+func (source *numericErrorSetter) JawsSet(*jaws.Element, int) error {
+	source.seenLast = source.input.Last.Load()
 	return source.err
 }
 
 func TestMakeNumericBinding(t *testing.T) {
 	source := &numericTestSource[numericNamedUint]{value: 7}
 	nb, ok := makeNumericBinding(source)
-	if !ok || !nb.writable() || nb.source != source {
+	if !ok || !nb.writable() || nb.sourceValue() != source {
 		t.Fatalf("reflected binding = (%v, %v)", nb, ok)
 	}
 	text, err := nb.getText(nil)
 	if err != nil || text != "7" {
 		t.Fatalf("reflected get = (%q, %v), want (7, nil)", text, err)
 	}
-	value, accepted := nb.ops.parse("18446744073709551615")
-	if !accepted {
-		t.Fatal("reflected binding rejected uint64 maximum")
+	input := &Input{}
+	accepted, err := nb.acceptText(input, nil, "18446744073709551615")
+	if !accepted || err != nil || source.value != numericNamedUint(math.MaxUint64) {
+		t.Fatalf("reflected accept = (%v, %v), value = %v", accepted, err, source.value)
 	}
-	if err = nb.setValue(nil, value); err != nil || source.value != numericNamedUint(math.MaxUint64) {
-		t.Fatalf("reflected set = %v, value = %v", err, source.value)
+	if last := input.Last.Load(); last != "18446744073709551615" {
+		t.Fatalf("reflected accept stored Last = %v", last)
 	}
 
 	static, ok := makeNumericBinding(numericNamedInt(-12))
-	if !ok || static.writable() || static.source != nil {
+	if !ok || static.writable() || static.sourceValue() != nil {
 		t.Fatalf("static binding = (%v, %v)", static, ok)
 	}
 	if text, err = static.getText(nil); err != nil || text != "-12" {
@@ -237,7 +295,7 @@ func TestMakeNumericBinding(t *testing.T) {
 	}
 	for _, tt := range invalidSources {
 		t.Run(tt.name, func(t *testing.T) {
-			if binding, accepted := makeNumericBinding(tt.source); accepted || binding.getValue != nil {
+			if binding, accepted := makeNumericBinding(tt.source); accepted || binding != nil {
 				t.Fatalf("makeNumericBinding(%T) = (%v, %v), want zero binding and false", tt.source, binding, accepted)
 			}
 		})
@@ -249,11 +307,17 @@ func TestMakeNumericBinding(t *testing.T) {
 	}
 
 	setErr := errors.New("numeric setter error")
-	errorSetter, ok := makeNumericBinding(numericErrorSetter{err: setErr})
+	errorInput := &Input{}
+	errorSource := &numericErrorSetter{err: setErr, input: errorInput}
+	errorSetter, ok := makeNumericBinding(errorSource)
 	if !ok || !errorSetter.writable() {
 		t.Fatalf("error setter binding = (%v, %v), want writable binding", errorSetter, ok)
 	}
-	if err = errorSetter.setValue(nil, 2); !errors.Is(err, setErr) {
-		t.Fatalf("reflected setter error = %v, want %v", err, setErr)
+	accepted, err = errorSetter.acceptText(errorInput, nil, "2")
+	if !accepted || !errors.Is(err, setErr) {
+		t.Fatalf("reflected accept = (%v, %v), want (true, %v)", accepted, err, setErr)
+	}
+	if errorSource.seenLast != "2" {
+		t.Fatalf("Last observed by setter = %v, want 2", errorSource.seenLast)
 	}
 }

--- a/lib/ui/numeric_test.go
+++ b/lib/ui/numeric_test.go
@@ -208,6 +208,8 @@ func (source *numericTestSource[T]) JawsSet(_ *jaws.Element, value T) error {
 }
 
 func TestTypedNumericBindingStoresLastBeforeSet(t *testing.T) {
+	// Observing Last at setter entry pins the ordering needed when a setter hook
+	// dirties the Element and lets JawsUpdate run before JawsSet returns.
 	input := &Input{}
 	source := &numericTestSource[numericNamedInt]{input: input}
 	binding := newNumericBinding[numericNamedInt](source)
@@ -217,6 +219,40 @@ func TestTypedNumericBindingStoresLastBeforeSet(t *testing.T) {
 	}
 	if source.seenLast != "-123" {
 		t.Fatalf("Last observed by typed setter = %v, want -123", source.seenLast)
+	}
+}
+
+type numericRejectedBinding struct {
+	err error
+}
+
+func (binding numericRejectedBinding) sourceValue() any {
+	return nil
+}
+
+func (binding numericRejectedBinding) writable() bool {
+	return true
+}
+
+func (binding numericRejectedBinding) getText(*jaws.Element) (string, error) {
+	return "", nil
+}
+
+func (binding numericRejectedBinding) acceptText(*Input, *jaws.Element, string) (bool, error) {
+	return false, binding.err
+}
+
+func TestHandleNumericInputRejectsWithoutError(t *testing.T) {
+	_, rq := newCoreRequest(t)
+	elem := rq.NewElement(nil)
+	input := &Input{}
+	input.Last.Store("previous")
+	err := handleNumericInput(input, numericRejectedBinding{err: errors.New("ignored")}, elem, "bad")
+	if err != nil {
+		t.Fatalf("handleNumericInput rejected error = %v, want nil", err)
+	}
+	if last := input.Last.Load(); last != "" {
+		t.Fatalf("Last after rejected input = %v, want empty string", last)
 	}
 }
 

--- a/lib/ui/range.go
+++ b/lib/ui/range.go
@@ -44,12 +44,13 @@ func NewRange[T Numeric](source bind.Getter[T]) *Range {
 
 // JawsRender renders the Range as an HTML range input.
 func (u *Range) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err error) {
+	source := u.binding.sourceValue()
 	if u.binding.writable() {
-		if err = validateEditableNumericSource(u.binding.source); err != nil {
+		if err = validateEditableNumericSource(source); err != nil {
 			return
 		}
 	}
-	getterAttrs := u.applyGetterAttrs(elem, u.binding.source)
+	getterAttrs := u.applyGetterAttrs(elem, source)
 	text, err := u.binding.getText(elem)
 	if err != nil {
 		elem.Cancel(err)


### PR DESCRIPTION
## Summary

- Preserve `T` through `NewNumber` and `NewRange` parsing, formatting, and setter calls instead of boxing values for reflection.
- Keep the template-facing `RequestWriter.Number` and `RequestWriter.Range` path type-erased behind a reflected binding.
- Share the integer syntax, float finiteness, and direct float32-rounding rules between both paths.
- Add differential tests for typed and reflected bindings, width boundaries, named types, setter ordering, and float32 double-rounding.
- Document why the two adapters coexist and the store-before-set ordering required by concurrent dirty updates.
- Retain typed and reflected benchmark coverage as a regression guard.

## Benchmarks

These are deliberately narrow benchmarks of the numeric binding adapter:

- `GetText` constructs the binding once, then repeatedly calls the getter and formats its value as browser text. It measures the path used while rendering or updating an existing widget.
- `AcceptText` constructs the binding and `Input` once, then repeatedly parses valid browser text, stores it in `Input.Last`, and calls a trivial setter. It measures numeric conversion and binding dispatch, not dirty propagation or application setter work.
- `Construction` repeatedly builds only the binding adapter. For the typed path this is `newNumericBinding[T]`; for the reflected path it is `makeNumericBinding`, including method discovery and validation.

All three use named `int16`, `uint64`, and `float32` types. These cover a narrow signed integer, the widest decimal integer, and the precision-sensitive float32 path while ensuring the reflected case exercises named types rather than a finite switch over predeclared types.

The benchmarks exclude HTML generation, WebSocket traffic, Requests, Elements, dirty processing, and browser work. The percentages therefore describe binding overhead, not end-to-end JaWS performance.

### Method

The main-equivalent baseline is `62dc4cd`: merged main (`cb84464`) plus the benchmark harness and a behavior-neutral extraction that makes accepted input directly benchmarkable. It precedes the typed/reflected implementation split. The reflected benchmark cases added during review were overlaid unchanged on that revision, so baseline and PR ran identical benchmark code.

Every row below therefore compares the main-equivalent implementation with PR #263 for the operation named in that row. Each case ran ten times and was compared with `benchstat`:

```console
go test -run '^$' -bench '^BenchmarkNumericBinding' -benchmem -benchtime=200ms -count=10 ./lib/ui
```

Apple M5 Max, darwin/arm64.

### `NewNumber[T]` and `NewRange[T]`: main versus PR

This table measures the binding path selected when Go code calls the generic constructors. The binding retains the compile-time type `T` in the PR.

| Measured operation and type | Main-equivalent `62dc4cd` | PR #263 `3b73ae0` | PR change | Main allocs/op | PR allocs/op |
|---|---:|---:|---:|---:|---:|
| Render/update: getter + format / int16 | 15.29 ns | 10.95 ns | -28.36% | 2 | 1 |
| Render/update: getter + format / uint64 | 23.00 ns | 17.16 ns | -25.43% | 2 | 1 |
| Render/update: getter + format / float32 | 24.96 ns | 20.40 ns | -18.29% | 2 | 1 |
| Accepted input: parse + cache + setter / int16 | 37.07 ns | 19.45 ns | -47.53% | 3 | 1 |
| Accepted input: parse + cache + setter / uint64 | 47.24 ns | 28.89 ns | -38.85% | 3 | 1 |
| Accepted input: parse + cache + setter / float32 | 39.88 ns | 20.88 ns | -47.64% | 3 | 1 |
| Binding construction / int16 | 25.62 ns | 15.43 ns | -39.79% | 2 | 1 |
| Binding construction / uint64 | 25.93 ns | 15.36 ns | -40.78% | 2 | 1 |
| Binding construction / float32 | 25.68 ns | 15.41 ns | -40.00% | 2 | 1 |

The typed adapter now carries `T` directly instead of boxing values for `reflect.Value`. Every measured operation loses at least one allocation; accepted input loses two. `benchstat` reports a 36.97% geomean time reduction and a 56.32% geomean allocation-count reduction, with every timing difference statistically significant at n=10.

The geomean summarizes these nine microbenchmark ratios. It does not mean a complete render or input event is 36.97% faster.

### `RequestWriter.Number` and `RequestWriter.Range`: main versus PR

This table measures the type-erased helper path used by `{{$.Number ...}}` and `{{$.Range ...}}` in Go templates. It remains reflected in the PR.

| Measured operation and type | Main-equivalent `62dc4cd` | PR #263 `3b73ae0` | PR change | allocs/op, main → PR | B/op, main → PR |
|---|---:|---:|---:|---:|---:|
| Render/update: reflected getter + format / int16 | 102.7 ns | 101.3 ns | -1.27% | 4 → 4 | 40 → 40 |
| Render/update: reflected getter + format / uint64 | 113.7 ns | 111.2 ns | -2.20% | 4 → 4 | 64 → 64 |
| Render/update: reflected getter + format / float32 | 114.8 ns | 112.6 ns | -1.87% | 4 → 4 | 40 → 40 |
| Accepted input: parse + cache + reflected setter / int16 | 146.2 ns | 136.5 ns | -6.63% | 6 → 5 | 68 → 66 |
| Accepted input: parse + cache + reflected setter / uint64 | 157.3 ns | 147.1 ns | -6.52% | 6 → 5 | 80 → 72 |
| Accepted input: parse + cache + reflected setter / float32 | 145.2 ns | 140.1 ns | -3.51% | 6 → 5 | 72 → 68 |
| Binding construction: method discovery / int16 | 268.1 ns | 264.3 ns | -1.42% | 7 → 6 | 304 → 368 |
| Binding construction: method discovery / uint64 | 267.6 ns | 266.3 ns | -0.47% | 7 → 6 | 304 → 368 |
| Binding construction: method discovery / float32 | 265.9 ns | 264.8 ns | no significant change | 7 → 6 | 304 → 368 |

This path must still use reflection because `RequestWriter.Number` and `RequestWriter.Range` receive `any`, and a template source may expose any named numeric type. The refactor keeps that work behind `numericReflected` while sharing the same scalar parsers and formatters as the typed path.

The reflected path's geomean time decreases 2.72% and allocation count decreases 10.61%. Reads are effectively steady, while accepted input loses one allocation. Construction also loses one allocation and remains approximately the same speed, but its explicit adapter object is larger: total construction bytes rise from 304 to 368 B/op. That 64-byte cost occurs when the adapter is built; it is not repeated by `GetText` or `AcceptText`.

### `TypeFor` gate experiment

The suggested float-only `TypeFor[T]().Bits()` gate was measured separately with `-benchtime=1s -count=15`. It changed typed construction by -5.04% for int16, -2.31% for uint64, and +1.25% for float32, for a -2.07% geomean with no allocation or byte change. The sub-nanosecond integer gains did not justify an extra conditional and a float regression, so the gate is not included.

## Verification

- `go test -race -coverprofile=/tmp/jaws_experiment_coverage.out ./...`
- `go test ./...`
- `GOOS=linux GOARCH=386 CGO_ENABLED=0 go test -exec=true ./lib/ui/...`
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run`
- `gofumpt -l lib/ui/numeric.go lib/ui/numeric_test.go lib/ui/numeric_benchmark_test.go lib/ui/number_range_test.go lib/ui/number.go lib/ui/range.go`

`lib/ui` has 100% statement coverage under the race detector.
