### PR TITLE
jaws: separate initial attribute callbacks from getter locking

### DIFF
--- a/.agents/skills/jaws/SKILL.md
+++ b/.agents/skills/jaws/SKILL.md
@@ -268,6 +268,11 @@ For clickable content rendering:
 ## Rendering and update rules
 
 - Keep HTML structure in templates; avoid manual HTML string assembly in Go.
+- `Element.ApplyGetter` applies a primary getter's tag and event-handler interfaces;
+  it does not invoke `InitialHTMLAttrHandler`. Collect initial attributes separately
+  with `Element.ApplyInitialHTMLAttr`, without holding widget or bound-value locks that
+  the callback may acquire. The handler owns its synchronization. A `bind.Binder`
+  acquires its own lock before invoking its `InitialHTMLAttrHook`.
 - `ui.Template.JawsUpdate` re-renders the template data into the generated wrapper.
 - `ui.Container`, `ui.Tbody` and `ui.Select` claim a private `containerState` on each
   Element before registering tags or handlers, invoking application code, or writing

--- a/contracts.go
+++ b/contracts.go
@@ -131,10 +131,13 @@ type ContextMenuHandler interface {
 	JawsContextMenu(elem *Element, click Click) (err error)
 }
 
-// InitialHTMLAttrHandler can add attributes during initial [Element] rendering.
+// InitialHTMLAttrHandler provides attributes for initial [Element] rendering.
 type InitialHTMLAttrHandler interface {
-	// JawsInitialHTMLAttr is called when an [Element] is initially rendered,
-	// and may return an initial HTML attribute string to write out.
+	// JawsInitialHTMLAttr returns attributes for elem's initial render, or an empty string.
+	//
+	// Callers must not hold a lock protecting the handler or its source. The method
+	// must synchronize shared state. Its result need not share a state snapshot with
+	// other values read during rendering.
 	JawsInitialHTMLAttr(elem *Element) (s template.HTMLAttr)
 }
 

--- a/element.go
+++ b/element.go
@@ -483,7 +483,7 @@ func (elem *Element) ApplyParams(params []any) (attrs []template.HTMLAttr) {
 	return
 }
 
-// ApplyGetter applies the tag and handler interfaces exposed by getter to elem.
+// ApplyGetter applies getter's tag and event-handler interfaces to elem.
 //
 // If getter implements [tag.TagGetter], the candidate is the value returned by
 // [tag.TagGetter.JawsGetTag]; otherwise the candidate is getter itself. Eligible
