### PR TITLE
docs(ui): document JsVar numeric precision limits

### DIFF
--- a/.agents/skills/jaws/SKILL.md
+++ b/.agents/skills/jaws/SKILL.md
@@ -265,22 +265,12 @@ The handler candidate is asked via `JawsClick` / `JawsContextMenu` / `JawsInput`
 
 ## JsVar JSON number limits
 
-- `ui.JsVar` uses Go `encoding/json` and browser `JSON.parse` / `JSON.stringify`.
-  JSON numbers become JavaScript `Number` values rather than retaining Go numeric
-  types or integer widths. Root and nested integers outside `-9007199254740991`
-  through `9007199254740991` are not reliably preserved; a browser write can
-  commit a rounded value to Go. JaWS does not reject or transform wider integers.
-- If exactness matters, use a field of Go's built-in `string` type in the
-  JsVar-bound model. Convert it to `BigInt` for browser calculations and back to a
-  string before `jawsVar`; `JSON.stringify` does not encode `BigInt` values
-  directly.
-- A Go `json:",string"` tag makes Go-to-browser encoding use a JSON string but is
-  not a complete bidirectional workaround: the generic browser setter cannot
-  assign that untyped string to an integer field. Keep the bound field as a
-  built-in `string`, implement `ui.PathSetter` to parse and validate the encoded
-  form, or keep the exact integer outside the browser-writable binding. Pass the
-  same string representation to browser-facing `JawsSetPath` calls because they
-  broadcast the caller-supplied value.
+- Browser JSON numbers use JavaScript `Number` values. Integers outside
+  `-9007199254740991` through `9007199254740991` may round, and a browser write
+  may commit the rounded value to Go.
+- Represent exact wide integers as built-in strings. Convert `BigInt` values back
+  to strings before `jawsVar`; a Go `json:",string"` tag is not generic
+  round-trip support. Use a built-in string field or implement `ui.PathSetter`.
 
 ## Clickable template pattern
 

--- a/.agents/skills/jaws/SKILL.md
+++ b/.agents/skills/jaws/SKILL.md
@@ -263,6 +263,25 @@ On incoming events, JaWS dispatches in this order:
 
 The handler candidate is asked via `JawsClick` / `JawsContextMenu` / `JawsInput`, matched to the event kind; there is no generic `JawsEvent` method. Return `jaws.ErrEventUnhandled` to fall through to the next candidate.
 
+## JsVar JSON number limits
+
+- `ui.JsVar` uses Go `encoding/json` and browser `JSON.parse` / `JSON.stringify`.
+  JSON numbers become JavaScript `Number` values rather than retaining Go numeric
+  types or integer widths. Root and nested integers outside `-9007199254740991`
+  through `9007199254740991` are not reliably preserved; a browser write can
+  commit a rounded value to Go. JaWS does not reject or transform wider integers.
+- If exactness matters, use a field of Go's built-in `string` type in the
+  JsVar-bound model. Convert it to `BigInt` for browser calculations and back to a
+  string before `jawsVar`; `JSON.stringify` does not encode `BigInt` values
+  directly.
+- A Go `json:",string"` tag makes Go-to-browser encoding use a JSON string but is
+  not a complete bidirectional workaround: the generic browser setter cannot
+  assign that untyped string to an integer field. Keep the bound field as a
+  built-in `string`, implement `ui.PathSetter` to parse and validate the encoded
+  form, or keep the exact integer outside the browser-writable binding. Pass the
+  same string representation to browser-facing `JawsSetPath` calls because they
+  broadcast the caller-supplied value.
+
 ## Clickable template pattern
 
 For clickable content rendering:

--- a/README.md
+++ b/README.md
@@ -175,28 +175,19 @@ must read or change and exchange with Go. Unlike most JaWS UI values, a `JsVar`
 is a bidirectional channel: the binding does not by itself make either the Go
 value or the browser value authoritative.
 
-Values cross this boundary through Go's `encoding/json` and the browser's
-`JSON.parse` and `JSON.stringify`. JSON numbers become JavaScript `Number`
-values rather than retaining a Go numeric type or integer width. Every integer
-in the inclusive range `-9007199254740991` through `9007199254740991` is
-represented exactly. Outside that safe range, not every integer is
-representable. A root or nested signed or unsigned integer may be rounded in the
-initial browser snapshot or a server update, and a later browser write can
-commit the rounded value to Go. `JsVar` does not reject or transform such values.
-
-If an integer must remain exact, give it an application-level JSON
-representation such as a decimal field of Go's built-in `string` type in the
-`JsVar`-bound state. JavaScript can convert that string to `BigInt` for
-calculations, but must convert it back to a string before calling `jawsVar`
-because `JSON.stringify` does not encode `BigInt` values directly:
+Browser JSON numbers use JavaScript `Number` values. Signed and unsigned
+integers outside `-9007199254740991` through `9007199254740991` may be rounded,
+and a later browser write may commit the rounded value to Go. Represent exact
+wide integers as decimal fields of Go's built-in `string` type and convert them
+explicitly, for example with `strconv.FormatInt` or `strconv.FormatUint`:
 
 ```go
 type Client struct {
 	Counter string `json:"counter"`
 }
-
-client.Counter = strconv.FormatInt(counter, 10)
 ```
