### PR TITLE
ui: default Handler responses to HTML content type

### DIFF
--- a/lib/ui/handler.go
+++ b/lib/ui/handler.go
@@ -61,15 +61,19 @@ func (pt *pageTemplate) JawsRender(elem *jaws.Element, w io.Writer, params []any
 	return
 }
 
-// statusRecorder wraps an [http.ResponseWriter] to record whether any response
-// bytes have been committed, so [uiHandler.ServeHTTP] can still send a 500 for a
-// render failure that occurred before any output was written.
+// statusRecorder wraps an [http.ResponseWriter] to apply the page handler's
+// default HTML content type and record whether any response bytes have been
+// committed, so [uiHandler.ServeHTTP] can still send a 500 for a render failure
+// that occurred before any output was written.
 type statusRecorder struct {
 	http.ResponseWriter
 	wrote bool
 }
 
 func (sr *statusRecorder) Write(p []byte) (int, error) {
+	if sr.Header().Get("Content-Type") == "" {
+		sr.Header().Set("Content-Type", "text/html; charset=utf-8")
+	}
 	sr.wrote = true
 	return sr.ResponseWriter.Write(p)
 }
@@ -109,9 +113,13 @@ func (h uiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // The returned handler can be registered directly with a router. Each request
 // results in the template being looked up through the configured template
 // lookupers and rendered with a [With] value as the template data, exposing
-// dot through its Dot field. Handler renders without a generated wrapper and does
-// not use dot as a tag, so dot may be arbitrary template data. The handler reuses
-// dot across requests; dot and its callbacks must support concurrent execution.
+// dot through its Dot field. Unless the response already has a Content-Type,
+// Handler sets it to "text/html; charset=utf-8" when rendering writes its first
+// bytes. A render failure before any output retains [http.Error]'s text response.
+//
+// Handler renders without a generated wrapper and does not use dot as a tag, so
+// dot may be arbitrary template data. The handler reuses dot across requests;
+// dot and its callbacks must support concurrent execution.
 func Handler(jw *jaws.Jaws, name string, dot any) http.Handler {
 	return uiHandler{Jaws: jw, name: name, dot: dot}
 }

--- a/lib/ui/handler_178_test.go
+++ b/lib/ui/handler_178_test.go
@@ -145,6 +145,9 @@ func TestHandler_ExecuteErrorAfterOutputKeepsPartialBody(t *testing.T) {
 	if got := rr.Body.String(); got != "prefix" {
 		t.Fatalf("body = %q, want %q", got, "prefix")
 	}
+	if got, want := rr.Header().Get("Content-Type"), "text/html; charset=utf-8"; got != want {
+		t.Fatalf("Content-Type = %q, want %q", got, want)
+	}
 	if len(logger.errors) != 1 || !errors.Is(logger.errors[0], renderErr) {
 		t.Fatalf("logged errors = %#v, want one %v", logger.errors, renderErr)
 	}

--- a/lib/ui/handler_content_type_test.go
+++ b/lib/ui/handler_content_type_test.go
@@ -1,0 +1,80 @@
+package ui
+
+import (
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/linkdata/jaws"
+)
+
+func TestHandler_DefaultsContentTypeToHTML(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"bom", "\ufeff<!doctype html><html><body>hello</body></html>"},
+		{"element", "<main>hello</main>"},
+		{"doctype", "<!doctype html><html><body>hello</body></html>"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			jw, err := jaws.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(jw.Close)
+			if err = jw.AddTemplateLookuper(template.Must(template.New("page").Parse(tc.body))); err != nil {
+				t.Fatal(err)
+			}
+
+			rr := httptest.NewRecorder()
+			Handler(jw, "page", nil).ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+
+			if got, want := rr.Header().Get("Content-Type"), "text/html; charset=utf-8"; got != want {
+				t.Fatalf("Content-Type = %q, want %q", got, want)
+			}
+			if got := rr.Body.String(); got != tc.body {
+				t.Fatalf("body = %q, want %q", got, tc.body)
+			}
+		})
+	}
+}
+
+func TestHandler_PreservesExplicitContentType(t *testing.T) {
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+	if err = jw.AddTemplateLookuper(template.Must(template.New("page").Parse("<main>hello</main>"))); err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	rr.Header().Set("Content-Type", "application/xhtml+xml")
+	Handler(jw, "page", nil).ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if got, want := rr.Header().Get("Content-Type"), "application/xhtml+xml"; got != want {
+		t.Fatalf("Content-Type = %q, want %q", got, want)
+	}
+}
+
+func TestHandler_RenderFailureBeforeOutputUsesTextContentType(t *testing.T) {
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	jw.Logger = new(templateLogger)
+	t.Cleanup(jw.Close)
+
+	rr := httptest.NewRecorder()
+	Handler(jw, "missing", nil).ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if got, want := rr.Code, http.StatusInternalServerError; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+	if got, want := rr.Header().Get("Content-Type"), "text/plain; charset=utf-8"; got != want {
+		t.Fatalf("Content-Type = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- default `ui.Handler` response bodies to `text/html; charset=utf-8` on their first render write
- preserve an explicitly configured `Content-Type`
- retain `http.Error`'s text content type when rendering fails before output
- document the response content-type behavior and cover valid HTML prefixes that Go's sniffer classifies as text

Fixes #285.

## Verification

- `go generate ./...`
- `go vet ./...`
- `gofumpt -l` on changed Go files
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`
- `JAWS_REQUIRE_NODE=1 go test -race -count=1 ./...`
- `JAWS_REQUIRE_NODE=1 go test -count=1 ./...`
- `go build ./...`
