### PR TITLE
docs(ui): define Register escape-hatch contract

### DIFF
--- a/.agents/skills/jaws/SKILL.md
+++ b/.agents/skills/jaws/SKILL.md
@@ -230,29 +230,27 @@ Implications:
 
 ## Registering template-authored elements
 
-- `$.Register(updater, params...)` binds a render-independent `jaws.Updater` to a DOM
-  element whose markup is written by the surrounding template. The returned Jid must be
-  used as that element's HTML `id`:
+- `$.Register(updater, params...)` is an advanced escape hatch primarily for
+  binding a render-independent `jaws.Updater` to otherwise static HTML written by
+  the surrounding template. The registered HTML should contain no JaWS widgets.
+  The returned Jid must be used as that element's HTML `id`:
 
   ```gotemplate
   <section id="{{$.Register .Dot.Panel}}">...</section>
   ```
 
 - Register never calls `JawsRender`; use it only for a custom updater designed to work
-  without render-time initialization. It uses the updater as a tag, attaches supported
-  click and context-menu handlers, applies tag and supported handler params, and invokes
-  `JawsUpdate` once. HTML attribute params are ignored; write attributes on the
-  template-authored element.
+  without render-time initialization. It uses the updater as a tag, attaches its event
+  handlers, applies tag and handler params, and invokes `JawsUpdate` once. HTML attribute
+  params are ignored; write attributes on the template-authored element.
 - The updater must be a non-nil interface whose dynamic value is comparable at runtime,
   equal to itself, and usable as a tag. A typed nil is invoked normally and must tolerate
   its nil receiver. Reuse one updater for live Elements only when it supports that use
   without retaining Element-specific state on the shared value; it must be safe for
   concurrent use when shared across Requests.
-- Prefer ordinary widget rendering. The container family supports update-only
-  registration with the limitations below, and `ui.Select` is its input-handling
-  exception. Template-authored `input`, `textarea`, and `contenteditable` elements,
-  the typed input widgets, `ui.Number`, `ui.Range`, `ui.JsVar`, and Templates with
-  a non-empty `OuterHTMLTag` require rendering.
+- Render standard widgets through their ordinary helpers. Register makes no
+  compatibility guarantees for passing a standard widget as its updater or placing
+  JaWS widgets inside its HTML; do not rely on combinations that happen to work.
 - Always emit the returned Jid as the element's `id`. A surrounding Template owns the
   registered Element; otherwise it remains until explicit deletion, reported DOM
   removal, or Request shutdown.
@@ -288,15 +286,6 @@ For clickable content rendering:
   output. Contention returns `jaws.ErrElementStateClaimed` with no render side effects.
   The state holds the render-time dirty tag, reconciliation mutex and owned child
   Elements; the widget value retains only its definition.
-- Container-family updates normally load that state. Update-only use through
-  `$.Register` lazily claims a missing state before invoking the provider. A foreign
-  state, typed-nil state or lost concurrent claim is reported through `MustLog`, and no
-  children are reconciled; Select also sends no value. The lazy state has no render-time
-  dirty tag. `$.Register` delivers Select input to its handler but does not call
-  `Element.ApplyGetter` for that handler, so Select retains no handler-derived tag for
-  its own post-set dirtying. Any handler-initiated dirtying still occurs, and separately
-  registered tags remain registered. Use ordinary `$.Select` rendering when Select
-  should register and use a usable tag exposed by its handler.
 - Container ownership also lives in `containerState`, not in `elem.UI()`. Cleanup
   detaches children under the state mutex and recurses after unlocking, so it also finds
   children when the Element's visible UI is the private registration wrapper. Failed
@@ -328,9 +317,7 @@ For clickable content rendering:
   - a composite UI must use Template values equal under `==` for rendering and updating
     an Element; using unequal values is unsupported;
   - a Template with a non-empty `OuterHTMLTag`, including any returned by