+
+Convert JavaScript `BigInt` values back to strings before calling `jawsVar`:
 
 ```js
 const next = BigInt(client.counter) + 1n;
@@ -204,16 +195,9 @@ client.counter = next.toString();
 jawsVar("client.counter", client.counter);
 ```
 
-Use a built-in `string` field in the bound state when relying on the generic path
-setter. A Go `json:",string"` tag makes Go-to-browser encoding use a JSON string,
-but is not bidirectional for `JsVar`'s generic path setter: `JsVar` decodes
-browser input into an untyped value, so the resulting string is not assignable
-to an integer field. When the domain model must retain an integer field, combine
-a string representation with an application `ui.PathSetter` that parses and
-validates it, or keep the exact integer outside the browser-writable binding.
-Pass the string representation to browser-facing `JawsSetPath` calls as well;
-they broadcast the caller-supplied value rather than re-encoding the destination
-field.
+A Go `json:",string"` tag is not generic round-trip support: browser input is an
+untyped string that cannot be assigned to an integer field. Use a built-in
+`string` field or implement `ui.PathSetter` to parse and validate it.
 
 Create each binding for the Request that renders it. A `JsVarMaker` can be kept
 in shared handler data because each call returns a fresh `JsVar` over the

--- a/README.md
+++ b/README.md
@@ -175,6 +175,46 @@ must read or change and exchange with Go. Unlike most JaWS UI values, a `JsVar`
 is a bidirectional channel: the binding does not by itself make either the Go
 value or the browser value authoritative.
 
