### PR TITLE
docs(ui): define JsVar generic write limits

### DIFF
--- a/.agents/skills/jaws/SKILL.md
+++ b/.agents/skills/jaws/SKILL.md
@@ -263,7 +263,7 @@ On incoming events, JaWS dispatches in this order:
 
 The handler candidate is asked via `JawsClick` / `JawsContextMenu` / `JawsInput`, matched to the event kind; there is no generic `JawsEvent` method. Return `jaws.ErrEventUnhandled` to fall through to the next candidate.
 
-## JsVar JSON number limits
+## JsVar JSON representation limits
 
 - `ui.JsVar` uses Go `encoding/json` and browser `JSON.parse` / `JSON.stringify`.
   JSON numbers become JavaScript `Number` values rather than retaining Go numeric
@@ -281,6 +281,14 @@ The handler candidate is asked via `JawsClick` / `JawsContextMenu` / `JawsInput`
   form, or keep the exact integer outside the browser-writable binding. Pass the
   same string representation to browser-facing `JawsSetPath` calls because they
   broadcast the caller-supplied value.
+- JSON-marshalable values can be sent to the browser, but the generic browser
+  setter does not unmarshal back into the concrete destination type. It decodes
+  an untyped JSON value and assigns it through `jq`. Values that need
+  destination-aware decoding need a browser-facing DTO made from directly
+  assignable JSON shapes or a root `ui.PathSetter` that parses and validates the
+  decoded generic value. Custom JSON/text unmarshalers are not invoked;
+  confirmed type mismatches include `time.Time`, base64 `[]byte`, and maps with
+  non-string Go keys.
 
 ## Clickable template pattern
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,22 @@ Pass the string representation to browser-facing `JawsSetPath` calls as well;
 they broadcast the caller-supplied value rather than re-encoding the destination
 field.
 
+`JSON`-marshalable describes values that JaWS can send to the browser. Generic
+browser writes are narrower: JaWS first decodes each write into an untyped Go
+JSON value and then assigns it by path, rather than unmarshaling directly into
+the destination Go type. Destination-aware `encoding/json` behavior therefore
+does not run. Custom `json.Unmarshaler` / `encoding.TextUnmarshaler` methods are
+not invoked; generic assignment may reject the representation or apply its own
+conversions without that custom validation or transformation. Confirmed type
+mismatches include the JSON representations of `time.Time`, base64-encoded
+`[]byte`, and maps with non-string Go keys.
+
+For those values, expose a browser-facing model made from directly assignable
+JSON-shaped fields, or implement `ui.PathSetter` on the bound root. A
+`PathSetter` receives the already-decoded generic value and is responsible for
+parsing and validation; it does not receive the original JSON bytes. Keep
+server-side `JawsSetPath` broadcasts in the same browser-facing representation.
+
 Create each binding for the Request that renders it. A `JsVarMaker` can be kept
 in shared handler data because each call returns a fresh `JsVar` over the
 possibly shared backing state:

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -192,6 +192,17 @@ parse the encoded form, or keep the exact value outside the browser-writable
 binding. Pass the string representation to browser-facing `JawsSetPath` calls;
 they broadcast the caller-supplied value.
 
+JSON-marshalable values can be sent to the browser, but generic browser writes
+do not perform destination-aware `encoding/json` decoding into the bound Go
+type. JaWS decodes a write into an untyped JSON value and assigns it by path.
+Custom JSON or text unmarshalers are not invoked; generic assignment may reject
+the representation or apply its own rules without the custom validation or
+transformation. Confirmed type mismatches include `time.Time`, base64 `[]byte`,
+and maps with non-string Go keys. Use directly assignable browser-facing fields
+or implement `PathSetter` on the bound root to parse and validate the decoded
+generic value. Use the same representation for server-side `JawsSetPath`
+broadcasts.
+
 `JsVar` values are client-writable. The generic path setter can write exported
 JSON fields and append to slices, and it has no default accumulated-state size
 limit. Set the binding's optional `ClientCheck` to validate each actual generic

