### PR TITLE
Click.String: normalize names before wire framing

### DIFF
--- a/click.go
+++ b/click.go
@@ -12,7 +12,7 @@ import (
 type Click struct {
 	// Name is the event target name. Parsing off the wire normalizes it: leading
 	// and trailing whitespace is trimmed and internal whitespace runs collapse to a
-	// single space, so it does not round-trip losslessly through [Click.String].
+	// single space. [Click.String] applies the same normalization when formatting.
 	Name    string
 	X       float64 // X is the browser clientX coordinate in CSS pixels.
 	Y       float64 // Y is the browser clientY coordinate in CSS pixels.
@@ -51,11 +51,11 @@ func (clk *Click) setKeyState(state int) {
 
 // String formats clk for the JaWS wire protocol.
 //
-// It is not a lossless inverse of parsing: a [Click.Name] with leading, trailing
-// or repeated internal whitespace is normalized when parsed back (see the Name
-// field). The production wire direction is browser-to-server (parse only).
+// It normalizes leading, trailing and repeated internal whitespace in
+// [Click.Name] to the wire representation described by the Name field.
 func (clk Click) String() string {
-	return fmt.Sprintf("%s %s %d %s", runFormatFloat(clk.X), runFormatFloat(clk.Y), clk.keyState(), clk.Name)
+	name := strings.Join(strings.Fields(clk.Name), " ")
+	return fmt.Sprintf("%s %s %d %s", runFormatFloat(clk.X), runFormatFloat(clk.Y), clk.keyState(), name)
 }
 
 func parseClickData(value string) (clk Click, after string, ok bool) {

--- a/click_test.go
+++ b/click_test.go
@@ -152,10 +152,38 @@ func TestFinite(t *testing.T) {
 }
 
 func TestClickString(t *testing.T) {
-	got := (Click{Name: "x", X: 1.25, Y: 2.5, Shift: true, Control: true, Alt: true}).String()
-	want := "1.25 2.5 7 x"
-	if got != want {
-		t.Fatalf("String() = %q, want %q", got, want)
+	for _, tt := range []struct {
+		name string
+		clk  Click
+		want string
+	}{
+		{
+			name: "canonical",
+			clk:  Click{Name: "x", X: 1.25, Y: 2.5, Shift: true, Control: true, Alt: true},
+			want: "1.25 2.5 7 x",
+		},
+		{
+			name: "name whitespace",
+			clk:  Click{Name: " \tsave\n all\r ", X: 1.25, Y: 2.5},
+			want: "1.25 2.5 0 save all",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded := tt.clk.String()
+			if got := encoded; got != tt.want {
+				t.Fatalf("String() = %q, want %q", got, tt.want)
+			}
+			got, after, ok := parseClickData(encoded)
+			if !ok {
+				t.Fatalf("parseClickData(String()) failed for %q", encoded)
+			}
+			if after != "" {
+				t.Fatalf("trailing data = %q, want none", after)
+			}
+			if want := strings.Join(strings.Fields(tt.clk.Name), " "); got.Name != want {
+				t.Fatalf("parsed name = %q, want %q", got.Name, want)
+			}
+		})
 	}
 }
 
@@ -228,11 +256,8 @@ func BenchmarkParseClickData(b *testing.B) {
 func Fuzz_clickStringRoundTrip(f *testing.F) {
 	f.Add("name", int32(1), int32(2), true, false, true)
 	f.Add("button", int32(-1), int32(999), false, false, false)
+	f.Add("save\tall", int32(0), int32(0), false, false, false)
 	f.Fuzz(func(t *testing.T, name string, x int32, y int32, shift, control, alt bool) {
-		// parseClickData rebuilds Name by joining strings.FieldsSeq tokens with single
-		// spaces, so it trims and collapses whitespace. Normalize the seed the same way
-		// so the round trip is exact (see Click.Name); String is not lossless otherwise.
-		name = strings.Join(strings.Fields(name), " ")
 		clk := Click{
 			Name:    name,
 			X:       float64(x),
@@ -248,8 +273,10 @@ func Fuzz_clickStringRoundTrip(f *testing.F) {
 		if after != "" {
 			t.Fatalf("expected no trailing data, got %q", after)
 		}
-		if got != clk {
-			t.Fatalf("roundtrip mismatch: want=%+v got=%+v", clk, got)
+		want := clk
+		want.Name = strings.Join(strings.Fields(name), " ")
+		if got != want {
+			t.Fatalf("roundtrip mismatch: want=%+v got=%+v", want, got)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- normalize `Click.Name` whitespace before producing wire data
- prevent tabs and newlines in `Name` from becoming the click bubble suffix
- exercise the whitespace case directly and remove fuzz pre-normalization so arbitrary names validate the documented round trip

Fixes #274.

## Verification

- `go test -race -run '^(TestClick|Fuzz_clickStringRoundTrip)$' .`
- `go test . -run '^$' -fuzz '^Fuzz_clickStringRoundTrip$' -fuzztime=3s` (434,081 executions)
- `go generate ./...`
- `go vet ./...`
- `gofumpt -l click.go click_test.go`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`
- `JAWS_REQUIRE_NODE=1 go test -race -count=1 ./...`
- `JAWS_REQUIRE_NODE=1 go test -count=1 ./...`
- `go build ./...`
