### PR TITLE
docs: define browser interaction limits

### DIFF
--- a/.agents/skills/jaws/SKILL.md
+++ b/.agents/skills/jaws/SKILL.md
@@ -263,6 +263,33 @@ On incoming events, JaWS dispatches in this order:
 
 The handler candidate is asked via `JawsClick` / `JawsContextMenu` / `JawsInput`, matched to the event kind; there is no generic `JawsEvent` method. Return `jaws.ErrEventUnhandled` to fall through to the next candidate.
 
+## Browser interaction and inbound message limits
+
+- The bundled client forwards input, click, and context-menu events only while
+  its WebSocket is open. Events during the initial connection are not queued or
+  replayed. When early interaction matters, initially render controls disabled
+  or inside an `inert` region, then use `Request.SetConnectFn` to change
+  request-local readiness and dirty a request-specific readiness tag used by
+  the Template, or the exact Element whose custom updater removes the gate.
+- Native form reset is unsupported for managed inputs and Select. A reset button
+  or `form.reset()` changes browser state without the per-control events JaWS
+  transports. Use a JaWS-handled `type="button"` to reset Go state and dirty its
+  tags.
+- A `ui.Radio` is one independent boolean binding. Radios in the same native
+  HTML group do not become a server-side group because the browser does not send
+  input events for peers it unchecks. Use `RequestWriter.RadioGroup` with a
+  single-select `named.BoolArray` whose `named.Bool.Name` values are distinct
+  (its zero value or `named.NewBoolArray(false)`), or coordinated setters that
+  clear peers as one synchronized state change and then dirty every changed
+  binding.
+- Every browser-to-server WebSocket message is limited to 32 KiB, including
+  protocol fields, Jids, and values after UTF-8 encoding and JSON escaping. The
+  client does not chunk `Input`, `Set`, `Click`, `ContextMenu`, or `Remove`; an
+  oversized message closes the connection. Use conservative text limits, HTTP
+  uploads for large values, small `jawsVar` writes, and independently updated
+  smaller wrappers for large dynamic trees.
+  `JsVar.ClientCheck` runs after receipt and cannot enforce the transport limit.
+
 ## JsVar JSON representation limits
 
 - `ui.JsVar` uses Go `encoding/json` and browser `JSON.parse` / `JSON.stringify`.

--- a/.agents/skills/jaws/SKILL.md
+++ b/.agents/skills/jaws/SKILL.md
@@ -266,28 +266,27 @@ The handler candidate is asked via `JawsClick` / `JawsContextMenu` / `JawsInput`
 ## Browser interaction and inbound message limits
 
 - The bundled client forwards input, click, and context-menu events only while
-  its WebSocket is open. Events during the initial connection are not queued or
-  replayed. When early interaction matters, initially render controls disabled
-  or inside an `inert` region, then use `Request.SetConnectFn` to change
-  request-local readiness and dirty a request-specific readiness tag used by
-  the Template, or the exact Element whose custom updater removes the gate.
+  its WebSocket is open and does not replay earlier events. When early
+  interaction matters, disable native controls or make the interactive region
+  inert, then use `Request.SetConnectFn` to update request-local readiness and
+  dirty the request-specific readiness tag used by the Template, or the exact
+  Element whose custom updater removes the gate.
 - Native form reset is unsupported for managed inputs and Select. A reset button
   or `form.reset()` changes browser state without the per-control events JaWS
-  transports. Use a JaWS-handled `type="button"` to reset Go state and dirty its
-  tags.
+  transports. Use a JaWS-handled button with `type="button"` to reset Go state and
+  dirty the affected tags.
 - A `ui.Radio` is one independent boolean binding. Radios in the same native
   HTML group do not become a server-side group because the browser does not send
   input events for peers it unchecks. Use `RequestWriter.RadioGroup` with a
-  single-select `named.BoolArray` whose `named.Bool.Name` values are distinct
-  (its zero value or `named.NewBoolArray(false)`), or coordinated setters that
-  clear peers as one synchronized state change and then dirty every changed
-  binding.
-- Every browser-to-server WebSocket message is limited to 32 KiB, including
-  protocol fields, Jids, and values after UTF-8 encoding and JSON escaping. The
-  client does not chunk `Input`, `Set`, `Click`, `ContextMenu`, or `Remove`; an
-  oversized message closes the connection. Use conservative text limits, HTTP
-  uploads for large values, small `jawsVar` writes, and independently updated
-  smaller wrappers for large dynamic trees.
+  single-select `named.BoolArray` whose `named.Bool.Name` values are distinct, or
+  coordinated setters that clear peers as one synchronized state change and
+  then dirty every changed binding.
+- Every browser-to-server WebSocket message is limited to 32 KiB. The client
+  does not chunk `Input`, `Set`, `Click`, `ContextMenu`, or `Remove`; an
+  oversized message closes the connection. Keep text values,
+  click/context-menu names, and `jawsVar` writes conservatively sized; use HTTP
+  uploads for large values and smaller independently updated wrappers for large
+  trees.
   `JsVar.ClientCheck` runs after receipt and cannot enforce the transport limit.
 
 ## JsVar JSON representation limits

--- a/README.md
+++ b/README.md
@@ -152,9 +152,8 @@ are first offered to any extra objects added to the Element, in
 reverse registration order (last added first). If none handle the event, the Element's UI type is
 invoked. If none handle the event, it is ignored.
 