--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -48,6 +48,12 @@ func validateJsVarName(value []any) (name string, err error) {
 type PathSetter interface {
 	// JawsSetPath should set the JSON object member identified by jsPath to the given value.
 	//
+	// For a browser-originated write, value is the result of decoding the JSON
+	// payload into any: an object is map[string]any, an array is []any, and scalar
+	// values use the standard encoding/json generic types. The original JSON bytes
+	// are not available. A programmatic [JsVar.JawsSetPath] call passes its
+	// caller-supplied value unchanged.
+	//
 	// If the member is already the given value, it should return [jaws.ErrValueUnchanged].
 	//
 	// When a [JsVar]'s bound value (Ptr) implements PathSetter, the JsVar
@@ -191,6 +197,23 @@ func JSONSizeCheck[T any](maxBytes int) (check JsVarCheck[T]) {
 // string is not assignable to an integer field. Keep the bound field as a built-in
 // string or implement [PathSetter] to parse and validate the encoded value. Pass
 // the same string representation to browser-facing [JsVar.JawsSetPath] calls.
+//
+// JSON-marshalable describes the server-to-browser representation, not every
+// value the generic browser setter can write back. A generic write is decoded
+// into an untyped JSON value before [github.com/linkdata/jq.Set] assigns it by
+// path; it is not unmarshaled directly into T. Destination-aware [json.Unmarshal]
+// behavior therefore does not run, including custom json.Unmarshaler and
+// encoding.TextUnmarshaler methods. The jq assignment may reject such a
+// representation or apply its own conversion rules without the destination's
+// custom validation or transformation. Confirmed type mismatches include an
+// RFC3339 JSON string for time.Time, a base64 JSON string for []byte, and JSON
+// object keys for a Go map with non-string keys.
+//
+// Use browser-facing state composed of directly assignable JSON-shaped values,
+// or implement [PathSetter] on the bound root to parse and validate the decoded
+// generic value. PathSetter receives that decoded value, not the original JSON
+// bytes. Server broadcasts must use the same browser-facing representation; see
+// [JsVar.JawsSetPath].
 //
 // The variable name and browser-side jawsVar paths must be
 // application-controlled. The browser rejects exact "__proto__" path
@@ -528,6 +551,11 @@ func (jsvar *JsVar[T]) JawsUpdate(elem *jaws.Element) {
 
 // JawsInput applies a browser-side JavaScript variable update.
 //
+// Browser JSON is first decoded into an untyped Go value and then assigned by
+// path. This generic path does not apply destination-aware [json.Unmarshal]
+// semantics; see [JsVar] for supported representations and [PathSetter] for
+// custom decoding.
+//
 // For a generic path write, a non-nil [JsVar.ClientCheck] validates the complete
 // tentative state before it is committed. The check runs while the JsVar write
 // lock is held. It must only inspect value: it must not mutate it, re-enter this
@@ -563,7 +591,7 @@ func (jsvar *JsVar[T]) JawsInput(elem *jaws.Element, value string) (err error) {
 // Create a fresh JsVar for each live [jaws.Element]; l and v may be shared by
 // distinct request-scoped JsVar values. Use [JsVarMaker] when construction
 // depends on the current request or the maker is stored in shared handler data.
-// See [JsVar] for the browser's JSON number precision limits.
+// See [JsVar] for browser JSON representation and write-back limits.
 func NewJsVar[T any](l sync.Locker, v *T) *JsVar[T] {
 	return &JsVar[T]{RWLocker: bind.AsRWLocker(l), Ptr: v}
 }


### PR DESCRIPTION
## Summary

- distinguish outbound JSON marshalability from the narrower generic browser-write contract
- document that browser writes decode into `any` before jq assignment and do not invoke destination-aware JSON/text unmarshalers
- identify confirmed mismatches such as `time.Time`, base64 `[]byte`, and maps with non-string keys
- document browser-facing DTO and `PathSetter` workarounds, including the exact value shape received by `PathSetter`

Runtime behavior is unchanged.

Fixes #280.

## Stack

This PR is based on #295 because both changes update the same `JsVar` limitation sections. Its diff contains only the generic write-back documentation.

## Verification

- `go generate ./...`
- `go vet ./...`
- `gofumpt -l lib/ui/jsvar.go`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`
- `go build ./...`
- `JAWS_REQUIRE_NODE=1 go test -count=1 ./...`
- `JAWS_REQUIRE_NODE=1 go test -race -count=1 ./...`
- `go doc ./lib/ui PathSetter`
- `go doc ./lib/ui JsVar`
- `go doc ./lib/ui JsVar.JawsInput`
- `go doc ./lib/ui NewJsVar`