@@ -494,8 +494,8 @@ func (elem *Element) ApplyParams(params []any) (attrs []template.HTMLAttr) {
 // automatically tagged.
 //
 // If getter implements [InputHandler], [ClickHandler], or [ContextMenuHandler], it is
-// added as an event handler. attrs contains any non-empty attribute returned by
-// [InitialHTMLAttrHandler].
+// added as an event handler. ApplyGetter does not invoke [InitialHTMLAttrHandler];
+// call [Element.ApplyInitialHTMLAttr] separately.
 //
 // The returned tagValue does not confirm registration. It is nil if getter or its
 // candidate is a nil interface, or if the candidate is ineligible for expansion. A
@@ -506,10 +506,10 @@ func (elem *Element) ApplyParams(params []any) (attrs []template.HTMLAttr) {
 //
 // If the [Element] is already frozen and getter is an event handler, the handler
 // is not added: in production with a [Jaws.Logger] configured this is logged and
-// initial-attribute and tag processing still occur, while debug builds and servers
-// without a Logger panic before that processing. For a non-event-handler getter,
-// initial-attribute and tag processing still occur after freezing.
-func (elem *Element) ApplyGetter(getter any) (tagValue any, attrs []template.HTMLAttr) {
+// tag processing still occurs, while debug builds and servers without a Logger panic
+// before that processing. For a non-event-handler getter, tag processing still occurs
+// after freezing.
+func (elem *Element) ApplyGetter(getter any) (tagValue any) {
 	if getter != nil {
 		tagValue = getter
 		if tagger, ok := getter.(tag.TagGetter); ok {
@@ -522,15 +522,26 @@ func (elem *Element) ApplyGetter(getter any) (tagValue any, attrs []template.HTM
 		} else if _, ok := getter.(ContextMenuHandler); ok {
 			elem.appendHandlers(getter)
 		}
-		if ah, ok := getter.(InitialHTMLAttrHandler); ok {
-			if attr := ah.JawsInitialHTMLAttr(elem); attr != "" {
-				attrs = append(attrs, attr)
-			}
-		}
 		if usableAsTag(tagValue) {
 			elem.Tag(tagValue)
 		} else {
 			tagValue = nil
+		}
+	}
+	return
+}
+
+// ApplyInitialHTMLAttr returns getter's initial HTML attributes.
+//
+// It returns nil unless getter implements [InitialHTMLAttrHandler] and returns a
+// non-empty value; otherwise that value is the sole slice element. It does not apply
+// tags or event handlers.
+//
+// Callers must not hold a lock protecting getter or its source.
+func (elem *Element) ApplyInitialHTMLAttr(getter any) (attrs []template.HTMLAttr) {
+	if ah, ok := getter.(InitialHTMLAttrHandler); ok {
+		if attr := ah.JawsInitialHTMLAttr(elem); attr != "" {
+			attrs = append(attrs, attr)
 		}
 	}
 	return

--- a/element_test.go
+++ b/element_test.go
@@ -603,7 +603,7 @@ func TestElement_HandlersFrozenAfterRender(t *testing.T) {
 	}
 	assertHandlerMutationFrozen(t, e, func() { e.AddHandlers(testClickHandler{}) })
 	assertHandlerMutationFrozen(t, e, func() { e.ApplyParams([]any{testEventHandler{}}) })
-	assertHandlerMutationFrozen(t, e, func() { _, _ = e.ApplyGetter(testClickHandler{}) })
+	assertHandlerMutationFrozen(t, e, func() { e.ApplyGetter(testClickHandler{}) })
 }
 
 func TestElement_FreezeSealsHandlers(t *testing.T) {
@@ -792,15 +792,12 @@ func TestElement_ApplyGetterDebugBranches(t *testing.T) {
 	defer rq.Close()
 	elem := rq.NewElement(&testUi{})
 
-	if gotTag, attrs := elem.ApplyGetter(nil); gotTag != nil || len(attrs) != 0 {
-		t.Fatalf("unexpected %v %#v", gotTag, attrs)
+	if gotTag := elem.ApplyGetter(nil); gotTag != nil {
+		t.Fatalf("unexpected tag %v", gotTag)
 	}
 
 	ag := testApplyGetterAll{}
-	gotTags, attrs := elem.ApplyGetter(ag)
-	if len(attrs) != 0 {
-		t.Fatalf("expected no attrs, got %#v", attrs)
-	}
+	gotTags := elem.ApplyGetter(ag)
 	if !elem.HasTag(tag.Tag("tg")) {
 		t.Fatalf("missing Tag('tg') in %#v", gotTags)
 	}
@@ -861,10 +858,14 @@ func (testNonComparableContextMenuHandler) JawsContextMenu(elem *Element, click 
 var _ ContextMenuHandler = testNonComparableContextMenuHandler{}
 
 type testInitialHTMLAttrHandler struct {
-	attr template.HTMLAttr
+	attr  template.HTMLAttr
+	calls *int
 }
 
 func (h testInitialHTMLAttrHandler) JawsInitialHTMLAttr(elem *Element) (s template.HTMLAttr) {
+	if h.calls != nil {
+		(*h.calls)++
+	}
 	s = h.attr
 	return
 }
@@ -892,18 +893,22 @@ func (s *testStringSetterWithInitialHTMLAttr) JawsInitialHTMLAttr(elem *Element)
 }
 
 type testClickAndInitialHTMLAttr struct {
-	called *bool
-	attr   template.HTMLAttr
+	clickCalled *bool
+	attrCalls   *int
+	attr        template.HTMLAttr
 }
 
 func (h testClickAndInitialHTMLAttr) JawsClick(elem *Element, click Click) error {
-	if h.called != nil {
-		*h.called = true
+	if h.clickCalled != nil {
+		*h.clickCalled = true
 	}
 	return nil
 }
 
 func (h testClickAndInitialHTMLAttr) JawsInitialHTMLAttr(elem *Element) (attr template.HTMLAttr) {
+	if h.attrCalls != nil {
+		(*h.attrCalls)++
+	}
 	attr = h.attr
 	return
 }
@@ -929,12 +934,9 @@ func TestElement_ApplyGetter(t *testing.T) {
 	e := rq.NewElement(tss)
 
 	var tch testClickHandler
-	gotTag, attrs := e.ApplyGetter(tch)
+	gotTag := e.ApplyGetter(tch)
 	if gotTag != tch {
 		t.Errorf("tag was %#v", gotTag)
-	}
-	if len(attrs) != 0 {
-		t.Fatalf("expected no attrs, got %#v", attrs)
 	}
 	is.Equal(len(e.handlers), 1)
 	if !e.HasTag(tch) {
@@ -973,7 +975,7 @@ func TestElement_ApplyGetter_NonComparableHandler_NilLogger(t *testing.T) {
 	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
 	e := rq.NewElement(&testUi{s: "x"})
 	tch := testNonComparableClickHandler{names: []string{"name"}}
-	gotTag, _ := e.ApplyGetter(tch)
+	gotTag := e.ApplyGetter(tch)
 	if gotTag != nil {
 		t.Fatalf("expected declined non-comparable candidate to return a nil tag, got %#v", gotTag)
 	}
@@ -1011,12 +1013,9 @@ func TestElement_ApplyGetter_NilTagGetter(t *testing.T) {
 	defer rq.Close()
 
 	e := rq.NewElement(&testUi{s: "foo"})
-	gotTag, attrs := e.ApplyGetter(testNilTagGetter{})
+	gotTag := e.ApplyGetter(testNilTagGetter{})
 	if gotTag != nil {
 		t.Fatalf("expected nil tag, got %#v", gotTag)
-	}
-	if len(attrs) != 0 {
-		t.Fatalf("expected no attrs, got %#v", attrs)
 	}
 	if got := rq.TagsOf(e); len(got) != 0 {
 		t.Fatalf("expected nil tag getter to not tag element, got %v", got)
@@ -1076,9 +1075,10 @@ func TestElement_ApplyParams_InitialHTMLAttrHandler(t *testing.T) {
 	defer rq.Close()
 
 	e := rq.NewElement(testDivWidget{inner: "x"})
+	attrCalls := 0
 	attrs := e.ApplyParams([]any{
 		"hidden",
-		testInitialHTMLAttrHandler{attr: `data-attr="ok"`},
+		testInitialHTMLAttrHandler{attr: `data-attr="ok"`, calls: &attrCalls},
 	})
 	if len(attrs) != 1 {
 		t.Fatalf("expected 1 attr, got %d", len(attrs))
@@ -1089,6 +1089,9 @@ func TestElement_ApplyParams_InitialHTMLAttrHandler(t *testing.T) {
 	if strings.Contains(string(attrs[0]), "data-attr") {
 		t.Fatalf("unexpected initial HTML attr in ApplyParams output: %q", attrs[0])
 	}
+	if attrCalls != 0 {
+		t.Fatalf("JawsInitialHTMLAttr called %d times, want 0", attrCalls)
+	}
 }
 
 func TestElement_ApplyParams_IgnoreInitialHTMLAttrOnCombinedParamHandler(t *testing.T) {
@@ -1096,10 +1099,12 @@ func TestElement_ApplyParams_IgnoreInitialHTMLAttrOnCombinedParamHandler(t *test
 	defer rq.Close()
 
 	e := rq.NewElement(testDivWidget{inner: "x"})
-	called := false
+	clickCalled := false
+	attrCalls := 0
 	h := testClickAndInitialHTMLAttr{
-		called: &called,
-		attr:   `data-attr="ignored"`,
+		clickCalled: &clickCalled,
+		attrCalls:   &attrCalls,
+		attr:        `data-attr="ignored"`,
 	}
 
 	attrs := e.ApplyParams([]any{h})
@@ -1112,12 +1117,43 @@ func TestElement_ApplyParams_IgnoreInitialHTMLAttrOnCombinedParamHandler(t *test
 	if err := CallEventHandlers(e.UI(), e, what.Click, "1 2 0 x"); err != nil {
 		t.Fatalf("expected click handler to run, got %v", err)
 	}
-	if !called {
+	if !clickCalled {
 		t.Fatal("expected click handler to be called")
+	}
+	if attrCalls != 0 {
+		t.Fatalf("JawsInitialHTMLAttr called %d times, want 0", attrCalls)
 	}
 }
 
-func TestElement_ApplyGetter_InitialHTMLAttrHandler(t *testing.T) {
+func TestElement_ApplyInitialHTMLAttr(t *testing.T) {
+	rq := newTestRequest(t)
+	defer rq.Close()
+
+	e := rq.NewElement(testDivWidget{inner: "x"})
+	if attrs := e.ApplyInitialHTMLAttr(nil); len(attrs) != 0 {
+		t.Fatalf("unexpected attrs for nil getter: %#v", attrs)
+	}
+
+	attrCalls := 0
+	h := testInitialHTMLAttrHandler{calls: &attrCalls}
+	if attrs := e.ApplyInitialHTMLAttr(h); len(attrs) != 0 {
+		t.Fatalf("unexpected empty attr result: %#v", attrs)
+	}
+	if attrCalls != 1 {
+		t.Fatalf("JawsInitialHTMLAttr called %d times, want 1", attrCalls)
+	}
+
+	h.attr = `data-attr="ok"`
+	attrs := e.ApplyInitialHTMLAttr(h)
+	if len(attrs) != 1 || attrs[0] != h.attr {
+		t.Fatalf("unexpected attrs: %#v", attrs)
+	}
+	if attrCalls != 2 {
+		t.Fatalf("JawsInitialHTMLAttr called %d times, want 2", attrCalls)
+	}
+}
+
+func TestElement_ApplyInitialHTMLAttr_RendersGetterAttribute(t *testing.T) {
 	rq := newTestRequest(t)
 	defer rq.Close()
 
@@ -1143,35 +1179,65 @@ func TestElement_ApplyGetter_InitialHTMLAttrHandler(t *testing.T) {
 	}
 }
 
-func TestElement_ApplyGetter_InitialHTMLAttrAndClickHandler(t *testing.T) {
+func TestElement_ApplyGetter_DoesNotApplyInitialHTMLAttr(t *testing.T) {
 	rq := newTestRequest(t)
 	defer rq.Close()
 
 	e := rq.NewElement(testDivWidget{inner: "x"})
-	called := false
+	clickCalled := false
+	attrCalls := 0
 	h := testClickAndInitialHTMLAttr{
-		called: &called,
-		attr:   `data-attr="ok"`,
+		clickCalled: &clickCalled,
+		attrCalls:   &attrCalls,
+		attr:        `data-attr="ok"`,
 	}
-	_, attrs := e.ApplyGetter(h)
-	if len(attrs) != 1 || attrs[0] != `data-attr="ok"` {
-		t.Fatalf("unexpected attrs from ApplyGetter: %#v", attrs)
+	if gotTag := e.ApplyGetter(h); gotTag != h {
+		t.Fatalf("tag = %#v, want %#v", gotTag, h)
 	}
-	if len(e.handlers) != 1 {
-		t.Fatalf("expected 1 handler before ApplyParams, got %d", len(e.handlers))
-	}
-	paramsAttrs := e.ApplyParams(nil)
-	if len(paramsAttrs) != 0 {
-		t.Fatalf("unexpected attrs from ApplyParams: %#v", paramsAttrs)
+	if attrCalls != 0 {
+		t.Fatalf("JawsInitialHTMLAttr called %d times, want 0", attrCalls)
 	}
 	if len(e.handlers) != 1 {
-		t.Fatalf("expected click handler to remain after ApplyParams, got %d handlers", len(e.handlers))
+		t.Fatalf("expected 1 handler, got %d", len(e.handlers))
+	}
+	if !e.HasTag(h) {
+		t.Fatal("expected combined handler to be tagged")
 	}
 	if err := CallEventHandlers(e.UI(), e, what.Click, "1 2 0 x"); err != nil {
 		t.Fatalf("expected click handler to run, got %v", err)
 	}
-	if !called {
+	if !clickCalled {
 		t.Fatal("expected click handler to be called")
+	}
+}
+
+func TestElement_ApplyInitialHTMLAttr_CombinedHandlerOnlyAppliesAttr(t *testing.T) {
+	rq := newTestRequest(t)
+	defer rq.Close()
+
+	e := rq.NewElement(testDivWidget{inner: "x"})
+	clickCalled := false
+	attrCalls := 0
+	h := testClickAndInitialHTMLAttr{
+		clickCalled: &clickCalled,
+		attrCalls:   &attrCalls,
+		attr:        `data-attr="ok"`,
+	}
+	attrs := e.ApplyInitialHTMLAttr(h)
+	if len(attrs) != 1 || attrs[0] != h.attr {
+		t.Fatalf("unexpected attrs: %#v", attrs)
+	}
+	if attrCalls != 1 {
+		t.Fatalf("JawsInitialHTMLAttr called %d times, want 1", attrCalls)
+	}
+	if clickCalled {
+		t.Fatal("click handler was called")
+	}
+	if len(e.handlers) != 0 {
+		t.Fatalf("expected no handlers, got %d", len(e.handlers))
+	}
+	if got := rq.TagsOf(e); len(got) != 0 {
+		t.Fatalf("expected no tags, got %v", got)
 	}
 }
 

--- a/element_test.go
+++ b/element_test.go
@@ -1137,7 +1137,7 @@ func TestElement_ApplyInitialHTMLAttr(t *testing.T) {
 	attrCalls := 0
 	h := testInitialHTMLAttrHandler{calls: &attrCalls}
 	if attrs := e.ApplyInitialHTMLAttr(h); len(attrs) != 0 {
-		t.Fatalf("unexpected empty attr result: %#v", attrs)
+		t.Fatalf("empty attr must yield no attrs, got %#v", attrs)
 	}
 	if attrCalls != 1 {
 		t.Fatalf("JawsInitialHTMLAttr called %d times, want 1", attrCalls)

--- a/eventhandler_test.go
+++ b/eventhandler_test.go
@@ -42,7 +42,7 @@ func (t *testJawsEvent) JawsGetTag() (tagValue any) {
 }
 
 func (t *testJawsEvent) JawsRender(elem *Element, w io.Writer, params []any) (err error) {
-	tagValue, _ := elem.ApplyGetter(t)
+	tagValue := elem.ApplyGetter(t)
 	_, _ = fmt.Fprint(w, params)
 	t.msgCh <- fmt.Sprintf("JawsRender(%d)%#v", elem.jid, tagValue)
 	return

--- a/jaws.go
+++ b/jaws.go
@@ -25,12 +25,15 @@ package jaws
 // back into the same Request.
 //
 // Bound-value locks in lib/bind, lib/ui, and lib/named are released before dirtying or
-// broadcasting. Code holding a core lock must not invoke UI value methods. Container
-// reconciliation has one deliberate reverse edge: containerState.mu may be held while
-// Request.NewElement takes Request.mu. Provider callbacks and validation precede that
-// edge; rendering, removal, recursive cleanup, cancellation, and logging follow it.
-// Core-lock holders must therefore never invoke container render or update methods.
-// containerState.mu is a sync.Mutex, so the deadlock detector cannot enforce this rule.
+// broadcasting. InitialHTMLAttrHandler callbacks run without caller-held widget or
+// bound-value locks; bind.Binder acquires its own lock before calling its narrower
+// InitialHTMLAttrHook. Code holding a core lock must not invoke UI value methods.
+// Container reconciliation has one deliberate reverse edge: containerState.mu may be
+// held while Request.NewElement takes Request.mu. Provider callbacks and validation
+// precede that edge; rendering, removal, recursive cleanup, cancellation, and logging
+// follow it. Core-lock holders must therefore never invoke container render or update
+// methods. containerState.mu is a sync.Mutex, so the deadlock detector cannot enforce
+// this rule.
 
 import (
 	"bufio"

--- a/lib/bind/binder.go
+++ b/lib/bind/binder.go
@@ -87,8 +87,9 @@ type Formatter interface {
 // Binder methods are safe for concurrent use when the locker passed to [New]
 // is safe for concurrent use.
 //
-// Binder holds its lock while invoking [Formatter.Format], [fmt.Formatter.Format],
-// [fmt.Stringer.String], and [InitialHTMLAttrHook].
+// Binder holds its lock while rendering HTML, including while invoking [GetHTMLHook],
+// [Formatter.Format], [fmt.Formatter.Format] and [fmt.Stringer.String], and while
+// invoking [InitialHTMLAttrHook].
 type Binder[T comparable] interface {
 	RWLocker
 	Setter[T]

--- a/lib/bind/binder.go
+++ b/lib/bind/binder.go
@@ -87,8 +87,8 @@ type Formatter interface {
 // Binder methods are safe for concurrent use when the locker passed to [New]
 // is safe for concurrent use.
 //
-// Binder holds its lock while rendering HTML, including while invoking
-// [Formatter.Format], [fmt.Formatter.Format], and [fmt.Stringer.String].
+// Binder holds its lock while invoking [Formatter.Format], [fmt.Formatter.Format],
+// [fmt.Stringer.String], and [InitialHTMLAttrHook].
 type Binder[T comparable] interface {
 	RWLocker
 	Setter[T]

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -275,7 +275,8 @@ func NewArticle(inner any) *Article {
 }
 
 func (w *Article) JawsRender(e *jaws.Element, wr io.Writer, params []any) error {
-  _, getterAttrs := e.ApplyGetter(w.HTMLGetter)
+  e.ApplyGetter(w.HTMLGetter)
+  getterAttrs := e.ApplyInitialHTMLAttr(w.HTMLGetter)
   attrs := append(e.ApplyParams(params), getterAttrs...)
   return htmlio.WriteHTMLInner(wr, e.Jid(), "article", "", w.HTMLGetter.JawsGetHTML(e), attrs...)
 }

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -284,6 +284,10 @@ func (w *Article) JawsRender(e *jaws.Element, wr io.Writer, params []any) error 
 // JawsUpdate is inherited from the embedded ui.HTMLInner.
 ```
 
+`ApplyGetter` registers the getter's tag and event handlers;
+`ApplyInitialHTMLAttr` runs the getter's `JawsInitialHTMLAttr` callback and must
+be called without holding any lock that callback may acquire.
+
 ## Adding an interactive input widget
 
 Use one of the typed input bases:

--- a/lib/ui/containerstate.go
+++ b/lib/ui/containerstate.go
@@ -130,7 +130,8 @@ func (u Container) render(elem *jaws.Element, w io.Writer, params []any, complet
 	}()
 
 	var getterAttrs []template.HTMLAttr
-	dirtyTag, getterAttrs = elem.ApplyGetter(u.children)
+	dirtyTag = elem.ApplyGetter(u.children)
+	getterAttrs = elem.ApplyInitialHTMLAttr(u.children)
 	attrs := append(elem.ApplyParams(params), getterAttrs...)
 	b := elem.Jid().AppendStartTagAttr(nil, u.outerHTMLTag)
 	b = htmlio.AppendAttrs(b, attrs)

--- a/lib/ui/containerstate.go
+++ b/lib/ui/containerstate.go
@@ -129,9 +129,8 @@ func (u Container) render(elem *jaws.Element, w io.Writer, params []any, complet
 		}
 	}()
 
-	var getterAttrs []template.HTMLAttr
 	dirtyTag = elem.ApplyGetter(u.children)
-	getterAttrs = elem.ApplyInitialHTMLAttr(u.children)
+	getterAttrs := elem.ApplyInitialHTMLAttr(u.children)
 	attrs := append(elem.ApplyParams(params), getterAttrs...)
 	b := elem.Jid().AppendStartTagAttr(nil, u.outerHTMLTag)
 	b = htmlio.AppendAttrs(b, attrs)

--- a/lib/ui/html_widgets.go
+++ b/lib/ui/html_widgets.go
@@ -19,7 +19,8 @@ type HTMLInner struct {
 }
 
 func (u *HTMLInner) renderInner(elem *jaws.Element, w io.Writer, htmlTag, htmlType string, params []any) (err error) {
-	_, getterAttrs := elem.ApplyGetter(u.HTMLGetter)
+	elem.ApplyGetter(u.HTMLGetter)
+	getterAttrs := elem.ApplyInitialHTMLAttr(u.HTMLGetter)
 	attrs := append(elem.ApplyParams(params), getterAttrs...)
 	err = htmlio.WriteHTMLInner(w, elem.Jid(), htmlTag, htmlType, u.HTMLGetter.JawsGetHTML(elem), attrs...)
 	return

--- a/lib/ui/img.go
+++ b/lib/ui/img.go
@@ -24,7 +24,8 @@ func NewImg(g bind.Getter[string]) *Img { return &Img{Getter: g} }
 
 // JawsRender renders ui as an HTML img element.
 func (u *Img) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err error) {
-	_, getterAttrs := elem.ApplyGetter(u.Getter)
+	elem.ApplyGetter(u.Getter)
+	getterAttrs := elem.ApplyInitialHTMLAttr(u.Getter)
 	srcAttr := htmlio.Attr("src", u.JawsGet(elem))
 	attrs := append(elem.ApplyParams(params), getterAttrs...)
 	// HTML parsing keeps the first duplicate attribute, so emit the canonical

--- a/lib/ui/input_widgets.go
+++ b/lib/ui/input_widgets.go
@@ -41,7 +41,8 @@ type Input struct {
 }
 
 func (u *Input) applyGetterAttrs(elem *jaws.Element, getter any) (attrs []template.HTMLAttr) {
-	u.tag, attrs = elem.ApplyGetter(getter)
+	u.tag = elem.ApplyGetter(getter)
+	attrs = elem.ApplyInitialHTMLAttr(getter)
 	return
 }
 

--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"html/template"
 	"io"
 	"reflect"
 	"regexp"
@@ -422,15 +421,13 @@ func (jsvar *JsVar[T]) JawsSet(elem *jaws.Element, value T) (err error) {
 // may acquire the locker passed to [NewJsVar].
 func (jsvar *JsVar[T]) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err error) {
 	// The render-time snapshot is taken under the write lock; see renderSnapshot.
-	// Everything below runs without the lock: ApplyParams and, crucially, writing to
-	// w must not hold the value lock, because a slow client stalling a network write
-	// would otherwise block every goroutine sharing the locker.
-	var getter any
-	var getterAttrs []template.HTMLAttr
-	var jsvarName string
-	var data []byte
-	getter, jsvarName, data, err = jsvar.renderSnapshot(elem, params)
-	getterAttrs = elem.ApplyInitialHTMLAttr(getter)
+	// After renderSnapshot returns, ApplyInitialHTMLAttr, AddHandlers, ApplyParams
+	// and, crucially, writing to w run without the lock. ApplyInitialHTMLAttr must
+	// stay out here because the bound value's JawsInitialHTMLAttr may acquire the
+	// same non-reentrant locker; writing to w must stay out because a slow client
+	// stalling a network write would block every goroutine sharing the locker.
+	getter, jsvarName, data, err := jsvar.renderSnapshot(elem, params)
+	getterAttrs := elem.ApplyInitialHTMLAttr(getter)
 	elem.AddHandlers(jsvar)
 	if err == nil {
 		attrs := append(elem.ApplyParams(params[1:]), getterAttrs...)

--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -415,19 +415,24 @@ func (jsvar *JsVar[T]) JawsSet(elem *jaws.Element, value T) (err error) {
 // The serialized value is a render-time snapshot. See [JsVar] for the
 // synchronization semantics between rendering and the WebSocket subscription.
 //
-// The bound value's [github.com/linkdata/jaws/lib/tag.TagGetter] JawsGetTag callback
-// runs while the JsVar write lock is held, so it must not re-enter this JsVar (for
-// example call JawsGet or JawsSet on it), which would self-deadlock the non-reentrant
-// lock.
+// The bound value's [github.com/linkdata/jaws/lib/tag.TagGetter] JawsGetTag runs with
+// the JsVar write lock held and must not acquire that lock or re-enter the JsVar.
+//
+// [jaws.InitialHTMLAttrHandler.JawsInitialHTMLAttr] runs without the JsVar lock and
+// may acquire the locker passed to [NewJsVar].
 func (jsvar *JsVar[T]) JawsRender(elem *jaws.Element, w io.Writer, params []any) (err error) {
 	// The render-time snapshot is taken under the write lock; see renderSnapshot.
 	// Everything below runs without the lock: ApplyParams and, crucially, writing to
 	// w must not hold the value lock, because a slow client stalling a network write
 	// would otherwise block every goroutine sharing the locker.
+	var getter any
 	var getterAttrs []template.HTMLAttr
 	var jsvarName string
 	var data []byte
-	if getterAttrs, jsvarName, data, err = jsvar.renderSnapshot(elem, params); err == nil {
+	getter, jsvarName, data, err = jsvar.renderSnapshot(elem, params)
+	getterAttrs = elem.ApplyInitialHTMLAttr(getter)
+	elem.AddHandlers(jsvar)
+	if err == nil {
 		attrs := append(elem.ApplyParams(params[1:]), getterAttrs...)
 		var b []byte
 		b = append(b, "\n<div id="...)
@@ -445,26 +450,23 @@ func (jsvar *JsVar[T]) JawsRender(elem *jaws.Element, w io.Writer, params []any)
 
 // renderSnapshot runs the render-time critical section under the write lock.
 //
-// It resolves the dirty tag and any initial HTML attrs from the bound value,
-// registers this JsVar as elem's handler, validates the JsVar name, and marshals a
-// snapshot of Ptr. The lock spans [jaws.Element.ApplyGetter] and the marshal so the
-// serialized value stays consistent with the dirty tag even if another request
-// sharing this JsVar sets it concurrently. The deferred unlock ensures a panic from
-// a bound-value callback or from marshaling cannot leak the lock.
+// It resolves the dirty tag, validates the JsVar name, and marshals a snapshot of
+// Ptr. The lock spans tag registration and the marshal so the serialized value stays
+// consistent with the dirty tag even if another request sharing this JsVar sets it
+// concurrently. The deferred unlock ensures a panic from a tag callback or from
+// marshaling cannot leak the lock.
 //
-// A nil Ptr has no bound value to inspect, so the getter callback is skipped and the
-// initial data is omitted. Passing the typed-nil Ptr to ApplyGetter instead would call
-// a value-receiver [github.com/linkdata/jaws/lib/tag.TagGetter] through the nil
+// A nil Ptr has no bound value to inspect, so bound-value callbacks are skipped and
+// the initial data is omitted. Passing the typed-nil Ptr to ApplyGetter instead would
+// call a value-receiver [github.com/linkdata/jaws/lib/tag.TagGetter] through the nil
 // pointer and panic.
-func (jsvar *JsVar[T]) renderSnapshot(elem *jaws.Element, params []any) (getterAttrs []template.HTMLAttr, jsvarName string, data []byte, err error) {
+func (jsvar *JsVar[T]) renderSnapshot(elem *jaws.Element, params []any) (getter any, jsvarName string, data []byte, err error) {
 	jsvar.Lock()
 	defer jsvar.Unlock()
-	var getter any
 	if jsvar.Ptr != nil {
 		getter = jsvar.Ptr
 	}
-	jsvar.dirtyTag, getterAttrs = elem.ApplyGetter(getter)
-	elem.AddHandlers(jsvar)
+	jsvar.dirtyTag = elem.ApplyGetter(getter)
 	if jsvarName, err = validateJsVarName(params); err == nil && jsvar.Ptr != nil {
 		data, err = json.Marshal(jsvar.Ptr)
 	}

--- a/lib/ui/jsvar_test.go
+++ b/lib/ui/jsvar_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/linkdata/jaws"
 	"github.com/linkdata/jaws/jawstest"
+	"github.com/linkdata/jaws/lib/bind"
 	"github.com/linkdata/jaws/lib/tag"
 	"github.com/linkdata/jaws/lib/what"
 )
@@ -49,6 +50,17 @@ type jsVarInitialAttrState struct {
 	marshalUnlocks       int
 	initialAttrUnlocks   int
 	clickCalls           int
+}
+
+type jsVarReentrantInitialAttrState struct {
+	locker bind.RWLocker
+	attr   template.HTMLAttr
+}
+
+func (state *jsVarReentrantInitialAttrState) JawsInitialHTMLAttr(*jaws.Element) template.HTMLAttr {
+	state.locker.RLock()
+	defer state.locker.RUnlock()
+	return state.attr
 }
 
 func (state *jsVarInitialAttrState) observeLock() (underWriteLock bool, unlocks int) {
@@ -250,6 +262,49 @@ func TestJsVar_RenderInitialHTMLAttrRunsOutsideBindingLock(t *testing.T) {
 	if state.clickCalls != 1 {
 		t.Errorf("bound click handler called %d times, want 1", state.clickCalls)
 	}
+}
+
+func testJsVarRenderInitialAttrReentry(t *testing.T, bindingLocker sync.Locker, lockerName string, wantAttr template.HTMLAttr) {
+	t.Helper()
+
+	_, rq := newCoreRequest(t)
+	state := jsVarReentrantInitialAttrState{
+		locker: bind.AsRWLocker(bindingLocker),
+		attr:   wantAttr,
+	}
+	jsvar := NewJsVar(bindingLocker, &state)
+	elem := rq.NewElement(jsvar)
+	var sb strings.Builder
+	done := make(chan error, 1)
+	go func() {
+		done <- jsvar.JawsRender(elem, &sb, []any{"state"})
+	}()
+
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-timer.C:
+		t.Fatalf("JsVar.JawsRender deadlocked while JawsInitialHTMLAttr re-entered the %s binding locker", lockerName)
+	case <-t.Context().Done():
+		t.Fatalf("render context ended while JawsInitialHTMLAttr re-entered the %s binding locker: %v", lockerName, t.Context().Err())
+	}
+	if got := sb.String(); !strings.Contains(got, string(wantAttr)) {
+		t.Fatalf("rendered HTML %q does not contain %q", got, wantAttr)
+	}
+}
+
+func TestJsVar_RenderInitialHTMLAttrCanReenterBindingLocker(t *testing.T) {
+	t.Run("RWMutex", func(t *testing.T) {
+		testJsVarRenderInitialAttrReentry(t, new(sync.RWMutex), "sync.RWMutex", `data-lock="rwmutex"`)
+	})
+
+	t.Run("MutexAdapter", func(t *testing.T) {
+		testJsVarRenderInitialAttrReentry(t, new(sync.Mutex), "sync.Mutex", `data-lock="mutex"`)
+	})
 }
 
 // TestJsVar_SetBroadcastsWirePayload pins the wire payload broadcast when a

--- a/lib/ui/jsvar_test.go
+++ b/lib/ui/jsvar_test.go
@@ -27,6 +27,66 @@ type jsVarNilData struct {
 	Value string `json:"value"`
 }
 
+type jsVarRenderLock struct {
+	sync.RWMutex
+	unlocks int
+}
+
+func (mu *jsVarRenderLock) Unlock() {
+	mu.unlocks++
+	mu.RWMutex.Unlock()
+}
+
+type jsVarInitialAttrState struct {
+	mu                   *jsVarRenderLock
+	tagCalls             int
+	marshalCalls         int
+	initialAttrCalls     int
+	tagUnderLock         bool
+	marshalUnderLock     bool
+	initialAttrUnderLock bool
+	tagUnlocks           int
+	marshalUnlocks       int
+	initialAttrUnlocks   int
+	clickCalls           int
+}
+
+func (state *jsVarInitialAttrState) observeLock() (underWriteLock bool, unlocks int) {
+	if state.mu.TryRLock() {
+		unlocks = state.mu.unlocks
+		state.mu.RUnlock()
+		return
+	}
+	underWriteLock = true
+	unlocks = state.mu.unlocks
+	return
+}
+
+func (state *jsVarInitialAttrState) JawsGetTag() any {
+	state.tagCalls++
+	state.tagUnderLock, state.tagUnlocks = state.observeLock()
+	return tag.Tag("jsvar-initial-attr")
+}
+
+func (state *jsVarInitialAttrState) MarshalJSON() ([]byte, error) {
+	state.marshalCalls++
+	state.marshalUnderLock, state.marshalUnlocks = state.observeLock()
+	return []byte(`{"value":"ready"}`), nil
+}
+
+func (state *jsVarInitialAttrState) JawsInitialHTMLAttr(*jaws.Element) template.HTMLAttr {
+	state.initialAttrCalls++
+	var underWriteLock bool
+	underWriteLock, state.initialAttrUnlocks = state.observeLock()
+	state.initialAttrUnderLock = state.initialAttrUnderLock || underWriteLock
+	return `data-ready="true"`
+}
+
+func (state *jsVarInitialAttrState) JawsClick(*jaws.Element, jaws.Click) error {
+	state.clickCalls++
+	return nil
+}
+
 type jsVarPathHooks struct {
 	Value       string `json:"value"`
 	setCalls    int
@@ -142,6 +202,53 @@ func TestJsVar_RenderSetAndEvent(t *testing.T) {
 	}
 	if err := jaws.CallEventHandlers(jsv, elem, what.Click, `1 2 0 x`); !errors.Is(err, jaws.ErrEventUnhandled) {
 		t.Fatalf("expected ErrEventUnhandled, got %v", err)
+	}
+}
+
+func TestJsVar_RenderInitialHTMLAttrRunsOutsideBindingLock(t *testing.T) {
+	_, rq := newCoreRequest(t)
+
+	var mu jsVarRenderLock
+	state := jsVarInitialAttrState{mu: &mu}
+	jsv := NewJsVar(&mu, &state)
+	elem := rq.NewElement(jsv)
+
+	var sb strings.Builder
+	if err := jsv.JawsRender(elem, &sb, []any{"state"}); err != nil {
+		t.Fatal(err)
+	}
+	if state.tagCalls != 1 {
+		t.Errorf("JawsGetTag called %d times, want 1", state.tagCalls)
+	}
+	if !state.tagUnderLock {
+		t.Error("JawsGetTag ran without the binding lock")
+	}
+	if state.marshalCalls != 1 {
+		t.Errorf("MarshalJSON called %d times, want 1", state.marshalCalls)
+	}
+	if !state.marshalUnderLock {
+		t.Error("MarshalJSON ran without the binding lock")
+	}
+	if state.tagUnlocks != state.marshalUnlocks {
+		t.Errorf("binding unlocked between JawsGetTag and MarshalJSON: %d != %d", state.tagUnlocks, state.marshalUnlocks)
+	}
+	if state.initialAttrCalls != 1 {
+		t.Errorf("JawsInitialHTMLAttr called %d times, want 1", state.initialAttrCalls)
+	}
+	if state.initialAttrUnderLock {
+		t.Error("JawsInitialHTMLAttr ran with the binding lock held")
+	}
+	if state.initialAttrUnlocks <= state.marshalUnlocks {
+		t.Errorf("JawsInitialHTMLAttr did not run after the snapshot unlocked: %d <= %d", state.initialAttrUnlocks, state.marshalUnlocks)
+	}
+	if got := sb.String(); strings.Count(got, `data-ready="true"`) != 1 {
+		t.Errorf("rendered initial attr count = %d, want 1 in %q", strings.Count(got, `data-ready="true"`), got)
+	}
+	if err := jaws.CallEventHandlers(elem.UI(), elem, what.Click, "1 2 0 state"); err != nil {
+		t.Fatalf("dispatching the bound click handler: %v", err)
+	}
+	if state.clickCalls != 1 {
+		t.Errorf("bound click handler called %d times, want 1", state.clickCalls)
 	}
 }
 
@@ -555,6 +662,35 @@ func TestJsVar_RenderNilPointerWithTagGetterDoesNotLeakLock(t *testing.T) {
 	if got := sb.String(); strings.Contains(got, "data-jawsdata=") {
 		t.Errorf("expected no data-jawsdata for nil pointer, got %q", got)
 	}
+}
+
+type jsVarPanicTag struct{}
+
+func (*jsVarPanicTag) JawsGetTag() any {
+	panic("tag boom")
+}
+
+func TestJsVar_RenderTagGetterPanicDoesNotLeakLock(t *testing.T) {
+	_, rq := newCoreRequest(t)
+
+	var mu sync.Mutex
+	v := jsVarPanicTag{}
+	jsv := NewJsVar(&mu, &v)
+	elem := rq.NewElement(jsv)
+
+	var sb bytes.Buffer
+	var panicValue any
+	func() {
+		defer func() { panicValue = recover() }()
+		_ = jsv.JawsRender(elem, &sb, []any{"boom"})
+	}()
+	if panicValue == nil {
+		t.Fatal("expected tag getter panic to propagate")
+	}
+	if !mu.TryLock() {
+		t.Fatal("render left the JsVar locker held after a tag getter panic")
+	}
+	mu.Unlock()
 }
 
 type jsVarPanicMarshal struct{}

--- a/parseparams.go
+++ b/parseparams.go
@@ -22,15 +22,13 @@ func usableAsTag(t any) (ok bool) {
 // ParseParams parses the parameters passed to UI helpers when creating a new
 // [Element], returning UI tags, event handlers and HTML attributes.
 //
-// Unlike [Element.ApplyGetter], which is given the primary getter, ParseParams
-// only recognizes [InputFn], [InputHandler], [ClickHandler] and
-// [ContextMenuHandler]. A param implementing [InitialHTMLAttrHandler] is treated
-// only as a tag here; its JawsInitialHTMLAttr is intentionally invoked only for the
-// primary getter.
+// ParseParams recognizes [InputFn], [InputHandler], [ClickHandler] and
+// [ContextMenuHandler] as event handlers. It does not invoke
+// [InitialHTMLAttrHandler.JawsInitialHTMLAttr]; implementing that interface does
+// not affect parameter classification.
 //
-// A param recognized as an event handler is appended to handlers, and if it is
-// also usable as a tag (comparable, per usableAsTag) it is additionally appended
-// to tags, so a comparable handler is returned in both slices.
+// A recognized event handler that is also usable as a tag is returned in both tags
+// and handlers.
 func ParseParams(params []any) (tags []any, handlers []any, attrs []string) {
 	for i := range params {
 		switch data := params[i].(type) {

--- a/parseparams_fuzz_test.go
+++ b/parseparams_fuzz_test.go
@@ -102,8 +102,8 @@ func (h fuzzParseParamsNonComparableTagGetter) JawsGetTag() any {
 }
 
 // fuzzParseParamsInitialAttrOnly covers a param implementing an interface ParseParams
-// does not recognize: JawsInitialHTMLAttr is only invoked for the primary getter, so
-// ParseParams must classify this as a tag and nothing else.
+// does not recognize: JawsInitialHTMLAttr is invoked separately for the primary getter,
+// so ParseParams must classify this as a tag and nothing else.
 type fuzzParseParamsInitialAttrOnly struct {
 	ID byte
 }

--- a/testhelpers_test.go
+++ b/testhelpers_test.go
@@ -314,8 +314,8 @@ func newTestTextInputWidget(s testStringSetter) *testTextInputWidget {
 }
 
 func (u *testTextInputWidget) JawsRender(elem *Element, w io.Writer, params []any) (err error) {
-	var getterAttrs []template.HTMLAttr
-	u.tagValue, getterAttrs = elem.ApplyGetter(u.setter)
+	u.tagValue = elem.ApplyGetter(u.setter)
+	getterAttrs := elem.ApplyInitialHTMLAttr(u.setter)
 	attrs := append(elem.ApplyParams(params), getterAttrs...)
 	v := u.setter.JawsGet(elem)
 	u.last = v


### PR DESCRIPTION
## Summary

- define a framework-wide unlocked callback boundary for `InitialHTMLAttrHandler`; the widget audit found `JsVar` was the only standard renderer violating it
- split `Element.ApplyGetter` into tag/event application and a separate `Element.ApplyInitialHTMLAttr` phase, then migrate HTML, image, input, container, and JsVar renderers
- keep JsVar tag resolution and JSON marshaling in one uninterrupted write-locked snapshot while running initial attributes after unlock
- preserve bound-handler ordering and panic-safe lock release; document that initial attributes need not share the later getter/provider state snapshot
- exercise real callback lock re-entry with both `sync.RWMutex` and the `sync.Mutex` `bind.AsRWLocker` adapter path
- retain `bind.Binder` synchronization: widgets enter it unlocked, and Binder acquires its own read lock before invoking `InitialHTMLAttrHook`

## Breaking API change

Custom renderers change from:

```go
tagValue, attrs := elem.ApplyGetter(getter)
```

to:

```go
tagValue := elem.ApplyGetter(getter)
attrs := elem.ApplyInitialHTMLAttr(getter)
```

The initial-attribute phase must run without an externally held lock on the getter or its source. Tag registration now completes before that explicit phase.

## Verification

- `go generate ./...`
- `go vet ./...`
- `gofmt -l .`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`
- `JAWS_REQUIRE_NODE=1 go test -race -coverprofile=coverage.out ./...`
- `JAWS_REQUIRE_NODE=1 go test ./...`
- `go build ./...`

The Linux-only 386 leg runs in CI; macOS does not support `darwin/386`.

Fixes #264