### PR TITLE
fix(named): discard nil WriteLocked entries

### DIFF
--- a/lib/named/namedboolarray.go
+++ b/lib/named/namedboolarray.go
@@ -2,6 +2,7 @@ package named
 
 import (
 	"html/template"
+	"slices"
 	"strings"
 
 	"github.com/linkdata/deadlock"
@@ -32,8 +33,11 @@ func NewBoolArray(multi bool) *BoolArray {
 
 // ReadLocked calls fn with the [BoolArray] locked for reading.
 //
+// The provided slice is read-only, valid only for the duration of fn, and must
+// not be retained. The *[Bool] values remain usable as described below.
+//
 // fn must not call other [BoolArray] methods or [Bool.JawsSet]: those re-acquire
-// the same non-reentrant nba mutex and deadlock. It may operate on the provided
+// the same non-reentrant nba mutex and deadlock. It may inspect the provided
 // slice and call the *[Bool] methods that take only the Bool's own mutex — the
 // reads [Bool.Name], [Bool.HTML], [Bool.JawsGet], [Bool.Checked], [Bool.String]
 // (and similar) and the write [Bool.Set]. [Bool.Set] mutates the Bool under the
@@ -47,6 +51,11 @@ func (nba *BoolArray) ReadLocked(fn func(nbl []*Bool)) {
 
 // WriteLocked calls fn with the [BoolArray] locked for writing and replaces
 // the internal []*Bool slice with the return value.
+//
+// The returned slice and its backing array become internal storage after fn
+// returns and must not be retained or accessed outside [BoolArray.ReadLocked]
+// and [BoolArray.WriteLocked] callbacks. Nil entries are discarded without
+// changing the relative order of non-nil entries.
 //
 // Omitting a [Bool] from the returned slice does not detach it from nba:
 // [Bool.Array] continues to return nba, and [Bool.JawsSet] continues to apply
@@ -63,7 +72,9 @@ func (nba *BoolArray) ReadLocked(fn func(nbl []*Bool)) {
 func (nba *BoolArray) WriteLocked(fn func(nbl []*Bool) []*Bool) {
 	nba.mu.Lock()
 	defer nba.mu.Unlock()
-	nba.data = fn(nba.data)
+	nba.data = slices.DeleteFunc(fn(nba.data), func(nb *Bool) bool {
+		return nb == nil
+	})
 }
 
 // JawsContains returns the option widgets for a select backed by nba.

--- a/lib/named/namedboolarray_nil_test.go
+++ b/lib/named/namedboolarray_nil_test.go
@@ -1,0 +1,70 @@
+package named_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/linkdata/jaws"
+	"github.com/linkdata/jaws/lib/named"
+	"github.com/linkdata/jaws/lib/ui"
+)
+
+func TestBoolArrayWriteLockedDiscardsNilElements(t *testing.T) {
+	bools := named.NewBoolArray(false).Add("a", "A").Add("b", "B")
+	bools.Set("b", true)
+	bools.WriteLocked(func(values []*named.Bool) []*named.Bool {
+		return []*named.Bool{nil, values[1], nil, values[0], nil}
+	})
+
+	var values []*named.Bool
+	bools.ReadLocked(func(current []*named.Bool) {
+		values = append(values, current...)
+	})
+	if len(values) != 2 {
+		t.Fatalf("len(values) = %d, want 2", len(values))
+	}
+	if got := values[0].Name(); got != "b" {
+		t.Fatalf("values[0].Name() = %q, want b", got)
+	}
+	if got := values[1].Name(); got != "a" {
+		t.Fatalf("values[1].Name() = %q, want a", got)
+	}
+	if got := bools.Count("a"); got != 1 {
+		t.Fatalf("Count(a) = %d, want 1", got)
+	}
+	if got := bools.Get(); got != "b" {
+		t.Fatalf("Get() = %q, want b", got)
+	}
+	if !bools.IsChecked("b") {
+		t.Fatal("IsChecked(b) = false, want true")
+	}
+	const wantString = `&BoolArray{[&Bool{"b","B",true},&Bool{"a","A",false}]}`
+	if got := bools.String(); got != wantString {
+		t.Fatalf("String() = %q, want %q", got, wantString)
+	}
+	if !bools.Set("a", true) {
+		t.Fatal("Set(a, true) reported no change")
+	}
+	if got := bools.Get(); got != "a" {
+		t.Fatalf("Get() after Set(a, true) = %q, want a", got)
+	}
+
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	elem := rq.NewElement(ui.NewSelect(bools))
+	var rendered strings.Builder
+	if err = elem.JawsRender(&rendered, nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{">A</option>", ">B</option>"} {
+		if !strings.Contains(rendered.String(), want) {
+			t.Fatalf("rendered select = %q, want %q", rendered.String(), want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- discard nil entries returned by `BoolArray.WriteLocked` while preserving the order of non-nil values
- document the callback slice lifetime and ownership rules for `ReadLocked` and `WriteLocked`
- add a public-API regression covering reads, mutation, and real `ui.Select` rendering

## Verification

- `go generate ./...`
- `go test -race ./...`
- `go test ./...`
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`
- `go build ./...`

Fixes #165