-The bundled client sends these events only while its WebSocket is open. Events
-raised before the initial connection opens or after it stops are not queued or
-replayed.
+The bundled client sends input, set, click, and context-menu messages only while
+its WebSocket is open and does not queue them for later delivery.
 
 Event handlers should return `ErrEventUnhandled` if they didn't
 handle the event or want to pass it to the next handler.
@@ -344,14 +343,12 @@ client/server protocol code:
   framing, quoting) and invalid frames are ignored/dropped.
 * Each inbound WebSocket message is limited to 32 KiB. The bundled client does
   not chunk `Input`, `Set`, `Click`, `ContextMenu`, or `Remove`; an oversized
-  message closes the connection. The limit covers the complete protocol message
-  payload after UTF-8 encoding and JSON escaping, including command fields,
-  Jids, and separators, so there is no fixed maximum application-value length.
-  Use conservative HTML length limits for text controls, ordinary HTTP upload
-  endpoints for large values, small `jawsVar` writes, and independently updated
-  wrappers for dynamic trees that may remove thousands of managed descendants.
-  `JsVar.ClientCheck` and `JSONSizeCheck` run after receipt and cannot enforce
-  this transport limit.
+  message closes the connection. The limit covers the complete protocol payload
+  after UTF-8 encoding, so there is no fixed maximum application-value length.
+  Keep text values, click/context-menu names, and `jawsVar` writes conservatively
+  sized; use HTTP uploads for large values and independently updated wrappers
+  for large dynamic trees. `JsVar.ClientCheck` and `JSONSizeCheck` run after
+  receipt and cannot enforce this transport limit.
 * `what.Remove` means remove child element(s). For browser-originated `Remove`
   messages, the WebSocket `Jid` identifies the parent/container in the DOM and
   `Data` carries removed managed child IDs. The server only removes child IDs
@@ -672,30 +669,25 @@ editable when the source also implements `bind.Setter[T]`. Numeric types include
 signed and unsigned integers, `uintptr`, `float32`, `float64`, and named types
 with one of those underlying types.
 
-The bundled client forwards input, click, and context-menu events only while its
-WebSocket is open. JaWS does not automatically disable otherwise enabled
-controls during the initial connection interval, but events raised then are not
-queued or replayed. If those early interactions matter, initially render the
-controls disabled or inside an `inert` region. A request `ConnectFn` can change
-request-local readiness and dirty a request-specific readiness tag used by the
-Template, or the exact Element whose custom updater removes the gate after the
-WebSocket is accepted.
+When interaction before the initial WebSocket opens must be prevented, render
+native controls disabled or make the interactive region inert. A request
+`ConnectFn` can update request-local readiness and dirty the request-specific
+readiness tag used by the Template, or the exact Element whose custom updater
+removes the gate.
 
 Managed inputs and selects do not support native HTML form reset. A
 `<button type="reset">` or `form.reset()` changes browser values without the
 per-control input/change events JaWS transports, so it does not update Go state.
-Use a JaWS-handled `type="button"` that resets the authoritative Go values and
-dirties their tags.
+Use a JaWS-handled button with `type="button"` that resets the authoritative Go
+values and dirties their tags.
 
 Each `ui.Radio` binds one independent boolean. Radios in the same native HTML
 group, as determined by their name and form/tree scope, do not become a
 server-side group. The browser unchecks peers without sending their input
 events, so separately bound values can diverge. Use
 `RequestWriter.RadioGroup` with a single-select `named.BoolArray` whose
-`named.Bool.Name` values are distinct (its zero value or
-`named.NewBoolArray(false)`), or custom setters that clear peers as one
-synchronized state change and then dirty every changed binding, when Go state
-must be mutually exclusive.
+`named.Bool.Name` values are distinct, or custom setters that clear peers as one
+synchronized state change and then dirty every changed binding.
 
 Since all data access needs to be protected with locks, you will usually use
 `bind.New()` to create a `bind.Binder[T]` that combines a (RW)Locker and a

--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ are first offered to any extra objects added to the Element, in
 reverse registration order (last added first). If none handle the event, the Element's UI type is
 invoked. If none handle the event, it is ignored.
 
+The bundled client sends these events only while its WebSocket is open. Events
+raised before the initial connection opens or after it stops are not queued or
+replayed.
+
 Event handlers should return `ErrEventUnhandled` if they didn't
 handle the event or want to pass it to the next handler.
 
@@ -363,6 +367,16 @@ client/server protocol code:
 
 * The browser is not trusted. Incoming frames are validated (`What`, `Jid`,
   framing, quoting) and invalid frames are ignored/dropped.
+* Each inbound WebSocket message is limited to 32 KiB. The bundled client does
+  not chunk `Input`, `Set`, `Click`, `ContextMenu`, or `Remove`; an oversized
+  message closes the connection. The limit covers the complete protocol message
+  payload after UTF-8 encoding and JSON escaping, including command fields,
+  Jids, and separators, so there is no fixed maximum application-value length.
+  Use conservative HTML length limits for text controls, ordinary HTTP upload
+  endpoints for large values, small `jawsVar` writes, and independently updated
+  wrappers for dynamic trees that may remove thousands of managed descendants.
+  `JsVar.ClientCheck` and `JSONSizeCheck` run after receipt and cannot enforce
+  this transport limit.
 * `what.Remove` means remove child element(s). For browser-originated `Remove`
   messages, the WebSocket `Jid` identifies the parent/container in the DOM and
   `Data` carries removed managed child IDs. The server only removes child IDs