-    `ui.NewTemplate`, updates only an Element rendered by an equal Template value, so it
-    is not usable as a `$.Register` updater; `$.Register` never invokes its renderer and
-    therefore cannot establish the wrapper state an update needs.
+    `ui.NewTemplate`, updates only an Element rendered by an equal Template value.
 - Call `$.RadioGroup` from the template that renders the group: its Elements belong to
   the template whose body called it, not to the wrapper their markup lands in.
 - HTML getter paths must not mutate domain state, but they may call element update methods (`SetClass`, `RemoveClass`, `SetAttr`, `RemoveAttr`, etc.) on the passed-in `*Element` to co-ordinate wrapper class/attribute changes with the inner-HTML refresh. No custom `JawsUpdate` is needed for that case — the queued wrapper updates flush alongside the `SetInner` from `HTMLInner.JawsUpdate`.
@@ -387,8 +374,8 @@ Guideline:
 - Add regression tests for click dispatch when moving handlers between params and dot `JawsClick`.
 - For container regressions, verify identity reuse, append/remove/order behavior, and stale-element cleanup.
 - For container-family state changes, verify equal values keep independent Elements,
-  contention precedes callbacks/output, update-only registration claims lazily, and
-  nested ownership cleanup keeps the Request registry flat.
+  contention precedes callbacks/output, and nested ownership cleanup keeps the Request
+  registry flat.
 - Add pure domain tests for state transitions (win/loss, reset, bounds checks) independent of JaWS transport.
 - If rerendering fails, inspect tag comparability and dirty-target coverage before broadening dirty scope.
 

--- a/.agents/skills/jaws/SKILL.md
+++ b/.agents/skills/jaws/SKILL.md
@@ -239,18 +239,20 @@ Implications:
   ```
 
 - Register never calls `JawsRender`; use it only for a custom updater designed to work
-  without render-time initialization. It uses the updater as a tag, attaches its event
-  handlers, applies tag and handler params, and invokes `JawsUpdate` once. HTML attribute
-  params are ignored; write attributes on the template-authored element.
+  without render-time initialization. It uses the updater as a tag, attaches supported
+  click and context-menu handlers, applies tag and supported handler params, and invokes
+  `JawsUpdate` once. HTML attribute params are ignored; write attributes on the
+  template-authored element.
 - The updater must be a non-nil interface whose dynamic value is comparable at runtime,
   equal to itself, and usable as a tag. A typed nil is invoked normally and must tolerate
   its nil receiver. Reuse one updater for live Elements only when it supports that use
   without retaining Element-specific state on the shared value; it must be safe for
   concurrent use when shared across Requests.
 - Prefer ordinary widget rendering. The container family supports update-only
-  registration with the limitations below; typed inputs omit render-derived metadata,
-  while `ui.Number`, `ui.Range`, `ui.JsVar`, and Templates with a non-empty
-  `OuterHTMLTag` require rendering.
+  registration with the limitations below, and `ui.Select` is its input-handling
+  exception. Template-authored `input`, `textarea`, and `contenteditable` elements,
+  the typed input widgets, `ui.Number`, `ui.Range`, `ui.JsVar`, and Templates with
+  a non-empty `OuterHTMLTag` require rendering.
 - Always emit the returned Jid as the element's `id`. A surrounding Template owns the
   registered Element; otherwise it remains until explicit deletion, reported DOM
   removal, or Request shutdown.

--- a/README.md
+++ b/README.md
@@ -612,6 +612,12 @@ request processing loop, so custom `JawsUpdate` implementations should keep
 their work deterministic and report unrecoverable failures through
 `Element.Request.MustLog()` or `Element.Jaws.MustLog()`.
 
+`ui.RequestWriter.Register` is an advanced escape hatch primarily for attaching a
+custom, render-independent updater to otherwise static template-authored HTML.
+The registered HTML is intended to contain no JaWS widgets. Render standard
+widgets through their normal helpers; `Register` makes no compatibility guarantees
+for using them as its updater or inside its HTML.
+
 ### Data binding
 
 HTML input elements bind browser state to Go values. Text inputs use `string`,
@@ -637,20 +643,12 @@ at least one stable, usable key; `JawsGetTag` takes precedence over the setter's
 identity. Tags passed as render parameters register the Element but do not
 replace its setter-derived dirty target.
 
-Template-authored `input`, `textarea`, and `contenteditable` elements, and the
-standard typed input widgets are not supported through `RequestWriter.Register`;
-render them with their normal widget helpers. `ui.Select` supports a limited
-update-only registration mode, though ordinary rendering provides its complete
-initialization and dirty-target behavior.
-
 Number and Range retain the bound Go type through parsing, formatting, and setter
 calls. Integer inputs use base-10 integer syntax and enforce the bound type's
 width. Floating-point inputs enforce their bound type's width; `float32` values
 parse and format at 32-bit precision.
 A getter-only Number renders `readonly`; a getter-only Range renders `disabled`.
 Static numeric values passed to the template helpers use these getter-only forms.
-Number and Range require ordinary rendering and are not supported by
-`RequestWriter.Register`.
 
 Number sends edits on the browser's `change` event. Pending edits remain
 browser-local until then. Range sends live `input` events while its thumb moves.

--- a/README.md
+++ b/README.md
@@ -637,6 +637,12 @@ at least one stable, usable key; `JawsGetTag` takes precedence over the setter's
 identity. Tags passed as render parameters register the Element but do not
 replace its setter-derived dirty target.
 
+Template-authored `input`, `textarea`, and `contenteditable` elements, and the
+standard typed input widgets are not supported through `RequestWriter.Register`;
+render them with their normal widget helpers. `ui.Select` supports a limited
+update-only registration mode, though ordinary rendering provides its complete
+initialization and dirty-target behavior.
+
 Number and Range retain the bound Go type through parsing, formatting, and setter
 calls. Integer inputs use base-10 integer syntax and enforce the bound type's
 width. Floating-point inputs enforce their bound type's width; `float32` values

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -21,9 +21,10 @@ to that generated wrapper.
 Template bodies used with `rw.Template(...)` must be partials; full page
 templates should be rendered through `ui.Handler`.
 
-`rw.Register(...)` is the escape hatch for attaching a render-independent updater
-to an element whose markup is written directly in the surrounding template. Its
-returned JaWS ID must become that element's `id`:
+`rw.Register(...)` is an advanced escape hatch primarily for attaching a
+render-independent updater to otherwise static HTML written directly in the
+surrounding template. The registered HTML is intended to contain no JaWS widgets.
+Its returned JaWS ID must become that element's `id`:
 
 ```gotemplate
 <section id="{{$.Register .Dot.Panel}}" class="panel">
