### PR TITLE
docs(bind): define MakeHTMLGetter tag contract

### DIFF
--- a/.agents/skills/jaws/SKILL.md
+++ b/.agents/skills/jaws/SKILL.md
@@ -73,7 +73,14 @@ These are the two usual building blocks for widget handlers passed to `$.Button`
 
 ### `ui.New(innerHTML any) Object`
 
-- `innerHTML` is routed through `bind.MakeHTMLGetter`, so the same type rules apply: `string` is raw HTML, `template.HTML` is trusted as-is, `Getter[string]` / `Binder[string]` / `fmt.Stringer` are escaped.
+- `innerHTML` is routed through `bind.MakeHTMLGetter`, whose first matching
+  conversion applies: `HTMLGetter` is unchanged; `template.HTML` is trusted;
+  `Binder[string]`, `Getter[string]`, and `fmt.Stringer` adapters are escaped;
+  `string` is trusted; other values are formatted and escaped.
+- The adapters created for `Getter[string]` and `fmt.Stringer` inputs expose the
+  wrapped value as an implicit tag. It must be a usable direct tag or implement
+  `tag.TagGetter` and return values accepted by `tag.TagExpand`; return `nil` from
+  `JawsGetTag` when the value should be untagged.
 - Returns a chainable `Object`. Each builder — `.Clicked(fn)`, `.ContextMenu(fn)`, `.InitialHTMLAttr(fn)` — wraps the previous object so the chain is a linked list, newest first.
 - Event dispatch walks the chain newest-first and stops at the first link that does not return `jaws.ErrEventUnhandled`. Return `ErrEventUnhandled` from a link to fall through to the next.
 - `JawsInitialHTMLAttr` concatenates attribute strings from every link that defines one.
@@ -347,10 +354,12 @@ For clickable content rendering:
 
 ## HTML safety rules
 
-`bind.MakeHTMLGetter` behavior is type-dependent:
-- `string` is used as raw HTML and is not escaped.
-- `template.HTML` is trusted as-is.
-- `Getter[string]`, `Binder[string]`, `fmt.Stringer`, and formatter-based paths are escaped.
+`bind.MakeHTMLGetter` uses the first matching conversion:
+- `HTMLGetter` is returned unchanged.
+- `template.HTML` is not escaped.
+- `Binder[string]`, `Getter[string]`, and `fmt.Stringer` adapters are escaped.
+- `string` is not escaped.
+- Other values use escaped `fmt.Sprint` output.
 
 Guideline:
 - Never pass untrusted input as plain `string` to HTML-producing helpers.

