### PR TITLE
docs: define request context limits

### DIFF
--- a/.agents/skills/jaws/SKILL.md
+++ b/.agents/skills/jaws/SKILL.md
@@ -268,16 +268,14 @@ The handler candidate is asked via `JawsClick` / `JawsContextMenu` / `JawsInput`
 - `Jaws.BaseContext` and a context installed by `Request.SetContext` own their
   cancellation causes. If their independent cancellation or deadline wins,
   the Request context exposes that cause directly; JaWS does not add a
-  `jaws.ErrRequestCancelled` wrapper. Detect termination through `Done` or
-  `Err`, and use an application sentinel when caller-owned failure
-  classification matters.
+  `jaws.ErrRequestCancelled` wrapper. Use an application sentinel when
+  caller-owned failure classification matters.
 - A custom BaseContext or SetContext result may implement the optional
-  `AfterFunc(func()) func() bool` method recognized by `context.AfterFunc`. JaWS
-  may invoke that registration method or its returned stop function under core
-  locks. Both hooks must return promptly and must not synchronously re-enter the
-  same Jaws or Request, or wait for work that does. Standard-library contexts
-  need no workaround; an interface-only `struct{ context.Context }` wrapper can
-  hide optional methods on a custom context.
+  `AfterFunc(func()) func() bool` method recognized by `context.AfterFunc`. Its
+  registration and stop hooks must return promptly and must not synchronously
+  call the same Jaws or Request, or wait for work that does. Standard-library
+  contexts need no special handling; an interface-only
+  `struct{ context.Context }` wrapper can hide optional methods.
 
 ## Browser interaction and inbound message limits
 

--- a/.agents/skills/jaws/SKILL.md
+++ b/.agents/skills/jaws/SKILL.md
@@ -263,6 +263,22 @@ On incoming events, JaWS dispatches in this order:
 
 The handler candidate is asked via `JawsClick` / `JawsContextMenu` / `JawsInput`, matched to the event kind; there is no generic `JawsEvent` method. Return `jaws.ErrEventUnhandled` to fall through to the next candidate.
 
+## Request context limits
+
+- `Jaws.BaseContext` and a context installed by `Request.SetContext` own their
+  cancellation causes. If their independent cancellation or deadline wins,
+  the Request context exposes that cause directly; JaWS does not add a
+  `jaws.ErrRequestCancelled` wrapper. Detect termination through `Done` or
+  `Err`, and use an application sentinel when caller-owned failure
+  classification matters.
+- A custom BaseContext or SetContext result may implement the optional
+  `AfterFunc(func()) func() bool` method recognized by `context.AfterFunc`. JaWS
+  may invoke that registration method or its returned stop function under core
+  locks. Both hooks must return promptly and must not synchronously re-enter the
+  same Jaws or Request, or wait for work that does. Standard-library contexts
+  need no workaround; an interface-only `struct{ context.Context }` wrapper can
+  hide optional methods on a custom context.
+
 ## Browser interaction and inbound message limits
 
 - The bundled client forwards input, click, and context-menu events only while

--- a/README.md
+++ b/README.md
@@ -874,6 +874,31 @@ go func() {
 }()
 ```
 
+`Jaws.BaseContext` and a context installed by `Request.SetContext` own their
+cancellation causes. In the example, if `cancel` wins,
+`context.Cause(workCtx)` is the context's immutable cause; JaWS does not add a
+`jaws.ErrRequestCancelled` wrapper. Use `Done` or `Err` to detect termination.
+When background failures need stable classification, cancel with an
+application-defined sentinel and use
+`errors.Is(context.Cause(workCtx), sentinel)`. `ErrRequestCancelled` identifies
+non-nil causes wrapped by `Request.Cancel` or JaWS request-aware cancellation
+paths.
+
+A custom `Jaws.BaseContext` or context returned from `Request.SetContext` may
+implement the optional `AfterFunc(func()) func() bool` method recognized by
+`context.AfterFunc`. JaWS can invoke that registration method or its returned
+stop function while internal locks are held. Both hooks must return promptly
+and must not call methods on the same Jaws or Request, directly or through work
+they wait for. Ordinary contexts returned by the standard `context` constructors
+need no special handling. Wrap a custom context in an interface-only wrapper to
+hide optional methods when necessary:
+
+```go
+type contextOnly struct {
+	context.Context
+}
+```
+
 ### Security of the WebSocket callback
 
 While the `Jaws` instance is open, each Request gets a non-zero random 64-bit key

--- a/README.md
+++ b/README.md
@@ -842,23 +842,20 @@ go func() {
 ```
 
 `Jaws.BaseContext` and a context installed by `Request.SetContext` own their