@@ -33,12 +34,11 @@ returned JaWS ID must become that element's `id`:
 
 `Register` never calls `JawsRender`; use it for a custom updater designed to work
 without render-time initialization. It tags the element with the updater, attaches
-supported click and context-menu handlers, and calls `JawsUpdate` once for initial
-state. Write HTML attributes in the template because attribute params are ignored.
-Template-authored `input`, `textarea`, and `contenteditable` elements, and the
-typed input widgets are not supported; render them with their normal widget
-helpers. `Select` is the input-handling exception described below. See
-`RequestWriter.Register` for the complete standard-widget limitations.
+its event handlers, and calls `JawsUpdate` once for initial state. Write HTML
+attributes in the template because attribute params are ignored. Render standard
+widgets normally. `Register` makes no compatibility guarantees for using a
+standard widget as its updater or placing JaWS widgets inside its HTML; behavior
+in either position is unspecified.
 
 Use Go's native template action when a static structural fragment must be included
 without another JaWS-managed wrapper:
@@ -69,8 +69,7 @@ itself, and its `Dot` must be nil or usable as a tag under `tag.TagExpand`. Use
 `tag.Tag("...")` for string tags.
 
 A Template with a non-empty `OuterHTMLTag` can update only an Element rendered by
-an equal Template value. It is not usable as a `$.Register` updater because
-registration does not call its renderer.
+an equal Template value.
 
 ## Container-family value widgets
 
@@ -109,10 +108,6 @@ provider, panic when rendering or updating calls the missing provider. A zero
 Select behaves the same for render and update, while its `JawsInput` is a no-op.
 A typed-nil provider is called normally and must tolerate its nil receiver itself.
 