@@ -682,6 +696,31 @@ checkable inputs use `bool`, and date inputs use `time.Time`. `ui.Number` and
 editable when the source also implements `bind.Setter[T]`. Numeric types include
 signed and unsigned integers, `uintptr`, `float32`, `float64`, and named types
 with one of those underlying types.
+
+The bundled client forwards input, click, and context-menu events only while its
+WebSocket is open. JaWS does not automatically disable otherwise enabled
+controls during the initial connection interval, but events raised then are not
+queued or replayed. If those early interactions matter, initially render the
+controls disabled or inside an `inert` region. A request `ConnectFn` can change
+request-local readiness and dirty a request-specific readiness tag used by the
+Template, or the exact Element whose custom updater removes the gate after the
+WebSocket is accepted.
+
+Managed inputs and selects do not support native HTML form reset. A
+`<button type="reset">` or `form.reset()` changes browser values without the
+per-control input/change events JaWS transports, so it does not update Go state.
+Use a JaWS-handled `type="button"` that resets the authoritative Go values and
+dirties their tags.
+
+Each `ui.Radio` binds one independent boolean. Radios in the same native HTML
+group, as determined by their name and form/tree scope, do not become a
+server-side group. The browser unchecks peers without sending their input
+events, so separately bound values can diverge. Use
+`RequestWriter.RadioGroup` with a single-select `named.BoolArray` whose
+`named.Bool.Name` values are distinct (its zero value or
+`named.NewBoolArray(false)`), or custom setters that clear peers as one
+synchronized state change and then dirty every changed binding, when Go state
+must be mutually exclusive.
 
 Since all data access needs to be protected with locks, you will usually use
 `bind.New()` to create a `bind.Binder[T]` that combines a (RW)Locker and a