+Values cross this boundary through Go's `encoding/json` and the browser's
+`JSON.parse` and `JSON.stringify`. JSON numbers become JavaScript `Number`
+values rather than retaining a Go numeric type or integer width. Every integer
+in the inclusive range `-9007199254740991` through `9007199254740991` is
+represented exactly. Outside that safe range, not every integer is
+representable. A root or nested signed or unsigned integer may be rounded in the
+initial browser snapshot or a server update, and a later browser write can
+commit the rounded value to Go. `JsVar` does not reject or transform such values.
+
+If an integer must remain exact, give it an application-level JSON
+representation such as a decimal field of Go's built-in `string` type in the
+`JsVar`-bound state. JavaScript can convert that string to `BigInt` for
+calculations, but must convert it back to a string before calling `jawsVar`
+because `JSON.stringify` does not encode `BigInt` values directly:
+
+```go
+type Client struct {
+	Counter string `json:"counter"`
+}
+
+client.Counter = strconv.FormatInt(counter, 10)
+```
+
+```js
+const next = BigInt(client.counter) + 1n;
+client.counter = next.toString();
+jawsVar("client.counter", client.counter);
+```
+
+Use a built-in `string` field in the bound state when relying on the generic path
+setter. A Go `json:",string"` tag makes Go-to-browser encoding use a JSON string,
+but is not bidirectional for `JsVar`'s generic path setter: `JsVar` decodes
+browser input into an untyped value, so the resulting string is not assignable
+to an integer field. When the domain model must retain an integer field, combine
+a string representation with an application `ui.PathSetter` that parses and
+validates it, or keep the exact integer outside the browser-writable binding.
+Pass the string representation to browser-facing `JawsSetPath` calls as well;
+they broadcast the caller-supplied value rather than re-encoding the destination
+field.
+
 Create each binding for the Request that renders it. A `JsVarMaker` can be kept
 in shared handler data because each call returns a fresh `JsVar` over the
 possibly shared backing state:

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -174,6 +174,24 @@ slider := ui.NewRange(binder)
 {{$.Range .Dot.Percent `min="0"` `max="100"` `step="1"`}}
 ```
 
+## JavaScript variables
+
+`JsVar` values cross the browser boundary through `encoding/json`, `JSON.parse`,
+and `JSON.stringify`. JSON numbers become JavaScript `Number` values rather than
+retaining a Go numeric type or integer width. Root and nested integers outside
+the inclusive safe range `-9007199254740991` through `9007199254740991` are not
+reliably preserved; a browser write can commit a rounded value to Go. `JsVar`
+does not reject or transform them. When exact wide integers matter, represent
+them with fields of Go's built-in `string` type and convert to and from JavaScript
+`BigInt` in application code. Convert a `BigInt` back to a string before calling
+`jawsVar`; `JSON.stringify` does not encode it directly. A Go `json:",string"`
+tag makes Go-to-browser encoding use a JSON string, but JsVar's generic browser
+write still produces an untyped string that is not assignable to an integer
+field. Keep the bound field as a built-in `string`, implement `PathSetter` to
+parse the encoded form, or keep the exact value outside the browser-writable
+binding. Pass the string representation to browser-facing `JawsSetPath` calls;
+they broadcast the caller-supplied value.
+
 `JsVar` values are client-writable. The generic path setter can write exported
 JSON fields and append to slices, and it has no default accumulated-state size
 limit. Set the binding's optional `ClientCheck` to validate each actual generic

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -176,21 +176,12 @@ slider := ui.NewRange(binder)
 
 ## JavaScript variables
 
-`JsVar` values cross the browser boundary through `encoding/json`, `JSON.parse`,
-and `JSON.stringify`. JSON numbers become JavaScript `Number` values rather than
-retaining a Go numeric type or integer width. Root and nested integers outside
-the inclusive safe range `-9007199254740991` through `9007199254740991` are not
-reliably preserved; a browser write can commit a rounded value to Go. `JsVar`
-does not reject or transform them. When exact wide integers matter, represent
-them with fields of Go's built-in `string` type and convert to and from JavaScript
-`BigInt` in application code. Convert a `BigInt` back to a string before calling
-`jawsVar`; `JSON.stringify` does not encode it directly. A Go `json:",string"`
-tag makes Go-to-browser encoding use a JSON string, but JsVar's generic browser
-write still produces an untyped string that is not assignable to an integer
-field. Keep the bound field as a built-in `string`, implement `PathSetter` to
-parse the encoded form, or keep the exact value outside the browser-writable
-binding. Pass the string representation to browser-facing `JawsSetPath` calls;
-they broadcast the caller-supplied value.
+Browser JSON numbers use JavaScript `Number` values. Integers outside
+`-9007199254740991` through `9007199254740991` may be rounded, and a browser
+write may commit the rounded value to Go. Represent exact wide integers as
+built-in strings, converting JavaScript `BigInt` values back to strings before
+calling `jawsVar`. A Go `json:",string"` tag is not generic round-trip support;
+use a built-in string field or implement `PathSetter`.
 
 `JsVar` values are client-writable. The generic path setter can write exported
 JSON fields and append to slices, and it has no default accumulated-state size

--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -171,26 +171,15 @@ func JSONSizeCheck[T any](maxBytes int) (check JsVarCheck[T]) {
 // valid bindings. Do not use a browser-owned property such as window.name, or a
 // global owned by unrelated code.
 //
-// Values cross the browser boundary through [json.Marshal], [json.Unmarshal],
-// and the browser's JSON.parse and JSON.stringify. JSON numbers therefore become
-// JavaScript Number values rather than retaining a Go numeric type or integer
-// width. Every integer in the inclusive range -9007199254740991 through
-// 9007199254740991 is represented exactly. Outside that safe range, not every
-// integer is representable. A root or nested signed or unsigned integer may be
-// rounded in the initial browser snapshot or a server broadcast, and a later
-// browser write can commit the rounded value to Go. JsVar does not reject or
-// transform such values.
+// Browser JSON numbers use JavaScript Number values. Signed and unsigned
+// integers outside -9007199254740991 through 9007199254740991 may be rounded in
+// a snapshot or broadcast; a later browser write may store the rounded value in
+// Go.
 //
-// When exact wide integers matter, use an application-level JSON representation
-// such as a decimal field of Go's built-in string type in T. Browser code may
-// convert the string to a BigInt for calculations, but must convert it back to a
-// string before calling jawsVar because JSON.stringify does not encode BigInt
-// values directly. A json:",string" tag makes Go-to-browser encoding use a JSON
-// string, but is not by itself sufficient for generic browser writes: JsVar
-// decodes browser input into an untyped value before assignment, so the resulting
-// string is not assignable to an integer field. Keep the bound field as a built-in
-// string or implement [PathSetter] to parse and validate the encoded value. Pass
-// the same string representation to browser-facing [JsVar.JawsSetPath] calls.
+// Represent exact wide integers as built-in string fields and convert them
+// explicitly. Browser code must convert BigInt values back to strings before
+// calling jawsVar. A json:",string" tag is not generic round-trip support; use a
+// built-in string field or a [PathSetter].
 //
 // The variable name and browser-side jawsVar paths must be
 // application-controlled. The browser rejects exact "__proto__" path
@@ -563,7 +552,6 @@ func (jsvar *JsVar[T]) JawsInput(elem *jaws.Element, value string) (err error) {
 // Create a fresh JsVar for each live [jaws.Element]; l and v may be shared by
 // distinct request-scoped JsVar values. Use [JsVarMaker] when construction
 // depends on the current request or the maker is stored in shared handler data.
-// See [JsVar] for the browser's JSON number precision limits.
 func NewJsVar[T any](l sync.Locker, v *T) *JsVar[T] {
 	return &JsVar[T]{RWLocker: bind.AsRWLocker(l), Ptr: v}
 }

--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -171,6 +171,27 @@ func JSONSizeCheck[T any](maxBytes int) (check JsVarCheck[T]) {
 // valid bindings. Do not use a browser-owned property such as window.name, or a
 // global owned by unrelated code.
 //
+// Values cross the browser boundary through [json.Marshal], [json.Unmarshal],
+// and the browser's JSON.parse and JSON.stringify. JSON numbers therefore become
+// JavaScript Number values rather than retaining a Go numeric type or integer
+// width. Every integer in the inclusive range -9007199254740991 through
+// 9007199254740991 is represented exactly. Outside that safe range, not every
+// integer is representable. A root or nested signed or unsigned integer may be
+// rounded in the initial browser snapshot or a server broadcast, and a later
+// browser write can commit the rounded value to Go. JsVar does not reject or
+// transform such values.
+//
+// When exact wide integers matter, use an application-level JSON representation
+// such as a decimal field of Go's built-in string type in T. Browser code may
+// convert the string to a BigInt for calculations, but must convert it back to a
+// string before calling jawsVar because JSON.stringify does not encode BigInt
+// values directly. A json:",string" tag makes Go-to-browser encoding use a JSON
+// string, but is not by itself sufficient for generic browser writes: JsVar
+// decodes browser input into an untyped value before assignment, so the resulting
+// string is not assignable to an integer field. Keep the bound field as a built-in
+// string or implement [PathSetter] to parse and validate the encoded value. Pass
+// the same string representation to browser-facing [JsVar.JawsSetPath] calls.
+//
 // The variable name and browser-side jawsVar paths must be
 // application-controlled. The browser rejects exact "__proto__" path
 // components; put user data in values, not names or paths.
@@ -392,6 +413,10 @@ func (jsvar *JsVar[T]) setPath(elem *jaws.Element, jsPath string, value any, cli
 // page between its initial render and its broadcast subscription; see [JsVar]
 // for the synchronization model.
 //
+// The browser receives the JSON encoding of value, not a re-encoding of the
+// destination field after assignment. Applications using an encoded
+// representation such as decimal strings must pass that representation in value.
+//
 // When a write produces a broadcast, value is marshaled while the application
 // locker is held. Custom marshaling callbacks reachable from value, including
 // MarshalJSON and MarshalText, must not acquire that locker or re-enter the
@@ -538,6 +563,7 @@ func (jsvar *JsVar[T]) JawsInput(elem *jaws.Element, value string) (err error) {
 // Create a fresh JsVar for each live [jaws.Element]; l and v may be shared by
 // distinct request-scoped JsVar values. Use [JsVarMaker] when construction
 // depends on the current request or the maker is stored in shared handler data.
+// See [JsVar] for the browser's JSON number precision limits.
 func NewJsVar[T any](l sync.Locker, v *T) *JsVar[T] {
 	return &JsVar[T]{RWLocker: bind.AsRWLocker(l), Ptr: v}
 }


### PR DESCRIPTION
## Summary

- document that JsVar JSON numbers follow JavaScript `Number` semantics rather than retaining Go numeric types or integer widths
- define the inclusive safe-integer range and warn that wider root or nested integers can round and later be committed back to Go
- show a lossless decimal-string/`BigInt` workaround
- explain why `json:",string"` is not a bidirectional generic-setter workaround and how `PathSetter`/`JawsSetPath` must preserve the chosen representation

This documents the browser transport boundary; runtime behavior is unchanged.

Fixes #276.

## Verification

- `go generate ./...`
- `go vet ./...`
- `gofumpt -l lib/ui/jsvar.go`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`
- `go build ./...`
- `JAWS_REQUIRE_NODE=1 go test -count=1 ./...`
- `JAWS_REQUIRE_NODE=1 go test -race -count=1 ./...`
- `go doc ./lib/ui JsVar`
- `go doc ./lib/ui JsVar.JawsSetPath`
- `go doc ./lib/ui NewJsVar`