-cancellation causes. In the example, if `cancel` wins,
-`context.Cause(workCtx)` is the context's immutable cause; JaWS does not add a
-`jaws.ErrRequestCancelled` wrapper. Use `Done` or `Err` to detect termination.
-When background failures need stable classification, cancel with an
-application-defined sentinel and use
-`errors.Is(context.Cause(workCtx), sentinel)`. `ErrRequestCancelled` identifies
-non-nil causes wrapped by `Request.Cancel` or JaWS request-aware cancellation
-paths.
+cancellation causes. In the example, if `cancel` wins, both
+`context.Cause(workCtx)` and `context.Cause(rq.Context())` expose that cause
+unchanged; JaWS does not add a `jaws.ErrRequestCancelled` wrapper. When
+background failures need stable classification, cancel with an
+application-defined sentinel and use `errors.Is(context.Cause(workCtx),
+sentinel)`. `ErrRequestCancelled` identifies a non-nil cause supplied when JaWS
+cancels a Request.
 
 A custom `Jaws.BaseContext` or context returned from `Request.SetContext` may
 implement the optional `AfterFunc(func()) func() bool` method recognized by
-`context.AfterFunc`. JaWS can invoke that registration method or its returned
-stop function while internal locks are held. Both hooks must return promptly
-and must not call methods on the same Jaws or Request, directly or through work
-they wait for. Ordinary contexts returned by the standard `context` constructors
-need no special handling. Wrap a custom context in an interface-only wrapper to
-hide optional methods when necessary:
+`context.AfterFunc`. Its registration and stop hooks must return promptly and
+must not synchronously call the same Jaws or Request, or wait for work that does.
+Standard-library contexts need no special handling. An interface-only wrapper
+can hide optional methods on a custom context:
 
 ```go
 type contextOnly struct {

--- a/errors.go
+++ b/errors.go
@@ -110,18 +110,16 @@ var ErrWebsocketOriginWrongHost = errors.New("websocket Origin host mismatch")
 // check fails closed rather than accepting an unverified Origin.
 var ErrWebsocketOriginNoInitial = errors.New("websocket Origin cannot be validated: no initial request")
 
-// ErrRequestCancelled identifies a non-nil Request cancellation cause wrapped
-// by [Request.Cancel] or a JaWS request-aware cancellation path.
+// ErrRequestCancelled identifies a non-nil cause supplied when JaWS cancels a [Request].
 //
-// The concrete error reachable via [context.Cause] on [Request.Context] matches
-// this sentinel through [errors.Is] and unwraps to the underlying cancellation
-// cause. The exported sentinel itself carries no cause.
+// The error returned by [context.Cause] on [Request.Context] matches this
+// sentinel through [errors.Is] and unwraps to the supplied cause. The sentinel
+// itself carries no cause.
 //
-// A caller-supplied parent context owns its immutable cancellation cause. If
-// [Jaws.BaseContext] or a context installed by [Request.SetContext] is canceled
-// or reaches its deadline first, [context.Cause] exposes that cause directly and
-// JaWS does not add an ErrRequestCancelled wrapper to it. Cause-free JaWS
-// cancellation is exposed as [context.Canceled].
+// Cancellation originating from [Jaws.BaseContext] or a context installed by
+// [Request.SetContext] retains that context's cause; JaWS does not wrap it with
+// this sentinel. A JaWS cancellation without a supplied cause is
+// [context.Canceled].
 var ErrRequestCancelled errRequestCancelled
 
 type errRequestCancelled struct {

--- a/errors.go
+++ b/errors.go
@@ -110,11 +110,18 @@ var ErrWebsocketOriginWrongHost = errors.New("websocket Origin host mismatch")
 // check fails closed rather than accepting an unverified Origin.
 var ErrWebsocketOriginNoInitial = errors.New("websocket Origin cannot be validated: no initial request")
 
-// ErrRequestCancelled indicates a [Request] was cancelled.
+// ErrRequestCancelled identifies a non-nil Request cancellation cause wrapped
+// by [Request.Cancel] or a JaWS request-aware cancellation path.
 //
-// The concrete error reachable via [context.Cause] on [Request.Context] wraps the
-// underlying cancellation cause, so it can be matched with [errors.Is] and its cause
-// retrieved with Unwrap. The exported sentinel itself carries no cause.
+// The concrete error reachable via [context.Cause] on [Request.Context] matches
+// this sentinel through [errors.Is] and unwraps to the underlying cancellation
+// cause. The exported sentinel itself carries no cause.
+//
+// A caller-supplied parent context owns its immutable cancellation cause. If
+// [Jaws.BaseContext] or a context installed by [Request.SetContext] is canceled
+// or reaches its deadline first, [context.Cause] exposes that cause directly and
+// JaWS does not add an ErrRequestCancelled wrapper to it. Cause-free JaWS
+// cancellation is exposed as [context.Canceled].
 var ErrRequestCancelled errRequestCancelled
 
 type errRequestCancelled struct {

--- a/jaws.go
+++ b/jaws.go
@@ -101,29 +101,26 @@ type Jid = jid.Jid // convenience alias
 // [Jaws.ServeWithTimeout]; mutating one after serving has begun is an
 // unsynchronized write and is not supported. Methods document their own
 // concurrency behavior and may be called concurrently when stated.
-//
-// A custom BaseContext or a custom context installed through
-// [Request.SetContext] may implement the optional
-// `AfterFunc(func()) func() bool` method recognized by [context.AfterFunc]. JaWS
-// may invoke that registration method or its returned stop function while
-// internal Jaws or Request locks are held. Both hooks must return promptly and
-// must not call methods on the same Jaws or Request, directly or through work
-// they wait for. Contexts returned directly by the standard context constructors
-// expose no application hook and need no special handling.
 type Jaws struct {
-	CookieName              string          // Name for session cookies; defaults to a name derived from the executable ([assets.DefaultCookieName]), falling back to "jaws"
-	AutoSession             bool            // Create and associate a session during a successful WebSocket upgrade when a Request has none. Defaults to false.
-	TrustForwardedHeaders   bool            // Trust X-Forwarded-* headers: governs the session cookie Secure flag (X-Forwarded-Proto) and the client IP used for session/request binding (X-Forwarded-For/X-Real-IP). Defaults to false; only enable behind a single reverse proxy you control that sets these headers.
-	Logger                  Logger          // Optional logger to use
-	Debug                   bool            // Set to true to enable debug info in generated HTML code. Call GenerateHeadHTML after changing it.
-	MakeAuth                MakeAuthFn      // Function to create ui.With.Auth for Templates. If nil, templates get the fail-open DefaultAuth (IsAdmin()==true for everyone); set it to enforce authorization. See DefaultAuth.
-	BaseContext             context.Context // Non-nil parent context for Requests; New uses context.Background(). See Request.Context.
-	WebSocketPingInterval   time.Duration   // Interval between keepalive pings on active WebSocket connections. Defaults to DefaultWebSocketPingInterval. Set <=0 to disable keepalive pings.
-	MaxPendingRequestsPerIP int             // Maximum number of unclaimed Requests per client IP. Defaults to DefaultMaxPendingRequestsPerIP. Set <=0 to disable the cap.
-	webSocketTimeout        time.Duration   // timeout duration passed to ServeWith
-	maintenanceInterval     time.Duration   // Serve maintenance tick interval; set by ServeWithTimeout and read under mu, zero until Serve starts
-	created                 time.Time       // monotonic base captured in New(); read-only after construction, basis for runtimeSeconds
-	runtimeSeconds          atomic.Int32    // whole seconds since created; refreshed during request allocation and by the Serve loop, read lock-free by MarkWritten and the eviction/idle checks
+	CookieName            string     // Name for session cookies; defaults to a name derived from the executable ([assets.DefaultCookieName]), falling back to "jaws"
+	AutoSession           bool       // Create and associate a session during a successful WebSocket upgrade when a Request has none. Defaults to false.
+	TrustForwardedHeaders bool       // Trust X-Forwarded-* headers: governs the session cookie Secure flag (X-Forwarded-Proto) and the client IP used for session/request binding (X-Forwarded-For/X-Real-IP). Defaults to false; only enable behind a single reverse proxy you control that sets these headers.
+	Logger                Logger     // Optional logger to use
+	Debug                 bool       // Set to true to enable debug info in generated HTML code. Call GenerateHeadHTML after changing it.
+	MakeAuth              MakeAuthFn // Function to create ui.With.Auth for Templates. If nil, templates get the fail-open DefaultAuth (IsAdmin()==true for everyone); set it to enforce authorization. See DefaultAuth.
+	// BaseContext is the non-nil parent context for Requests.
+	//
+	// New uses [context.Background]. If a custom context implements the optional
+	// method recognized by [context.AfterFunc], that method and its returned stop
+	// function must return promptly and must not synchronously call this Jaws or
+	// one of its Requests, or wait for work that does. See [Request.SetContext].
+	BaseContext             context.Context
+	WebSocketPingInterval   time.Duration // Interval between keepalive pings on active WebSocket connections. Defaults to DefaultWebSocketPingInterval. Set <=0 to disable keepalive pings.
+	MaxPendingRequestsPerIP int           // Maximum number of unclaimed Requests per client IP. Defaults to DefaultMaxPendingRequestsPerIP. Set <=0 to disable the cap.
+	webSocketTimeout        time.Duration // timeout duration passed to ServeWith
+	maintenanceInterval     time.Duration // Serve maintenance tick interval; set by ServeWithTimeout and read under mu, zero until Serve starts
+	created                 time.Time     // monotonic base captured in New(); read-only after construction, basis for runtimeSeconds
+	runtimeSeconds          atomic.Int32  // whole seconds since created; refreshed during request allocation and by the Serve loop, read lock-free by MarkWritten and the eviction/idle checks
 	bcastCh                 chan wire.Message
 	subCh                   chan subscription
 	unsubCh                 chan chan wire.Message

--- a/jaws.go
+++ b/jaws.go
@@ -101,6 +101,15 @@ type Jid = jid.Jid // convenience alias
 // [Jaws.ServeWithTimeout]; mutating one after serving has begun is an
 // unsynchronized write and is not supported. Methods document their own
 // concurrency behavior and may be called concurrently when stated.
+//
+// A custom BaseContext or a custom context installed through
+// [Request.SetContext] may implement the optional
+// `AfterFunc(func()) func() bool` method recognized by [context.AfterFunc]. JaWS
+// may invoke that registration method or its returned stop function while
+// internal Jaws or Request locks are held. Both hooks must return promptly and
+// must not call methods on the same Jaws or Request, directly or through work
+// they wait for. Contexts returned directly by the standard context constructors
+// expose no application hook and need no special handling.
 type Jaws struct {
 	CookieName              string          // Name for session cookies; defaults to a name derived from the executable ([assets.DefaultCookieName]), falling back to "jaws"
 	AutoSession             bool            // Create and associate a session during a successful WebSocket upgrade when a Request has none. Defaults to false.
@@ -108,7 +117,7 @@ type Jaws struct {
 	Logger                  Logger          // Optional logger to use
 	Debug                   bool            // Set to true to enable debug info in generated HTML code. Call GenerateHeadHTML after changing it.
 	MakeAuth                MakeAuthFn      // Function to create ui.With.Auth for Templates. If nil, templates get the fail-open DefaultAuth (IsAdmin()==true for everyone); set it to enforce authorization. See DefaultAuth.
-	BaseContext             context.Context // Non-nil base context for Requests, set to context.Background() in New()
+	BaseContext             context.Context // Non-nil parent context for Requests; New uses context.Background(). See Request.Context.
 	WebSocketPingInterval   time.Duration   // Interval between keepalive pings on active WebSocket connections. Defaults to DefaultWebSocketPingInterval. Set <=0 to disable keepalive pings.
 	MaxPendingRequestsPerIP int             // Maximum number of unclaimed Requests per client IP. Defaults to DefaultMaxPendingRequestsPerIP. Set <=0 to disable the cap.
 	webSocketTimeout        time.Duration   // timeout duration passed to ServeWith

--- a/request.go
+++ b/request.go
@@ -517,6 +517,12 @@ func (rq *Request) Set(key string, value any) {
 //
 // The context is derived from [Jaws.BaseContext] by default. Unlike the Request
 // pointer, it may be retained by background work.
+//
+// If [Jaws.BaseContext] or a context installed by [Request.SetContext] is
+// canceled or reaches its deadline first, [context.Cause] reports that context's
+// cause directly; JaWS does not add an [ErrRequestCancelled] wrapper. Use
+// [context.Context.Done] or [context.Context.Err] to detect termination, and an
+// application-defined cause when caller-owned cancellation needs classification.
 func (rq *Request) Context() (ctx context.Context) {
 	rq.mu.RLock()
 	ctx = rq.ctx
@@ -532,10 +538,24 @@ func (rq *Request) Context() (ctx context.Context) {
 // [Request.ServeHTTP] loop promptly, even while it is idle; no WebSocket event or
 // broadcast is required.
 //
+// The returned context owns cancellation initiated through its cancellation
+// function or deadline. If that cancellation finishes it first, [context.Cause]
+// on [Request.Context] retains the context's immutable cause; JaWS does not add
+// an [ErrRequestCancelled] wrapper.
+//
 // fn runs while the Request lock is held. It must not call methods on the same
 // Request, call code that may do so, or block on work that needs the same
 // Request. SetContext panics if fn is nil. If fn panics, SetContext releases the
 // lock and propagates the panic.
+//
+// A custom returned context may implement the optional
+// `AfterFunc(func()) func() bool` method recognized by [context.AfterFunc]. During
+// later Request derivation or cancellation, JaWS may invoke that registration
+// method or its returned stop function while internal locks are held. Both hooks
+// must return promptly and must not call methods on the same Request or its
+// [Jaws], directly or through work they wait for. Contexts returned directly by
+// the standard context constructors expose no application hook and need no
+// special handling.
 //
 // Background work that must cancel the Request should create a derived context in
 // fn and retain that context's cancellation function, not the Request pointer.
@@ -637,6 +657,10 @@ func (rq *Request) cancel(err error) {
 // It is safe to call synchronously from UI code, for example to terminate a
 // connection that violates a server-side limit. A nil err cancels without a
 // specific cause.
+//
+// If a non-nil err wins the cancellation race, [context.Cause] on
+// [Request.Context] matches [ErrRequestCancelled] and unwraps to err. See
+// [Request.Context] for caller-owned parent-context causes.
 //
 // Do not retain the Request for asynchronous cancellation; use [Request.SetContext]
 // and retain the derived context's cancellation function instead.

--- a/request.go
+++ b/request.go
@@ -517,11 +517,9 @@ func (rq *Request) Set(key string, value any) {
 // The context is derived from [Jaws.BaseContext] by default. Unlike the Request
 // pointer, it may be retained by background work.
 //
-// If [Jaws.BaseContext] or a context installed by [Request.SetContext] is
-// canceled or reaches its deadline first, [context.Cause] reports that context's
-// cause directly; JaWS does not add an [ErrRequestCancelled] wrapper. Use
-// [context.Context.Done] or [context.Context.Err] to detect termination, and an
-// application-defined cause when caller-owned cancellation needs classification.
+// Cancellation originating from [Jaws.BaseContext] or a context installed by
+// [Request.SetContext] retains that context's cause; JaWS does not wrap it with
+// [ErrRequestCancelled].
 func (rq *Request) Context() (ctx context.Context) {
 	rq.mu.RLock()
 	ctx = rq.ctx
@@ -537,24 +535,18 @@ func (rq *Request) Context() (ctx context.Context) {
 // [Request.ServeHTTP] loop promptly, even while it is idle; no WebSocket event or
 // broadcast is required.
 //
-// The returned context owns cancellation initiated through its cancellation
-// function or deadline. If that cancellation finishes it first, [context.Cause]
-// on [Request.Context] retains the context's immutable cause; JaWS does not add
-// an [ErrRequestCancelled] wrapper.
+// If the returned context is canceled first, its cause remains unchanged; see
+// [Request.Context].
 //
 // fn runs while the Request lock is held. It must not call methods on the same
 // Request, call code that may do so, or block on work that needs the same
 // Request. SetContext panics if fn is nil. If fn panics, SetContext releases the
 // lock and propagates the panic.
 //
-// A custom returned context may implement the optional
-// `AfterFunc(func()) func() bool` method recognized by [context.AfterFunc]. During
-// later Request derivation or cancellation, JaWS may invoke that registration
-// method or its returned stop function while internal locks are held. Both hooks
-// must return promptly and must not call methods on the same Request or its
-// [Jaws], directly or through work they wait for. Contexts returned directly by
-// the standard context constructors expose no application hook and need no
-// special handling.
+// If a custom context implements the optional method recognized by
+// [context.AfterFunc], that method and its returned stop function must return
+// promptly and must not synchronously call this Request or its [Jaws], or wait
+// for work that does. Standard-library contexts need no special handling.
 //
 // Background work that must cancel the Request should create a derived context in
 // fn and retain that context's cancellation function, not the Request pointer.


### PR DESCRIPTION
## Summary

- document that `BaseContext` and `SetContext` results retain their own cancellation cause when their cancellation or deadline wins
- define `ErrRequestCancelled` for non-nil causes supplied when JaWS cancels a Request, with caller-owned contexts as the documented exception
- require a custom context's optional `AfterFunc` registration method and returned stop function to return promptly and avoid synchronous re-entry
- show an interface-only `context.Context` wrapper for hiding optional methods
- surface the same rules in exported godoc, the README, and the JaWS skill

These are narrow custom-context boundaries; standard-library contexts need no special handling. Supporting arbitrary reentrant hooks or wrapping caller-owned causes would require a different context and request-lifecycle design.

This does not close #275. WebSocket-loop errors originate inside JaWS rather than a caller-owned context, so they remain subject to the `ErrRequestCancelled` contract.

## Verification

- `go generate ./...`
- `gofumpt -l .`
- `go vet ./...`
- `go build ./...`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec -quiet ./...`
- `JAWS_REQUIRE_NODE=1 go test -count=1 ./...`
- `JAWS_REQUIRE_NODE=1 go test -race -count=1 ./...`
- rendered `go doc` review for every affected exported symbol

## Stack

This PR is based on #297 because it follows that PR's edits to the README and JaWS skill. Its diff contains only the request-context limitations.

Fixes #277.
Fixes #282.