--- a/contracts.go
+++ b/contracts.go
@@ -113,6 +113,10 @@ type ClickHandler interface {
 	// select, textarea or option element, or inside one, are left to native
 	// input handling and do not invoke JawsClick on an ancestor.
 	//
+	// The bundled client forwards events only while its WebSocket is open.
+	// Events raised before the initial connection opens or after it stops are not
+	// queued or replayed.
+	//
 	// [Click.Name] is the first name HTML attribute or 'button' textContent
 	// found while walking from the event target up through its ancestors. If none
 	// is found it falls back to the event target's HTML id, so it is empty only
@@ -128,6 +132,10 @@ type ContextMenuHandler interface {
 	// from non-form-control descendants. Events whose target is an input, select,
 	// textarea or option element, or inside one, are left to native browser
 	// handling and do not invoke JawsContextMenu on an ancestor.
+	//
+	// The bundled client forwards events only while its WebSocket is open.
+	// Events raised before the initial connection opens or after it stops are not
+	// queued or replayed.
 	JawsContextMenu(elem *Element, click Click) (err error)
 }
 

--- a/contracts.go
+++ b/contracts.go
@@ -113,9 +113,8 @@ type ClickHandler interface {
 	// select, textarea or option element, or inside one, are left to native
 	// input handling and do not invoke JawsClick on an ancestor.
 	//
-	// The bundled client forwards events only while its WebSocket is open.
-	// Events raised before the initial connection opens or after it stops are not
-	// queued or replayed.
+	// Events that occur while the bundled client's WebSocket is not open are not
+	// forwarded or replayed.
 	//
 	// [Click.Name] is the first name HTML attribute or 'button' textContent
 	// found while walking from the event target up through its ancestors. If none
@@ -133,9 +132,8 @@ type ContextMenuHandler interface {
 	// textarea or option element, or inside one, are left to native browser
 	// handling and do not invoke JawsContextMenu on an ancestor.
 	//
-	// The bundled client forwards events only while its WebSocket is open.
-	// Events raised before the initial connection opens or after it stops are not
-	// queued or replayed.
+	// Events that occur while the bundled client's WebSocket is not open are not
+	// forwarded or replayed.
 	JawsContextMenu(elem *Element, click Click) (err error)
 }
 

--- a/eventhandler.go
+++ b/eventhandler.go
@@ -10,7 +10,14 @@ import (
 
 // InputHandler handles input events sent from the browser.
 type InputHandler interface {
-	// JawsInput is called when an [Element] receives a browser input event.
+	// JawsInput is called when JaWS dispatches an input-like message for an
+	// [Element]. See [InputFn] for the message kinds.
+	//
+	// The bundled client forwards events only while its WebSocket is open. Events
+	// raised before the initial connection opens or after it stops are not queued
+	// or replayed. Native browser state changes that emit no watched input or
+	// change event likewise produce no call; standard widgets document relevant
+	// cases.
 	JawsInput(elem *Element, value string) (err error)
 }
 

--- a/eventhandler.go
+++ b/eventhandler.go
@@ -8,16 +8,14 @@ import (
 	"github.com/linkdata/jaws/lib/what"
 )
 
-// InputHandler handles input events sent from the browser.
+// InputHandler handles input-like messages for an Element.
 type InputHandler interface {
 	// JawsInput is called when JaWS dispatches an input-like message for an
 	// [Element]. See [InputFn] for the message kinds.
 	//
-	// The bundled client forwards events only while its WebSocket is open. Events
-	// raised before the initial connection opens or after it stops are not queued
-	// or replayed. Native browser state changes that emit no watched input or
-	// change event likewise produce no call; standard widgets document relevant
-	// cases.
+	// The bundled client sends input and set messages only while its WebSocket is
+	// open and does not queue them for later delivery. Native changes that emit
+	// neither input nor change do not invoke JawsInput.
 	JawsInput(elem *Element, value string) (err error)
 }
 

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -130,31 +130,29 @@ or `fmt.Stringer` for string content that should be escaped.
 ## Browser input boundaries
 
 The bundled client forwards managed input, click, and context-menu events only
-while its WebSocket is open. Events raised during the initial connection are not
-queued or replayed, even though native controls can already be edited. When that
-interval matters, initially render controls disabled or inside an `inert` region,
-then use a request `ConnectFn` to change request-local readiness and dirty the
-request-specific readiness tag used by the Template, or the exact Element whose
-custom updater removes the gate.
+while its WebSocket is open and does not replay earlier events. When early
+interaction matters, disable native controls or make the interactive region
+inert, then use a request `ConnectFn` to update request-local readiness and dirty
+the request-specific readiness tag used by the Template, or the exact Element
+whose custom updater removes the gate.
 
 Native form reset is not a bound input operation. `<button type="reset">` and
 `form.reset()` change browser controls without the per-control input/change
-events JaWS observes. Use a JaWS-handled `type="button"` to reset authoritative
-Go values and dirty their tags.
+events JaWS observes. Use a JaWS-handled button with `type="button"` to reset
+authoritative Go values and dirty their tags.
 
 Separately constructed `Radio` widgets remain independent boolean bindings even
 when they belong to the same native HTML group. Native radio grouping unchecks
 peers without reporting those peers to JaWS. Use `RequestWriter.RadioGroup` with
-a single-select `named.BoolArray` whose `named.Bool.Name` values are distinct
-(its zero value or `named.NewBoolArray(false)`), or custom setters that clear
-peers as one synchronized state change and then dirty every changed binding.
+a single-select `named.BoolArray` whose `named.Bool.Name` values are distinct,
+or custom setters that clear peers as one synchronized state change and then
+dirty every changed binding.
 
 Every browser-to-server message must fit the 32 KiB limit. The
 bundled client does not chunk input values, `jawsVar` writes, click data, or
-removal acknowledgements. The limit includes protocol fields, Jids, and values
-after UTF-8 encoding and JSON escaping; an oversized message closes the
-connection. Use conservative text limits, HTTP uploads for large values, and
-independently updated smaller wrappers for large dynamic trees.
+removal reports; an oversized message closes the connection. Keep text values
+and click/context-menu names conservatively sized, use HTTP uploads for large
+values, and split large dynamic trees into independently updated wrappers.
 `JsVar.ClientCheck` runs only after receipt and cannot enforce this boundary.
 
 ## Numeric inputs

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -127,6 +127,36 @@ their content through `bind.MakeHTMLGetter`. Plain strings are treated as truste
 HTML and are not escaped; use a `bind.Getter[string]`, `bind.StringGetterFunc`,
 or `fmt.Stringer` for string content that should be escaped.
 
+## Browser input boundaries
+
+The bundled client forwards managed input, click, and context-menu events only
+while its WebSocket is open. Events raised during the initial connection are not
+queued or replayed, even though native controls can already be edited. When that
+interval matters, initially render controls disabled or inside an `inert` region,
+then use a request `ConnectFn` to change request-local readiness and dirty the
+request-specific readiness tag used by the Template, or the exact Element whose
+custom updater removes the gate.
+
+Native form reset is not a bound input operation. `<button type="reset">` and
+`form.reset()` change browser controls without the per-control input/change
+events JaWS observes. Use a JaWS-handled `type="button"` to reset authoritative
+Go values and dirty their tags.
+
+Separately constructed `Radio` widgets remain independent boolean bindings even
+when they belong to the same native HTML group. Native radio grouping unchecks
+peers without reporting those peers to JaWS. Use `RequestWriter.RadioGroup` with
+a single-select `named.BoolArray` whose `named.Bool.Name` values are distinct
+(its zero value or `named.NewBoolArray(false)`), or custom setters that clear
+peers as one synchronized state change and then dirty every changed binding.
+
+Every browser-to-server message must fit the 32 KiB limit. The
+bundled client does not chunk input values, `jawsVar` writes, click data, or
+removal acknowledgements. The limit includes protocol fields, Jids, and values
+after UTF-8 encoding and JSON escaping; an oversized message closes the
+connection. Use conservative text limits, HTTP uploads for large values, and
+independently updated smaller wrappers for large dynamic trees.
+`JsVar.ClientCheck` runs only after receipt and cannot enforce this boundary.
+
 ## Numeric inputs
 
 `NewNumber` and `NewRange` accept a `bind.Getter[T]` for any `Numeric` type:

--- a/lib/ui/doc.go
+++ b/lib/ui/doc.go
@@ -26,15 +26,13 @@
 // [Select] support multiple live Elements under their documented conditions.
 // Input widgets and [JsVar] require distinct widget values.
 //
-// Managed controls report browser input while the WebSocket is open. Events
-// before the initial connection opens are not queued. Native form reset is not
-// a bound input operation because browsers change controls without emitting the
-// per-control events JaWS transports. Use server-driven reset actions, and gate
-// initial interaction when those early events matter.
+// Managed controls report input only while the WebSocket is open; earlier events
+// are not queued. Native form reset does not update bindings. Gate initial
+// interaction when necessary and implement resets through JaWS.
 //
 // Each browser-to-server WebSocket message must fit the 32 KiB inbound limit
 // documented by [jaws.Request.ServeHTTP]. Standard widgets do not chunk large
-// values or removal acknowledgements.
+// values or removal reports.
 //
 // [RequestWriter.Register] is an advanced escape hatch primarily for binding a
 // render-independent updater to otherwise static HTML authored by the surrounding

--- a/lib/ui/doc.go
+++ b/lib/ui/doc.go
@@ -26,6 +26,16 @@
 // [Select] support multiple live Elements under their documented conditions.
 // Input widgets and [JsVar] require distinct widget values.
 //
+// Managed controls report browser input while the WebSocket is open. Events
+// before the initial connection opens are not queued. Native form reset is not
+// a bound input operation because browsers change controls without emitting the
+// per-control events JaWS transports. Use server-driven reset actions, and gate
+// initial interaction when those early events matter.
+//
+// Each browser-to-server WebSocket message must fit the 32 KiB inbound limit
+// documented by [jaws.Request.ServeHTTP]. Standard widgets do not chunk large
+// values or removal acknowledgements.
+//
 // [RequestWriter.Register] is an advanced escape hatch primarily for binding a
 // render-independent updater to otherwise static HTML authored by the surrounding
 // template. The registered HTML is intended to contain no JaWS widgets. Render

--- a/lib/ui/input_widgets.go
+++ b/lib/ui/input_widgets.go
@@ -30,10 +30,9 @@ import (
 // render parameters register the Element but do not replace that dirty target.
 // Without a valid setter-derived target, automatic reconciliation does not occur.
 //
-// Native HTML form reset is not a bound input operation. A reset button or a
-// call to form.reset() changes browser control state without the per-control
-// input/change event used by JaWS, so it does not update the Go binding. Use a
-// JaWS-handled button to reset authoritative Go values and dirty their tags.
+// A completed native form reset changes browser state without an input/change
+// event, so it does not update the Go binding. Reset authoritative Go values
+// from a JaWS-handled button with type="button", then dirty their tags.
 type Input struct {
 	// tag is the dirty tag, written once during render and read on the event
 	// goroutine (JawsInput). The render-completes-before-events lifecycle makes

--- a/lib/ui/input_widgets.go
+++ b/lib/ui/input_widgets.go
@@ -29,6 +29,11 @@ import (
 // value can reconcile rejected or normalized browser input. Tags supplied as
 // render parameters register the Element but do not replace that dirty target.
 // Without a valid setter-derived target, automatic reconciliation does not occur.
+//
+// Native HTML form reset is not a bound input operation. A reset button or a
+// call to form.reset() changes browser control state without the per-control
+// input/change event used by JaWS, so it does not update the Go binding. Use a
+// JaWS-handled button to reset authoritative Go values and dirty their tags.
 type Input struct {
 	// tag is the dirty tag, written once during render and read on the event
 	// goroutine (JawsInput). The render-completes-before-events lifecycle makes

--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -215,6 +215,13 @@ func JSONSizeCheck[T any](maxBytes int) (check JsVarCheck[T]) {
 // bytes. Server broadcasts must use the same browser-facing representation; see
 // [JsVar.JawsSetPath].
 //
+// For each matching live binding, jawsVar sends the complete browser write in
+// one WebSocket message. It must fit the 32 KiB inbound limit documented by
+// [jaws.Request.ServeHTTP], including its path, Element ID, protocol fields, and
+// value after UTF-8 encoding and JSON escaping.
+// [JsVar.ClientCheck] runs only after receipt and cannot enforce this transport
+// limit. Use a separate upload endpoint for large data.
+//
 // The variable name and browser-side jawsVar paths must be
 // application-controlled. The browser rejects exact "__proto__" path
 // components; put user data in values, not names or paths.

--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -192,12 +192,10 @@ func JSONSizeCheck[T any](maxBytes int) (check JsVarCheck[T]) {
 // Use a browser-facing DTO compatible with the generic setter, or implement
 // [PathSetter] to parse and validate the decoded value.
 //
-// For each matching live binding, jawsVar sends the complete browser write in
-// one WebSocket message. It must fit the 32 KiB inbound limit documented by
-// [jaws.Request.ServeHTTP], including its path, Element ID, protocol fields, and
-// value after UTF-8 encoding and JSON escaping.
-// [JsVar.ClientCheck] runs only after receipt and cannot enforce this transport
-// limit. Use a separate upload endpoint for large data.
+// While the WebSocket is open, jawsVar sends one complete message per matching
+// live binding, subject to [jaws.Request.ServeHTTP]'s inbound limit.
+// [JsVar.ClientCheck] runs only after receipt and cannot enforce that limit. Use
+// a separate upload endpoint for large data.
 //
 // The variable name and browser-side jawsVar paths must be
 // application-controlled. The browser rejects exact "__proto__" path

--- a/lib/ui/radio.go
+++ b/lib/ui/radio.go
@@ -11,11 +11,20 @@ import (
 //
 // A Radio value must back at most one live [jaws.Element]. Construct distinct
 // Radio values over the same setter to render one bound value more than once.
+//
+// Each Radio binds one independent boolean. When separately bound Radio widgets
+// belong to the same native HTML group, selecting one unchecks its peers without
+// sending input events for those peers, so their Go values are not changed. Use
+// [RequestWriter.RadioGroup] with a single-select [named.BoolArray] whose
+// [named.Bool.Name] values are distinct, or custom setters that clear peers as
+// one synchronized state change and then dirty every changed binding, when Go
+// state must be mutually exclusive.
 type Radio struct{ InputBool }
 
 // NewRadio returns a radio input widget bound to g.
 //
 // For writable use, g must provide the setter-derived dirty target described by [Input].
+// See [Radio] for grouping semantics.
 func NewRadio(g bind.Setter[bool]) *Radio { return &Radio{InputBool{Setter: g}} }
 
 // JawsRender renders ui as an HTML radio input.
@@ -24,6 +33,8 @@ func (u *Radio) JawsRender(elem *jaws.Element, w io.Writer, params []any) error 
 }
 
 // Radio renders an HTML radio input.
+//
+// See [Radio] for grouping semantics.
 func (rw RequestWriter) Radio(value any, params ...any) error {
 	return rw.NewUI(NewRadio(bind.MakeSetter[bool](value)), params...)
 }

--- a/lib/ui/radio.go
+++ b/lib/ui/radio.go
@@ -12,13 +12,11 @@ import (
 // A Radio value must back at most one live [jaws.Element]. Construct distinct
 // Radio values over the same setter to render one bound value more than once.
 //
-// Each Radio binds one independent boolean. When separately bound Radio widgets
-// belong to the same native HTML group, selecting one unchecks its peers without
-// sending input events for those peers, so their Go values are not changed. Use
-// [RequestWriter.RadioGroup] with a single-select [named.BoolArray] whose
-// [named.Bool.Name] values are distinct, or custom setters that clear peers as
-// one synchronized state change and then dirty every changed binding, when Go
-// state must be mutually exclusive.
+// Each Radio binds an independent boolean. An HTML radio group does not group
+// its Go bindings: the browser reports the newly checked radio, not peers it
+// unchecks. Use [RequestWriter.RadioGroup] with a single-select [named.BoolArray]
+// and distinct [named.Bool.Name] values, or coordinated setters that clear peers
+// together and dirty every changed binding.
 type Radio struct{ InputBool }
 
 // NewRadio returns a radio input widget bound to g.

--- a/lib/ui/radiogroup.go
+++ b/lib/ui/radiogroup.go
@@ -108,6 +108,13 @@ func (re RadioElement) Label(params ...any) template.HTML {
 // rendered radio in the group shares a name derived from the first created
 // radio Element's request-scoped [jaws.Jid].
 //
+// Use RadioGroup with a single-select [named.BoolArray] whose [named.Bool.Name]
+// values are distinct (its zero value or [named.NewBoolArray](false)) when Go
+// state must follow native single-selection behavior. A multi-select BoolArray
+// or duplicate Bool names are incompatible with native radio semantics.
+// Separately bound [Radio] widgets do not derive server-side grouping from their
+// native HTML group.
+//
 // The radio and label Elements belong to the [Template] whose body called RadioGroup,
 // which unregisters them when it next replaces its content. Ownership follows that call
 // site rather than the wrapper the markup lands in, so passing [RadioElement] values

--- a/lib/ui/radiogroup.go
+++ b/lib/ui/radiogroup.go
@@ -108,23 +108,13 @@ func (re RadioElement) Label(params ...any) template.HTML {
 // rendered radio in the group shares a name derived from the first created
 // radio Element's request-scoped [jaws.Jid].
 //
-// Use RadioGroup with a single-select [named.BoolArray] whose [named.Bool.Name]
-// values are distinct (its zero value or [named.NewBoolArray](false)) when Go
-// state must follow native single-selection behavior. A multi-select BoolArray
-// or duplicate Bool names are incompatible with native radio semantics.
-// Separately bound [Radio] widgets do not derive server-side grouping from their
-// native HTML group.
+// Use a single-select [named.BoolArray] with distinct [named.Bool.Name] values.
+// Multi-select arrays and duplicate names are incompatible with native radio
+// semantics. Separately bound [Radio] widgets are not grouped server-side by
+// their HTML name.
 //
-// The radio and label Elements belong to the [Template] whose body called RadioGroup,
-// which unregisters them when it next replaces its content. Ownership follows that call
-// site rather than the wrapper the markup lands in, so passing [RadioElement] values
-// into a nested wrapped template through its dot leaves them owned by the outer
-// template: an update of the inner wrapper alone replaces their DOM without their owner
-// reclaiming them, leaving that to the browser's removal acknowledgement for the ids
-// that reached the DOM and to the outer template's next update for any that did not.
-// Re-rendering them in the inner template is not an alternative, since [RadioElement]
-// allows Radio and Label at most one render each. Call RadioGroup from the template
-// that renders the group to avoid the condition entirely.
+// Call RadioGroup from the [Template] that renders the returned [RadioElement]
+// values; do not pass them into a nested wrapped Template for rendering.
 func (rw RequestWriter) RadioGroup(nba *named.BoolArray) (rel []RadioElement) {
 	group := &radioGroupState{}
 	nba.ReadLocked(func(nbl []*named.Bool) {

--- a/lib/ui/select.go
+++ b/lib/ui/select.go
@@ -25,10 +25,9 @@ import (
 // and must tolerate its nil receiver.
 //
 // Select supports one selected option; a multiple select is unsupported.
-// Native HTML form reset is also unsupported: it changes the browser selection
-// without sending the input event that updates the handler. Implement reset as
-// a JaWS-handled action that changes the authoritative selection and dirties its
-// tag.
+// A completed native form reset changes browser state without an input/change
+// event, so it does not update the Go binding. Reset the authoritative selection
+// from a JaWS-handled button with type="button", then dirty its tag.
 type Select struct {
 	handler named.SelectHandler
 }
@@ -39,6 +38,8 @@ var (
 )
 
 // NewSelect returns a single-selection Select backed by handler.
+//
+// See [Select] for native reset semantics.
 func NewSelect(handler named.SelectHandler) Select {
 	return Select{handler: handler}
 }
@@ -87,6 +88,7 @@ func (u Select) JawsInput(elem *jaws.Element, value string) (err error) {
 //
 // HTML attribute params are applied to the select element, but the multiple
 // attribute is unsupported because Select stores one selected option name.
+// See [Select] for native reset semantics.
 func (rw RequestWriter) Select(handler named.SelectHandler, params ...any) error {
 	return rw.NewUI(NewSelect(handler), params...)
 }

--- a/lib/ui/select.go
+++ b/lib/ui/select.go
@@ -25,6 +25,10 @@ import (
 // and must tolerate its nil receiver.
 //
 // Select supports one selected option; a multiple select is unsupported.
+// Native HTML form reset is also unsupported: it changes the browser selection
+// without sending the input event that updates the handler. Implement reset as
+// a JaWS-handled action that changes the authoritative selection and dirties its
+// tag.
 type Select struct {
 	handler named.SelectHandler
 }

--- a/lib/ui/template.go
+++ b/lib/ui/template.go
@@ -32,6 +32,12 @@ import (
 // update unregisters Elements from the previous execution. Elements created by a
 // failed execution are also unregistered.
 //
+// Before replacing a wrapper's contents, the browser acknowledges all managed
+// descendants it is removing in one WebSocket message. That acknowledgement
+// must fit the 32 KiB inbound limit documented by [jaws.Request.ServeHTTP].
+// Partition very large dynamic trees among nested wrappers, and update those
+// wrappers instead of replacing their common ancestor.
+//
 // Execution is not transactional. An error may leave partial output, queued
 // messages, or application side effects in place.
 type Template struct {

--- a/lib/ui/template.go
+++ b/lib/ui/template.go
@@ -32,11 +32,9 @@ import (
 // update unregisters Elements from the previous execution. Elements created by a
 // failed execution are also unregistered.
 //
-// Before replacing a wrapper's contents, the browser acknowledges all managed
-// descendants it is removing in one WebSocket message. That acknowledgement
-// must fit the 32 KiB inbound limit documented by [jaws.Request.ServeHTTP].
-// Partition very large dynamic trees among nested wrappers, and update those
-// wrappers instead of replacing their common ancestor.
+// Replacing wrapper contents reports all managed descendants being removed in
+// one WebSocket message, subject to [jaws.Request.ServeHTTP]'s 32 KiB inbound
+// limit. Split large trees into independently updated nested wrappers.
 //
 // Execution is not transactional. An error may leave partial output, queued
 // messages, or application side effects in place.

--- a/lib/ui/textarea.go
+++ b/lib/ui/textarea.go
@@ -13,11 +13,17 @@ import (
 //
 // A Textarea value must back at most one live [jaws.Element]. Construct distinct
 // Textarea values over the same setter to render one bound value more than once.
+//
+// Each browser edit sends the complete value in one WebSocket message. The
+// value plus protocol and JSON overhead must fit the 32 KiB inbound limit
+// documented by [jaws.Request.ServeHTTP]. Use a conservative maxlength or a
+// separate upload endpoint for potentially large text.
 type Textarea struct{ InputText }
 
 // NewTextarea returns a textarea widget bound to g.
 //
 // For writable use, g must provide the setter-derived dirty target described by [Input].
+// See [Textarea] for the browser-to-server message-size limit.
 func NewTextarea(g bind.Setter[string]) *Textarea { return &Textarea{InputText{Setter: g}} }
 
 // JawsRender renders ui as an HTML textarea.
@@ -32,6 +38,8 @@ func (u *Textarea) JawsRender(elem *jaws.Element, w io.Writer, params []any) (er
 }
 
 // Textarea renders an HTML textarea.
+//
+// See [Textarea] for the browser-to-server message-size limit.
 func (rw RequestWriter) Textarea(value any, params ...any) error {
 	return rw.NewUI(NewTextarea(bind.MakeSetter[string](value)), params...)
 }

--- a/lib/ui/textarea.go
+++ b/lib/ui/textarea.go
@@ -14,10 +14,10 @@ import (
 // A Textarea value must back at most one live [jaws.Element]. Construct distinct
 // Textarea values over the same setter to render one bound value more than once.
 //
-// Each browser edit sends the complete value in one WebSocket message. The
-// value plus protocol and JSON overhead must fit the 32 KiB inbound limit
-// documented by [jaws.Request.ServeHTTP]. Use a conservative maxlength or a
-// separate upload endpoint for potentially large text.
+// While the WebSocket is open, each input event sends the complete value in one
+// message. The value plus protocol and JSON overhead must fit the 32 KiB inbound
+// limit documented by [jaws.Request.ServeHTTP]. Use a conservative maxlength or
+// a separate upload endpoint for potentially large text.
 type Textarea struct{ InputText }
 
 // NewTextarea returns a textarea widget bound to g.

--- a/request.go
+++ b/request.go
@@ -42,6 +42,13 @@ const webSocketReadLimit = 32 * 1024
 // processed after it returns nil. The buffer is bounded, so the function should
 // return promptly; normal [ErrRequestOverloaded] handling applies if it fills.
 //
+// Browser events are sent only after the WebSocket opens and are not replayed
+// from the connection interval. An application that must prevent interaction in
+// that interval can initially render controls disabled or inside an inert
+// region, then have ConnectFn update request-local readiness and dirty the
+// request-specific readiness tag used by the Template, or the exact Element
+// whose custom updater removes that gate.
+//
 // Returning an error aborts the Request, discards its buffered broadcasts, and
 // closes the WebSocket connection without sending a failure message. Broadcasts
 // already delivered to other active Requests are unaffected. The Request pointer
@@ -1173,6 +1180,13 @@ func (rq *Request) runWebSocket(ws *websocket.Conn, pingInterval, wsTimeout time
 // Requires [Jaws.UseRequest] to have been successfully called for the [Request].
 // The JaWS processing loop ([Jaws.Serve] or [Jaws.ServeWithTimeout]) must also
 // be running so the request can subscribe to broadcasts and unsubscribe on exit.
+//
+// Each inbound WebSocket message is limited to 32 KiB. The bundled client does
+// not chunk Input, Set, Click, ContextMenu, or Remove messages. The limit applies
+// to the complete protocol message payload after UTF-8 encoding and JSON
+// escaping, including command fields, Element IDs, and separators, so no fixed
+// application-value length is guaranteed. An oversized message closes the
+// WebSocket connection.
 func (rq *Request) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if rq.startServe() {
 		defer rq.stopServe()

--- a/request.go
+++ b/request.go
@@ -42,12 +42,11 @@ const webSocketReadLimit = 32 * 1024
 // processed after it returns nil. The buffer is bounded, so the function should
 // return promptly; normal [ErrRequestOverloaded] handling applies if it fills.
 //
-// Browser events are sent only after the WebSocket opens and are not replayed
-// from the connection interval. An application that must prevent interaction in
-// that interval can initially render controls disabled or inside an inert
-// region, then have ConnectFn update request-local readiness and dirty the
+// Events before the WebSocket opens are not replayed. To prevent early
+// interaction, initially disable native controls or make the interactive region
+// inert, then have ConnectFn update request-local readiness and dirty the
 // request-specific readiness tag used by the Template, or the exact Element
-// whose custom updater removes that gate.
+// whose custom updater removes the gate.
 //
 // Returning an error aborts the Request, discards its buffered broadcasts, and
 // closes the WebSocket connection without sending a failure message. Broadcasts
@@ -1182,11 +1181,9 @@ func (rq *Request) runWebSocket(ws *websocket.Conn, pingInterval, wsTimeout time
 // be running so the request can subscribe to broadcasts and unsubscribe on exit.
 //
 // Each inbound WebSocket message is limited to 32 KiB. The bundled client does
-// not chunk Input, Set, Click, ContextMenu, or Remove messages. The limit applies
-// to the complete protocol message payload after UTF-8 encoding and JSON
-// escaping, including command fields, Element IDs, and separators, so no fixed
-// application-value length is guaranteed. An oversized message closes the
-// WebSocket connection.
+// not chunk Input, Set, Click, ContextMenu, or Remove messages; oversized
+// messages close the connection. The limit covers the entire protocol payload
+// after UTF-8 encoding, so no fixed application-value length is guaranteed.
 func (rq *Request) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if rq.startServe() {
 		defer rq.stopServe()


### PR DESCRIPTION
## Summary

- document the 32 KiB inbound WebSocket message limit and the bundled operations that are not chunked
- define the initial-connection event boundary and the supported `ConnectFn` readiness-gating pattern
- document native form reset as outside managed-input synchronization
- direct mutually exclusive radios to a single-select `RadioGroup` with distinct `named.Bool.Name` values, or coordinated application setters
- surface the limitations in exported godoc, both READMEs, and the JaWS skill

These boundaries keep uncommon cases explicit without adding transport reassembly, pre-connection event replay, native reset observation, or implicit cross-widget grouping machinery. The documentation points to existing supported alternatives: HTTP uploads, independently updated Template wrappers, request-local readiness tags, server-driven reset actions, and `RadioGroup`.

## Verification

- `go generate ./...`
- `gofumpt -l` on every touched Go file
- `go vet ./...`
- `go build ./...`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec -quiet ./...`
- `JAWS_REQUIRE_NODE=1 go test -count=1 ./...`
- `JAWS_REQUIRE_NODE=1 go test -race -count=1 ./...`
- rendered `go doc` review for every affected exported symbol

## Stack

This PR is based on #296 because it follows that PR's edits to the JsVar, README, and skill documentation. Its diff contains only the browser interaction and inbound-message limits.

Fixes #271.
Fixes #281.
Fixes #286.
Fixes #291.