--- a/lib/bind/makehtmlgetter.go
+++ b/lib/bind/makehtmlgetter.go
@@ -46,25 +46,20 @@ func (g htmlGetterString) JawsGetTag() any {
 
 // MakeHTMLGetter returns an [HTMLGetter] for value.
 //
-// Depending on the type of value, we return:
+// The first matching conversion is used:
 //
-//   - [HTMLGetter] is used as-is.
-//   - Binder[string] and Getter[string] values are escaped using [html.EscapeString].
-//   - [fmt.Stringer] values are escaped using [html.EscapeString].
-//   - Static [template.HTML] and string values are used as-is with no HTML escaping.
-//   - Everything else is rendered using [fmt.Sprint] and escaped using [html.EscapeString].
+//   - [HTMLGetter] is returned unchanged.
+//   - [template.HTML] is used unchanged.
+//   - Binder[string] and Getter[string] use escaped [Getter.JawsGet] output.
+//   - [fmt.Stringer] uses escaped [fmt.Stringer.String] output.
+//   - string is used unchanged.
+//   - Other values use escaped [fmt.Sprint] output.
 //
-// The Binder[string] and Getter[string] cases escape the raw [Getter.JawsGet]
-// value and so bypass any Format or GetHTML hook in the chain. The package's own
-// [Binder] (a *binder) implements [HTMLGetter] and is matched by the first case
-// above, which does honor those hooks; the Binder[string] case is reached only by
-// a hand-rolled Binder[string] that does not implement [HTMLGetter].
+// Getter[string] and [fmt.Stringer] adapters expose the wrapped value as an
+// implicit tag. The value must be accepted by [tag.TagExpand], directly or
+// through [tag.TagGetter]; JawsGetTag may return nil to leave it untagged.
 //
-// WARNING: Plain string values are NOT HTML-escaped. This is intentional so that
-// HTML markup can be passed conveniently from Go templates (e.g. `{{$.Span "<i>text</i>"}}`).
-// Never pass untrusted user input as a plain string; use [template.HTML] to signal
-// that the content is trusted, or wrap user input in a [Getter] or [fmt.Stringer]
-// so it will be escaped automatically.
+// Plain strings are not escaped; do not pass untrusted text as a plain string.
 func MakeHTMLGetter(value any) HTMLGetter {
 	switch v := value.(type) {
 	case HTMLGetter:

--- a/lib/bind/makehtmlgetter_render_test.go
+++ b/lib/bind/makehtmlgetter_render_test.go
@@ -1,0 +1,199 @@
+package bind_test
+
+import (
+	"errors"
+	"io"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/linkdata/jaws"
+	"github.com/linkdata/jaws/lib/tag"
+	"github.com/linkdata/jaws/lib/ui"
+)
+
+type makeHTMLGetterStringer struct{ text string }
+
+func (s makeHTMLGetterStringer) String() string { return s.text }
+
+type makeHTMLGetterGetter struct{ text string }
+
+func (g makeHTMLGetterGetter) JawsGet(*jaws.Element) string { return g.text }
+
+type makeHTMLGetterNaNStringer float64
+
+func (makeHTMLGetterNaNStringer) String() string { return "<nan>" }
+
+type makeHTMLGetterNaNGetter float64
+
+func (makeHTMLGetterNaNGetter) JawsGet(*jaws.Element) string { return "<getter>" }
+
+type makeHTMLGetterTaggedSliceStringer []string
+
+func (s makeHTMLGetterTaggedSliceStringer) String() string { return strings.Join(s, "") }
+
+func (makeHTMLGetterTaggedSliceStringer) JawsGetTag() any { return tag.Tag("slice") }
+
+type makeHTMLGetterTaggedNaNGetter float64
+
+func (makeHTMLGetterTaggedNaNGetter) JawsGet(*jaws.Element) string { return "<getter>" }
+
+func (makeHTMLGetterTaggedNaNGetter) JawsGetTag() any { return tag.Tag("getter") }
+
+type makeHTMLGetterLogger struct {
+	mu    sync.Mutex
+	calls int
+	errs  []error
+}
+
+func (*makeHTMLGetterLogger) Info(string, ...any) {}
+func (*makeHTMLGetterLogger) Warn(string, ...any) {}
+
+func (l *makeHTMLGetterLogger) Error(_ string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.calls++
+	for i := 0; i+1 < len(args); i += 2 {
+		key, ok := args[i].(string)
+		if err, isError := args[i+1].(error); ok && key == "err" && isError {
+			l.errs = append(l.errs, err)
+		}
+	}
+}
+
+func (l *makeHTMLGetterLogger) snapshot() (calls int, errs []error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.calls, append([]error(nil), l.errs...)
+}
+
+func newMakeHTMLGetterRequest(t *testing.T, logger jaws.Logger) *jaws.Request {
+	t.Helper()
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+	jw.Logger = logger
+	rq := jw.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	if rq == nil {
+		t.Fatal("NewRequest returned nil")
+	}
+	return rq
+}
+
+func renderMakeHTMLGetterSpan(t *testing.T, rq *jaws.Request, value any) (*jaws.Element, string) {
+	t.Helper()
+	elem := rq.NewElement(ui.NewSpan(value))
+	var rendered strings.Builder
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("JawsRender panicked: %v", recovered)
+		}
+	}()
+	if err := elem.JawsRender(&rendered, nil); err != nil {
+		t.Fatalf("JawsRender error: %v", err)
+	}
+	return elem, rendered.String()
+}
+
+func requireMakeHTMLGetterSpan(t *testing.T, elem *jaws.Element, rendered, inner string) {
+	t.Helper()
+	want := `<span id="` + elem.Jid().String() + `">` + inner + `</span>`
+	if rendered != want {
+		t.Fatalf("rendered HTML = %q, want %q", rendered, want)
+	}
+}
+
+func TestMakeHTMLGetterUsesWrappedValueAsTag(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		value any
+		inner string
+	}{
+		{name: "Stringer", value: makeHTMLGetterStringer{text: "<stringer>"}, inner: "&lt;stringer&gt;"},
+		{name: "Getter", value: makeHTMLGetterGetter{text: "<getter>"}, inner: "&lt;getter&gt;"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			rq := newMakeHTMLGetterRequest(t, nil)
+			elem, rendered := renderMakeHTMLGetterSpan(t, rq, tt.value)
+			requireMakeHTMLGetterSpan(t, elem, rendered, tt.inner)
+			if tags := rq.TagsOf(elem); len(tags) != 1 || tags[0] != tt.value {
+				t.Fatalf("registered tags = %#v, want %#v", tags, []any{tt.value})
+			}
+		})
+	}
+}
+
+func TestMakeHTMLGetterNonReflexiveWrappedTagIsReported(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		value any
+		inner string
+	}{
+		{name: "Stringer", value: makeHTMLGetterNaNStringer(math.NaN()), inner: "&lt;nan&gt;"},
+		{name: "Getter", value: makeHTMLGetterNaNGetter(math.NaN()), inner: "&lt;getter&gt;"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := &makeHTMLGetterLogger{}
+			rq := newMakeHTMLGetterRequest(t, logger)
+			elem, rendered := renderMakeHTMLGetterSpan(t, rq, tt.value)
+			requireMakeHTMLGetterSpan(t, elem, rendered, tt.inner)
+			if tags := rq.TagsOf(elem); len(tags) != 0 {
+				t.Fatalf("registered tags = %#v, want none", tags)
+			}
+			calls, errs := logger.snapshot()
+			if calls != 1 || len(errs) != 1 || !errors.Is(errs[0], tag.ErrNotUsableAsTag) {
+				t.Fatalf("logger.Error calls = %d with errors %v, want one ErrNotUsableAsTag", calls, errs)
+			}
+		})
+	}
+}
+
+func TestMakeHTMLGetterNonReflexiveWrappedTagPanicsWithoutLogger(t *testing.T) {
+	rq := newMakeHTMLGetterRequest(t, nil)
+	elem := rq.NewElement(ui.NewSpan(makeHTMLGetterNaNStringer(math.NaN())))
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		_ = elem.JawsRender(io.Discard, nil)
+	}()
+	err, ok := recovered.(error)
+	if !ok || !errors.Is(err, tag.ErrNotUsableAsTag) {
+		t.Fatalf("JawsRender panic = %v, want ErrNotUsableAsTag", recovered)
+	}
+}
+
+func TestMakeHTMLGetterUsesWrappedTagGetter(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		value any
+		inner string
+		tag   tag.Tag
+	}{
+		{
+			name:  "NonComparableStringer",
+			value: makeHTMLGetterTaggedSliceStringer{"<slice>"},
+			inner: "&lt;slice&gt;",
+			tag:   tag.Tag("slice"),
+		},
+		{
+			name:  "NonReflexiveGetter",
+			value: makeHTMLGetterTaggedNaNGetter(math.NaN()),
+			inner: "&lt;getter&gt;",
+			tag:   tag.Tag("getter"),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			rq := newMakeHTMLGetterRequest(t, nil)
+			elem, rendered := renderMakeHTMLGetterSpan(t, rq, tt.value)
+			requireMakeHTMLGetterSpan(t, elem, rendered, tt.inner)
+			if tags := rq.TagsOf(elem); len(tags) != 1 || tags[0] != tt.tag {
+				t.Fatalf("registered tags = %#v, want %#v", tags, []any{tt.tag})
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- document that `Getter[string]` and `fmt.Stringer` inputs remain implicit element tags
- require wrapped values to satisfy `tag.TagExpand` directly or through `tag.TagGetter`
- add public regressions for valid tag identity, non-reflexive invalid-tag reporting, and the `JawsGetTag` escape hatch

This clarifies the existing contract; it does not change runtime behavior.

## Verification

- `JAWS_REQUIRE_NODE=1 go test -race ./...`
- `JAWS_REQUIRE_NODE=1 go test ./...`
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`
- `go build ./...`

Fixes #265