-Container, Tbody, and Select support update-only use through
-`RequestWriter.Register`, although ordinary rendering provides their full
-initialization. A registered Select has no getter-derived tag for post-input dirtying.
-
 You can also use explicit constructors through:
 
 ```go
@@ -148,8 +143,6 @@ An editable source must expose at least one stable, usable source tag when it is
 rendered. Pointer-valued sources are usable directly; a source can instead implement
 `JawsGetTag`. `bind.New(&mu, &value)` supplies the backing value pointer as its tag.
 A changing getter-only source also needs a tag for dirty-driven server updates.
-Number and Range require ordinary rendering and are not update-only
-`RequestWriter.Register` widgets.
 
 A getter-only Number has the native `readonly` attribute. A getter-only Range is
 `disabled` and is therefore omitted from native form submission. Static numeric

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -33,10 +33,12 @@ returned JaWS ID must become that element's `id`:
 
 `Register` never calls `JawsRender`; use it for a custom updater designed to work
 without render-time initialization. It tags the element with the updater, attaches
-its event handlers, and calls `JawsUpdate` once for initial state. Write HTML
-attributes in the template because attribute params are ignored. Prefer a normal
-widget helper whenever the widget can render its own element; see
-`RequestWriter.Register` for the standard-widget limitations.
+supported click and context-menu handlers, and calls `JawsUpdate` once for initial
+state. Write HTML attributes in the template because attribute params are ignored.
+Template-authored `input`, `textarea`, and `contenteditable` elements, and the
+typed input widgets are not supported; render them with their normal widget
+helpers. `Select` is the input-handling exception described below. See
+`RequestWriter.Register` for the complete standard-widget limitations.
 
 Use Go's native template action when a static structural fragment must be included
 without another JaWS-managed wrapper:

--- a/lib/ui/container.go
+++ b/lib/ui/container.go
@@ -49,9 +49,9 @@ func (u Container) JawsRender(elem *jaws.Element, w io.Writer, params []any) err
 
 // JawsUpdate reconciles u's direct children.
 //
-// JawsUpdate supports update-only use through [RequestWriter.Register]. If elem's
-// widget state cannot be used, it reports [jaws.ErrElementStateClaimed] through
-// [jaws.Request.MustLog] without calling the provider or queuing browser work.
+// If elem's widget state cannot be used, JawsUpdate reports
+// [jaws.ErrElementStateClaimed] through [jaws.Request.MustLog] without calling the
+// provider or queuing browser work.
 func (u Container) JawsUpdate(elem *jaws.Element) {
 	u.update(elem)
 }

--- a/lib/ui/containerstate.go
+++ b/lib/ui/containerstate.go
@@ -15,8 +15,7 @@ import (
 type containerState struct {
 	mu sync.Mutex
 	// rendering is true from the successful state claim until JawsRender finishes.
-	// It keeps an update from treating a published but incomplete state as the lazy
-	// state of an update-only registered Element.
+	// It keeps an update from using a published but incomplete state.
 	rendering bool
 	dirtyTag  any
 	contents  []*jaws.Element
@@ -68,9 +67,8 @@ func claimContainerState(elem *jaws.Element) (st *containerState, err error) {
 // stateForContainerUpdate returns usable container state for elem, claiming an empty
 // state when the slot is unclaimed.
 func stateForContainerUpdate(elem *jaws.Element) (st *containerState, err error) {
-	// Update-only registration is the intended lazy-claim path, but the state slot does
-	// not encode how the Element was created. Treat an occupied foreign slot, typed
-	// nil, in-progress render, or lost concurrent claim as contention.
+	// A missing state uses the lazy-claim path. Treat an occupied foreign slot,
+	// typed nil, in-progress render, or lost concurrent claim as contention.
 	switch state := jaws.ElementState(elem).(type) {
 	case nil:
 		st, err = claimContainerState(elem)

--- a/lib/ui/doc.go
+++ b/lib/ui/doc.go
@@ -28,7 +28,10 @@
 //
 // [RequestWriter.Register] binds a render-independent updater to a DOM element
 // authored by the surrounding template. It is an escape hatch for custom markup,
-// not a replacement for rendering a widget normally.
+// not a replacement for rendering a widget normally. Template-authored input and
+// textarea elements, contenteditable elements, and the typed input widgets are not
+// supported through Register; [Select] is the documented update-only
+// input-handling exception.
 //
 // Container children must render one addressable direct DOM node carrying their
 // Element's JaWS ID so reconciliation can remove and order them. [NewTemplate]

--- a/lib/ui/doc.go
+++ b/lib/ui/doc.go
@@ -26,12 +26,11 @@
 // [Select] support multiple live Elements under their documented conditions.
 // Input widgets and [JsVar] require distinct widget values.
 //
-// [RequestWriter.Register] binds a render-independent updater to a DOM element
-// authored by the surrounding template. It is an escape hatch for custom markup,
-// not a replacement for rendering a widget normally. Template-authored input and
-// textarea elements, contenteditable elements, and the typed input widgets are not
-// supported through Register; [Select] is the documented update-only
-// input-handling exception.
+// [RequestWriter.Register] is an advanced escape hatch primarily for binding a
+// render-independent updater to otherwise static HTML authored by the surrounding
+// template. The registered HTML is intended to contain no JaWS widgets. Render
+// standard widgets normally; Register makes no compatibility guarantees for using
+// them as its updater or inside its HTML.
 //
 // Container children must render one addressable direct DOM node carrying their
 // Element's JaWS ID so reconciliation can remove and order them. [NewTemplate]

--- a/lib/ui/number.go
+++ b/lib/ui/number.go
@@ -15,7 +15,6 @@ import (
 // A Number value must back at most one live [jaws.Element]. Construct distinct
 // Number values over the same source to render one bound value more than once.
 // Construct a Number with [NewNumber]; using its zero value as a widget panics.
-// Number requires ordinary rendering and is not supported by [RequestWriter.Register].
 //
 // Editable Numbers send edits on the browser's change event. Pending edits remain
 // browser-local until then and may be replaced by server or ancestor renders.

--- a/lib/ui/range.go
+++ b/lib/ui/range.go
@@ -14,8 +14,7 @@ import (
 //
 // A Range value must back at most one live [jaws.Element]. Construct distinct
 // Range values over the same source to render one bound value more than once.
-// Construct a Range with [NewRange]; using its zero value as a widget panics. Range
-// requires ordinary rendering and is not supported by [RequestWriter.Register].
+// Construct a Range with [NewRange]; using its zero value as a widget panics.
 // Editable Ranges send live browser input while their thumb moves.
 type Range struct {
 	Input

--- a/lib/ui/register.go
+++ b/lib/ui/register.go
@@ -22,11 +22,13 @@ func (registerUI) JawsRender(*jaws.Element, io.Writer, []any) error {
 // initialization. Prefer [RequestWriter.NewUI] or a widget helper when the widget
 // can render its own element.
 //
-// Register tags the Element with updater, applies tag and event-handler params,
-// attaches event-handler methods implemented by updater, and invokes
-// [jaws.Updater.JawsUpdate] once for the initial browser state. Updater handlers
-// are tried only after applicable param handlers return [jaws.ErrEventUnhandled].
-// HTML attribute params have no effect; write attributes in the template.
+// Register tags the Element with updater, applies tag and supported event-handler
+// params, attaches click and context-menu methods implemented by updater, and
+// invokes [jaws.Updater.JawsUpdate] once for the initial browser state. A
+// registered [Select] also receives browser input through its input handler.
+// Updater handlers are tried only after applicable param handlers return
+// [jaws.ErrEventUnhandled]. HTML attribute params have no effect; write
+// attributes in the template.
 //
 // The updater must be non-nil, comparable at runtime, equal to itself, and usable
 // as a tag. A typed nil is invoked normally and must tolerate its nil receiver.
@@ -40,9 +42,10 @@ func (registerUI) JawsRender(*jaws.Element, io.Writer, []any) error {
 //
 // [Container], [Tbody], and [Select] support registration, though ordinary
 // rendering is preferable. A registered Select omits its handler-derived tag for
-// post-input dirtying. Typed input widgets omit getter-derived attributes,
-// handlers, and their getter-derived dirty tag. [Number], [Range], [JsVar], and a
-// [Template] with a non-empty OuterHTMLTag require ordinary rendering.
+// post-input dirtying. Template-authored input and textarea elements,
+// contenteditable elements, the typed input widgets, [Number], [Range], [JsVar],
+// and a [Template] with a non-empty OuterHTMLTag require ordinary rendering and
+// are not supported through Register.
 //
 // The returned Jid is suitable for including as an HTML id attribute:
 //
@@ -58,6 +61,8 @@ func (rw RequestWriter) Register(updater jaws.Updater, params ...any) jid.Jid {
 	elem.Tag(updater)
 	// The registerUI Element's UI is not the updater, so events reach the
 	// updater only through the element's handler list, not the elem.UI() fallback.
+	// InputHandler is retained for the documented registered Select path; the
+	// standard input widgets require ordinary rendering.
 	switch updater.(type) {
 	case jaws.InputHandler, jaws.ClickHandler, jaws.ContextMenuHandler:
 		elem.AddHandlers(updater)

--- a/lib/ui/register.go
+++ b/lib/ui/register.go
@@ -15,18 +15,25 @@ func (registerUI) JawsRender(*jaws.Element, io.Writer, []any) error {
 	return nil
 }
 
-// Register binds updater to a template-authored HTML element.
+// Register binds an updater to otherwise static template-authored HTML.
+//
+// Register is an advanced escape hatch primarily for updating HTML whose markup
+// is written by the surrounding template. The registered HTML is intended to
+// contain no JaWS widgets. Render widgets through [RequestWriter.NewUI] or their
+// corresponding RequestWriter helpers instead.
+//
+// Register makes no compatibility guarantees for passing a standard widget as
+// updater or placing JaWS widgets inside the registered HTML. Their behavior in
+// either position is unspecified.
 //
 // The returned [jid.Jid] must be the element's id. Register never calls
 // [jaws.Renderer.JawsRender], so updater must work without render-time
-// initialization. Prefer [RequestWriter.NewUI] or a widget helper when the widget
-// can render its own element.
+// initialization.
 //
-// Register tags the Element with updater, applies tag and supported event-handler
-// params, attaches click and context-menu methods implemented by updater, and
-// invokes [jaws.Updater.JawsUpdate] once for the initial browser state. A
-// registered [Select] also receives browser input through its input handler.
-// Updater handlers are tried only after applicable param handlers return
+// Register tags the Element with updater, applies tag and event-handler params,
+// attaches event-handler methods implemented by updater, and invokes
+// [jaws.Updater.JawsUpdate] once for the initial browser state. Updater handlers
+// are tried only after applicable param handlers return
 // [jaws.ErrEventUnhandled]. HTML attribute params have no effect; write
 // attributes in the template.
 //
@@ -39,13 +46,6 @@ func (registerUI) JawsRender(*jaws.Element, io.Writer, []any) error {
 // A surrounding [Template] owns and cleans up the registered Element. Outside a
 // Template, it remains registered until explicitly deleted, DOM removal is
 // reported, or its [jaws.Request] ends; always emit the returned Jid.
-//
-// [Container], [Tbody], and [Select] support registration, though ordinary
-// rendering is preferable. A registered Select omits its handler-derived tag for
-// post-input dirtying. Template-authored input and textarea elements,
-// contenteditable elements, the typed input widgets, [Number], [Range], [JsVar],
-// and a [Template] with a non-empty OuterHTMLTag require ordinary rendering and
-// are not supported through Register.
 //
 // The returned Jid is suitable for including as an HTML id attribute:
 //
@@ -61,8 +61,6 @@ func (rw RequestWriter) Register(updater jaws.Updater, params ...any) jid.Jid {
 	elem.Tag(updater)
 	// The registerUI Element's UI is not the updater, so events reach the
 	// updater only through the element's handler list, not the elem.UI() fallback.
-	// InputHandler is retained for the documented registered Select path; the
-	// standard input widgets require ordinary rendering.
 	switch updater.(type) {
 	case jaws.InputHandler, jaws.ClickHandler, jaws.ContextMenuHandler:
 		elem.AddHandlers(updater)


### PR DESCRIPTION
## Summary

- document `RequestWriter.Register` as an advanced escape hatch for custom, render-independent updaters over otherwise static HTML containing no JaWS widgets
- state that `Register` makes no compatibility guarantees for standard widgets used as its updater or placed inside its HTML
- remove per-widget compatibility promises, including the prior `Select` exception
- align exported godoc, the root and package READMEs, and the JaWS skill

This is a documentation-only clarification; runtime behavior is unchanged.

Fixes #287.

## Verification

- `go doc ./lib/ui RequestWriter.Register`
- `go doc ./lib/ui`
- `go generate ./...`
- `go vet ./...`
- `gofumpt -l` on changed Go files
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`
- `JAWS_REQUIRE_NODE=1 go test -race -count=1 ./...`
- `JAWS_REQUIRE_NODE=1 go test -count=1 ./...`
- `go build ./...`
