### PR TITLE
fix: invoke loggers after releasing locks

### DIFF
--- a/contracts.go
+++ b/contracts.go
@@ -186,8 +186,8 @@ func (*DefaultAuth) Email() string { return "" }
 
 // IsAdmin returns true for every caller.
 //
-// If a logger was supplied at construction, it logs a one-time warning that
-// [Jaws.MakeAuth] is unset and authorization is fail-open.
+// If configured with a logger, it logs one warning that [Jaws.MakeAuth] is unset
+// and authorization is fail-open.
 func (da *DefaultAuth) IsAdmin() bool {
 	// Warn loudly about the fail-open authorization default. When MakeAuth is nil
 	// templates receive DefaultAuth, IsAdmin() returns true for everyone, so
@@ -196,8 +196,7 @@ func (da *DefaultAuth) IsAdmin() bool {
 	da.once.Do(func() {
 		logger = da.logger
 	})
-	// sync.Once is not reentrant. Invoke the application logger only after Do
-	// releases its internal mutex so the logger may call IsAdmin itself.
+	// Logger.Warn may re-enter IsAdmin, so invoke it after once.Do returns.
 	if logger != nil {
 		logger.Warn("jaws: no MakeAuth; DefaultAuth.IsAdmin returns true")
 	}
@@ -207,9 +206,8 @@ func (da *DefaultAuth) IsAdmin() bool {
 // DefaultAuth returns the shared fail-open [DefaultAuth] used for templates when
 // [Jaws.MakeAuth] is nil.
 //
-// It is created on first use and reused, so the [sync.Once] warning in
-// [DefaultAuth.IsAdmin] fires at most once per [Jaws] rather than once per
-// template render. The value of [Jaws.Logger] in effect at first use is captured.
+// The returned value logs at most one warning through the [Jaws.Logger] in
+// effect when DefaultAuth is first called.
 func (jw *Jaws) DefaultAuth() *DefaultAuth {
 	jw.defaultAuthOnce.Do(func() {
 		jw.defaultAuthVal = &DefaultAuth{logger: jw.Logger}

--- a/contracts.go
+++ b/contracts.go
@@ -192,11 +192,15 @@ func (da *DefaultAuth) IsAdmin() bool {
 	// Warn loudly about the fail-open authorization default. When MakeAuth is nil
 	// templates receive DefaultAuth, IsAdmin() returns true for everyone, so
 	// any {{if .Auth.IsAdmin}}-gated UI is shown to all visitors.
+	var logger Logger
 	da.once.Do(func() {
-		if da.logger != nil {
-			da.logger.Warn("jaws: no MakeAuth; DefaultAuth.IsAdmin returns true")
-		}
+		logger = da.logger
 	})
+	// sync.Once is not reentrant. Invoke the application logger only after Do
+	// releases its internal mutex so the logger may call IsAdmin itself.
+	if logger != nil {
+		logger.Warn("jaws: no MakeAuth; DefaultAuth.IsAdmin returns true")
+	}
 	return true
 }
 

--- a/contracts_test.go
+++ b/contracts_test.go
@@ -4,6 +4,7 @@ import (
 	"html/template"
 	"testing"
 	"testing/synctest"
+	"time"
 
 	"github.com/linkdata/jaws/lib/what"
 	"github.com/linkdata/jaws/lib/wire"
@@ -126,6 +127,54 @@ func TestJaws_DefaultAuthReturnsSharedInstance(t *testing.T) {
 	}
 	if jw.DefaultAuth() != a {
 		t.Fatal("DefaultAuth must return the same shared instance")
+	}
+}
+
+type reentrantDefaultAuthLogger struct {
+	jw        *Jaws
+	warnCalls int
+	reentered bool
+}
+
+func (*reentrantDefaultAuthLogger) Info(string, ...any)  {}
+func (*reentrantDefaultAuthLogger) Error(string, ...any) {}
+
+func (logger *reentrantDefaultAuthLogger) Warn(string, ...any) {
+	logger.warnCalls++
+	logger.reentered = logger.jw.DefaultAuth().IsAdmin()
+}
+
+func TestDefaultAuth_IsAdminLoggerCanReenter(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+	logger := &reentrantDefaultAuthLogger{jw: jw}
+	jw.Logger = logger
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- jw.DefaultAuth().IsAdmin()
+	}()
+
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case isAdmin := <-done:
+		if !isAdmin {
+			t.Error("DefaultAuth.IsAdmin returned false")
+		}
+	case <-timer.C:
+		t.Fatal("DefaultAuth.IsAdmin deadlocked when Logger.Warn re-entered it")
+	case <-t.Context().Done():
+		t.Fatalf("test context ended while Logger.Warn re-entered DefaultAuth.IsAdmin: %v", t.Context().Err())
+	}
+	if logger.warnCalls != 1 {
+		t.Errorf("Logger.Warn calls = %d, want 1", logger.warnCalls)
+	}
+	if !logger.reentered {
+		t.Error("Logger.Warn re-entry returned false")
 	}
 }
 

--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -252,12 +252,10 @@ type JsVar[T any] struct {
 	dirtyTag    any           // current dirty tag, set during render; read via JawsGetTag
 }
 
-// JawsGetPath returns the value at jsPath.
-//
-// Lookup errors are logged on elem when possible after releasing the locker
-// passed to [NewJsVar].
+// JawsGetPath returns the value at jsPath, logging lookup errors on elem when possible.
 func (jsvar *JsVar[T]) JawsGetPath(elem *jaws.Element, jsPath string) (value any) {
 	value, err := jsvar.getPath(jsPath)
+	// The application logger may acquire the binding lock, so invoke it after getPath returns.
 	if elem != nil {
 		_ = elem.Jaws.Log(err)
 	}

--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -252,16 +252,22 @@ type JsVar[T any] struct {
 	dirtyTag    any           // current dirty tag, set during render; read via JawsGetTag
 }
 
-// JawsGetPath returns the value at jsPath, logging lookup errors on elem when possible.
+// JawsGetPath returns the value at jsPath.
+//
+// Lookup errors are logged on elem when possible after releasing the locker
+// passed to [NewJsVar].
 func (jsvar *JsVar[T]) JawsGetPath(elem *jaws.Element, jsPath string) (value any) {
-	jsvar.RLock()
-	defer jsvar.RUnlock()
-	var err error
-	value, err = jq.Get(jsvar.Ptr, jsPath)
+	value, err := jsvar.getPath(jsPath)
 	if elem != nil {
 		_ = elem.Jaws.Log(err)
 	}
 	return
+}
+
+func (jsvar *JsVar[T]) getPath(jsPath string) (value any, err error) {
+	jsvar.RLock()
+	defer jsvar.RUnlock()
+	return jq.Get(jsvar.Ptr, jsPath)
 }
 
 // JawsGet returns the bound value.

--- a/lib/ui/jsvar_test.go
+++ b/lib/ui/jsvar_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/linkdata/jaws/lib/bind"
 	"github.com/linkdata/jaws/lib/tag"
 	"github.com/linkdata/jaws/lib/what"
+	"github.com/linkdata/jq"
 )
 
 type jsVarData struct {
@@ -55,6 +56,56 @@ type jsVarInitialAttrState struct {
 type jsVarReentrantInitialAttrState struct {
 	locker bind.RWLocker
 	attr   template.HTMLAttr
+}
+
+type jsVarTryLocker interface {
+	sync.Locker
+	TryLock() bool
+}
+
+type jsVarReentrantGetPathLogger struct {
+	locker        jsVarTryLocker
+	lockAvailable bool
+	reentered     bool
+	calls         int
+	err           error
+}
+
+func (*jsVarReentrantGetPathLogger) Info(string, ...any) {}
+func (*jsVarReentrantGetPathLogger) Warn(string, ...any) {}
+
+func (logger *jsVarReentrantGetPathLogger) Error(_ string, args ...any) {
+	logger.calls++
+	for i := 0; i+1 < len(args); i += 2 {
+		if args[i] == "err" {
+			logger.err, _ = args[i+1].(error)
+		}
+	}
+	logger.lockAvailable = logger.locker.TryLock()
+	if !logger.lockAvailable {
+		return
+	}
+	logger.locker.Unlock()
+	logger.locker.Lock()
+	logger.reentered = true
+	logger.locker.Unlock()
+}
+
+type jsVarGetPathPanicLogger struct {
+	locker        jsVarTryLocker
+	lockAvailable bool
+	panicValue    any
+}
+
+func (*jsVarGetPathPanicLogger) Info(string, ...any) {}
+func (*jsVarGetPathPanicLogger) Warn(string, ...any) {}
+
+func (logger *jsVarGetPathPanicLogger) Error(string, ...any) {
+	logger.lockAvailable = logger.locker.TryLock()
+	if logger.lockAvailable {
+		logger.locker.Unlock()
+	}
+	panic(logger.panicValue)
 }
 
 func (state *jsVarReentrantInitialAttrState) JawsInitialHTMLAttr(*jaws.Element) template.HTMLAttr {
@@ -305,6 +356,75 @@ func TestJsVar_RenderInitialHTMLAttrCanReenterBindingLocker(t *testing.T) {
 	t.Run("MutexAdapter", func(t *testing.T) {
 		testJsVarRenderInitialAttrReentry(t, new(sync.Mutex), "sync.Mutex", `data-lock="mutex"`)
 	})
+}
+
+func testJsVarGetPathLoggerReentry(t *testing.T, bindingLocker jsVarTryLocker) {
+	t.Helper()
+
+	logger := &jsVarReentrantGetPathLogger{locker: bindingLocker}
+	_, rq := newConfiguredCoreRequest(t, func(jw *jaws.Jaws) {
+		jw.Logger = logger
+	})
+	state := jsVarData{Text: "value"}
+	jsvar := NewJsVar(bindingLocker, &state)
+	elem := rq.NewElement(jsvar)
+	if got := jsvar.JawsGetPath(elem, "text"); got != state.Text {
+		t.Fatalf("successful JawsGetPath = %#v, want %q", got, state.Text)
+	}
+	if logger.calls != 0 {
+		t.Fatalf("successful JawsGetPath logged %d errors, want 0", logger.calls)
+	}
+
+	if value := jsvar.JawsGetPath(elem, "["); value != nil {
+		t.Errorf("failed JawsGetPath = %#v, want nil", value)
+	}
+	if logger.calls != 1 || !errors.Is(logger.err, jq.ErrPathNotFound) {
+		t.Errorf("Logger.Error calls = %d with error %v, want one ErrPathNotFound", logger.calls, logger.err)
+	}
+	if !logger.lockAvailable {
+		t.Error("Logger.Error ran with the binding lock held")
+	}
+	if !logger.reentered {
+		t.Error("Logger.Error did not re-enter the binding locker")
+	}
+}
+
+func TestJsVar_GetPathLoggerCanAcquireBindingLocker(t *testing.T) {
+	t.Run("RWMutex", func(t *testing.T) {
+		testJsVarGetPathLoggerReentry(t, new(sync.RWMutex))
+	})
+
+	t.Run("MutexAdapter", func(t *testing.T) {
+		testJsVarGetPathLoggerReentry(t, new(sync.Mutex))
+	})
+}
+
+func TestJsVar_GetPathLoggerPanicDoesNotLeakBindingLock(t *testing.T) {
+	mu := new(sync.Mutex)
+	panicValue := new(int)
+	logger := &jsVarGetPathPanicLogger{locker: mu, panicValue: panicValue}
+	_, rq := newConfiguredCoreRequest(t, func(jw *jaws.Jaws) {
+		jw.Logger = logger
+	})
+	state := jsVarData{Text: "value"}
+	jsvar := NewJsVar(mu, &state)
+	elem := rq.NewElement(jsvar)
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		jsvar.JawsGetPath(elem, "[")
+	}()
+	if recovered != panicValue {
+		t.Fatalf("Logger.Error panic = %v, want %v", recovered, panicValue)
+	}
+	if !logger.lockAvailable {
+		t.Error("Logger.Error panicked with the binding lock held")
+	}
+	if !mu.TryLock() {
+		t.Fatal("Logger.Error panic left the binding lock held")
+	}
+	mu.Unlock()
 }
 
 // TestJsVar_SetBroadcastsWirePayload pins the wire payload broadcast when a


### PR DESCRIPTION
## Summary

- release the JsVar binding read lock before logging JawsGetPath lookup errors while keeping jq.Get protected and panic-safe
- invoke the DefaultAuth warning after sync.Once releases its mutex
- add deterministic re-entry regressions for RWMutex, the Mutex adapter, logger panics, and DefaultAuth
- scan all production logging paths; no other supported logger-under-lock instances were found

## Verification

- JAWS_REQUIRE_NODE=1 go test -race ./... -count=1
- go vet ./...
- staticcheck ./...
- golangci-lint run
- gosec ./...
- go build ./...

Fixes #266