### PR TITLE
request: preserve accepted events across removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,12 @@ fields are left intact and its methods still operate on the finished Request.
 Request identities are never reused, so a stale Element can never come to
 represent an unrelated connection.
 
+Event targets are fixed when each event is accepted. A live target remains
+eligible if it is later removed, whether removal is reported by the browser or
+initiated by the server; an Element removed before acceptance is excluded. A
+handler may therefore receive a deleted Element, whose render, update, and queue
+helpers are no-ops for the rest of the Request.
+
 Dirtying is two-stage: `Request.Dirty` and `Jaws.Dirty` expand and record their
 selectors on the `Jaws` instance, then the serving loop distributes ordinary tags
 across live Requests and each exact `*Element` only to its owner before scheduling

--- a/element.go
+++ b/element.go
@@ -137,8 +137,10 @@ func (elem *Element) UI() UI {
 // a deleted Element. A request-scoped widget that retains child Elements it
 // creates between render and update calls within one Request lifecycle can use
 // Deleted to detect and discard children removed out-of-band before reuse.
+//
 // An event accepted while the Element is live may still invoke its handler after
 // the Element is later removed from the Request.
+//
 // Deleted is not a lifetime check: it does not report whether the embedded
 // Request still represents the owning connection or make that Request safe to
 // use after its lifecycle.

--- a/element.go
+++ b/element.go
@@ -137,6 +137,8 @@ func (elem *Element) UI() UI {
 // a deleted Element. A request-scoped widget that retains child Elements it
 // creates between render and update calls within one Request lifecycle can use
 // Deleted to detect and discard children removed out-of-band before reuse.
+// An event accepted while the Element is live may still invoke its handler after
+// the Element is later removed from the Request.
 // Deleted is not a lifetime check: it does not report whether the embedded
 // Request still represents the owning connection or make that Request safe to
 // use after its lifecycle.

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -3726,6 +3726,30 @@ func BenchmarkRequestIncomingEventQueue(b *testing.B) {
 			}
 		})
 	}
+
+	const repeatedCount = 3600
+	b.Run("bubbled/repeated=3600/elems=1000", func(b *testing.B) {
+		rq := newBenchRequest(b, elemCount)
+		elem := rq.GetElementByJid(elemCount)
+		elem.AddHandlers(benchUnhandledClickHandler{})
+		elem.Freeze()
+		var value strings.Builder
+		value.WriteString("1 2 5 name")
+		for range repeatedCount {
+			value.WriteByte('\t')
+			value.WriteString(elem.Jid().String())
+		}
+		msg := wire.WsMsg{What: what.Click, Data: value.String()}
+		eventCallCh := make(chan eventFnCall, 1)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			rq.handleIncoming(msg, eventCallCh)
+			call := <-eventCallCh
+			runtime.KeepAlive(call)
+		}
+	})
 }
 
 // BenchmarkRequestEventCallChannelAllocation measures the backing storage for
@@ -3787,6 +3811,31 @@ func BenchmarkRequestEventDispatch(b *testing.B) {
 		b.ReportAllocs()
 		for b.Loop() {
 			err = rq.callAllEventHandlers(0, what.Click, clickValue)
+		}
+		if err != nil {
+			b.Fatal(err)
+		}
+	})
+
+	const repeatedCount = 3600
+	b.Run("bubbled/repeated=3600/elems=1000", func(b *testing.B) {
+		rq := newBenchRequest(b, elemCount)
+		elem := rq.GetElementByJid(elemCount)
+		elem.AddHandlers(benchUnhandledClickHandler{})
+		elem.Freeze()
+		var value strings.Builder
+		value.WriteString("1 2 5 name")
+		for range repeatedCount {
+			value.WriteByte('\t')
+			value.WriteString(elem.Jid().String())
+		}
+		data := value.String()
+
+		var err error
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			err = rq.callAllEventHandlers(0, what.Click, data)
 		}
 		if err != nil {
 			b.Fatal(err)

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -3089,6 +3089,31 @@ func (benchUnhandledClickHandler) JawsClick(*Element, Click) error {
 	return ErrEventUnhandled
 }
 
+func (benchUnhandledClickHandler) JawsContextMenu(*Element, Click) error {
+	return ErrEventUnhandled
+}
+
+type benchIncomingEventHandler struct {
+	handled chan<- struct{}
+}
+
+func (h benchIncomingEventHandler) complete() error {
+	h.handled <- struct{}{}
+	return nil
+}
+
+func (h benchIncomingEventHandler) JawsInput(*Element, string) error {
+	return h.complete()
+}
+
+func (h benchIncomingEventHandler) JawsClick(*Element, Click) error {
+	return h.complete()
+}
+
+func (h benchIncomingEventHandler) JawsContextMenu(*Element, Click) error {
+	return h.complete()
+}
+
 func BenchmarkJawsClosePendingRequests(b *testing.B) {
 	for _, pending := range []int{0, 1, 100} {
 		b.Run("pending="+strconv.Itoa(pending), func(b *testing.B) {
@@ -3581,6 +3606,125 @@ func BenchmarkJawsBroadcastCallTag(b *testing.B) {
 	b.ResetTimer()
 	for b.Loop() {
 		jw.Broadcast(msg)
+	}
+}
+
+// BenchmarkRequestIncomingEventDispatch measures accepting and executing an
+// event through handleIncoming and the real eventCaller goroutine. Each
+// iteration waits for its handler, so the event FIFO cannot accumulate work.
+// Direct cases use 1,000 Elements; bubbled cases resolve eight candidates.
+func BenchmarkRequestIncomingEventDispatch(b *testing.B) {
+	const (
+		elemCount      = 1000
+		candidateCount = 8
+	)
+	for _, tc := range []struct {
+		name    string
+		wht     what.What
+		bubbled bool
+	}{
+		{name: "direct/Input", wht: what.Input},
+		{name: "direct/Set", wht: what.Set},
+		{name: "bubbled/Click", wht: what.Click, bubbled: true},
+		{name: "bubbled/ContextMenu", wht: what.ContextMenu, bubbled: true},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			rq := newBenchRequest(b, elemCount)
+			rq.mu.Lock()
+			rq.ctx = b.Context()
+			rq.mu.Unlock()
+			handled := make(chan struct{}, 1)
+			handler := benchIncomingEventHandler{handled: handled}
+			var msg wire.WsMsg
+			if tc.bubbled {
+				var value strings.Builder
+				value.WriteString("1 2 5 name")
+				for id := elemCount - candidateCount + 1; id <= elemCount; id++ {
+					elem := rq.GetElementByJid(Jid(id))
+					if id == elemCount {
+						elem.AddHandlers(handler)
+					} else {
+						elem.AddHandlers(benchUnhandledClickHandler{})
+					}
+					elem.Freeze()
+					value.WriteByte('\t')
+					value.WriteString(elem.Jid().String())
+				}
+				msg = wire.WsMsg{What: tc.wht, Data: value.String()}
+			} else {
+				elem := rq.GetElementByJid(elemCount)
+				elem.AddHandlers(handler)
+				elem.Freeze()
+				msg = wire.WsMsg{Jid: elem.Jid(), What: tc.wht, Data: "value"}
+			}
+
+			eventCallCh := make(chan eventFnCall, 1)
+			outboundMsgCh := make(chan wire.WsMsg, 1)
+			eventDoneCh := make(chan struct{})
+			go rq.eventCaller(eventCallCh, outboundMsgCh, eventDoneCh)
+			b.Cleanup(func() {
+				close(eventCallCh)
+				<-eventDoneCh
+			})
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				rq.handleIncoming(msg, eventCallCh)
+				<-handled
+			}
+		})
+	}
+}
+
+// BenchmarkRequestIncomingEventQueue measures the process-goroutine work needed
+// to accept an event and place its resolved call on the event FIFO. Handler
+// execution is excluded; [BenchmarkRequestEventDispatch] covers the combined
+// resolution and invocation path.
+func BenchmarkRequestIncomingEventQueue(b *testing.B) {
+	for _, n := range []int{1, 1000} {
+		b.Run("direct/elems="+strconv.Itoa(n), func(b *testing.B) {
+			rq := newBenchRequest(b, n)
+			elem := rq.GetElementByJid(Jid(n))
+			elem.AddHandlers(benchInputHandler{})
+			elem.Freeze()
+			msg := wire.WsMsg{Jid: elem.Jid(), What: what.Input, Data: "value"}
+			eventCallCh := make(chan eventFnCall, 1)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				rq.handleIncoming(msg, eventCallCh)
+				call := <-eventCallCh
+				runtime.KeepAlive(call)
+			}
+		})
+	}
+
+	const elemCount = 1000
+	for _, candidateCount := range []int{1, 8, 16} {
+		b.Run("bubbled/candidates="+strconv.Itoa(candidateCount)+"/elems=1000", func(b *testing.B) {
+			rq := newBenchRequest(b, elemCount)
+			var value strings.Builder
+			value.WriteString("1 2 5 name")
+			for id := elemCount - candidateCount + 1; id <= elemCount; id++ {
+				elem := rq.GetElementByJid(Jid(id))
+				elem.AddHandlers(benchUnhandledClickHandler{})
+				elem.Freeze()
+				value.WriteByte('\t')
+				value.WriteString(elem.Jid().String())
+			}
+			msg := wire.WsMsg{What: what.Click, Data: value.String()}
+			eventCallCh := make(chan eventFnCall, 1)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				rq.handleIncoming(msg, eventCallCh)
+				call := <-eventCallCh
+				runtime.KeepAlive(call)
+			}
+		})
 	}
 }
 

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -3728,6 +3728,21 @@ func BenchmarkRequestIncomingEventQueue(b *testing.B) {
 	}
 }
 
+// BenchmarkRequestEventCallChannelAllocation measures the backing storage for
+// eventCallCh at the capacities used by a Request with zero or 1,000 Elements.
+func BenchmarkRequestEventCallChannelAllocation(b *testing.B) {
+	for _, elemCount := range []int{0, 1000} {
+		capacity := 4 + elemCount*4
+		b.Run("elems="+strconv.Itoa(elemCount)+"/capacity="+strconv.Itoa(capacity), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				eventCallCh := make(chan eventFnCall, capacity)
+				runtime.KeepAlive(eventCallCh)
+			}
+		})
+	}
+}
+
 // BenchmarkRequestEventDispatch measures the request-level event path that
 // resolves Jids and reads a frozen Element's handlers. The bubbled case exercises
 // the per-candidate eligibility checks before every handler returns unhandled.

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -3114,6 +3114,25 @@ func (h benchIncomingEventHandler) JawsContextMenu(*Element, Click) error {
 	return h.complete()
 }
 
+func benchRepeatedClickMsg(b *testing.B, repeated *Element, count int, tail ...*Element) wire.WsMsg {
+	b.Helper()
+	var value strings.Builder
+	value.WriteString("1 2 5 name")
+	for range count {
+		value.WriteByte('\t')
+		value.WriteString(repeated.Jid().String())
+	}
+	for _, elem := range tail {
+		value.WriteByte('\t')
+		value.WriteString(elem.Jid().String())
+	}
+	msg := wire.WsMsg{What: what.Click, Data: value.String()}
+	if size := len(msg.Append(nil)); size > webSocketReadLimit {
+		b.Fatalf("repeated click message = %d bytes, limit %d", size, webSocketReadLimit)
+	}
+	return msg
+}
+
 func BenchmarkJawsClosePendingRequests(b *testing.B) {
 	for _, pending := range []int{0, 1, 100} {
 		b.Run("pending="+strconv.Itoa(pending), func(b *testing.B) {
@@ -3612,7 +3631,8 @@ func BenchmarkJawsBroadcastCallTag(b *testing.B) {
 // BenchmarkRequestIncomingEventDispatch measures accepting and executing an
 // event through handleIncoming and the real eventCaller goroutine. Each
 // iteration waits for its handler, so the event FIFO cannot accumulate work.
-// Direct cases use 1,000 Elements; bubbled cases resolve eight candidates.
+// Direct cases use 1,000 Elements. The ordinary bubbled cases resolve eight
+// candidates; the repeated-route case exercises deduplication.
 func BenchmarkRequestIncomingEventDispatch(b *testing.B) {
 	const (
 		elemCount      = 1000
@@ -3675,12 +3695,45 @@ func BenchmarkRequestIncomingEventDispatch(b *testing.B) {
 			}
 		})
 	}
+
+	const repeatedCount = 4000
+	b.Run("bubbled/repeated=4000/elems=1000", func(b *testing.B) {
+		rq := newBenchRequest(b, elemCount)
+		rq.mu.Lock()
+		rq.ctx = b.Context()
+		rq.mu.Unlock()
+		handled := make(chan struct{}, 1)
+		repeated := rq.GetElementByJid(1)
+		repeated.AddHandlers(benchUnhandledClickHandler{})
+		repeated.Freeze()
+		completion := rq.GetElementByJid(2)
+		completion.AddHandlers(benchIncomingEventHandler{handled: handled})
+		completion.Freeze()
+		msg := benchRepeatedClickMsg(b, repeated, repeatedCount, completion)
+
+		eventCallCh := make(chan eventFnCall, 1)
+		outboundMsgCh := make(chan wire.WsMsg, 1)
+		eventDoneCh := make(chan struct{})
+		go rq.eventCaller(eventCallCh, outboundMsgCh, eventDoneCh)
+		b.Cleanup(func() {
+			close(eventCallCh)
+			<-eventDoneCh
+		})
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			rq.handleIncoming(msg, eventCallCh)
+			<-handled
+		}
+	})
 }
 
 // BenchmarkRequestIncomingEventQueue measures the process-goroutine work needed
 // to accept an event and place its resolved call on the event FIFO. Handler
-// execution is excluded; [BenchmarkRequestEventDispatch] covers the combined
-// resolution and invocation path.
+// execution is excluded. BenchmarkRequestIncomingEventDispatch covers the
+// complete handleIncoming-to-handler path through the FIFO;
+// BenchmarkRequestEventDispatch isolates resolution and invocation.
 func BenchmarkRequestIncomingEventQueue(b *testing.B) {
 	for _, n := range []int{1, 1000} {
 		b.Run("direct/elems="+strconv.Itoa(n), func(b *testing.B) {
@@ -3702,7 +3755,7 @@ func BenchmarkRequestIncomingEventQueue(b *testing.B) {
 	}
 
 	const elemCount = 1000
-	for _, candidateCount := range []int{1, 8, 16} {
+	for _, candidateCount := range []int{1, 8, 16, 32, 33, 34} {
 		b.Run("bubbled/candidates="+strconv.Itoa(candidateCount)+"/elems=1000", func(b *testing.B) {
 			rq := newBenchRequest(b, elemCount)
 			var value strings.Builder
@@ -3727,19 +3780,13 @@ func BenchmarkRequestIncomingEventQueue(b *testing.B) {
 		})
 	}
 
-	const repeatedCount = 3600
-	b.Run("bubbled/repeated=3600/elems=1000", func(b *testing.B) {
+	const repeatedCount = 4000
+	b.Run("bubbled/repeated=4000/elems=1000", func(b *testing.B) {
 		rq := newBenchRequest(b, elemCount)
-		elem := rq.GetElementByJid(elemCount)
+		elem := rq.GetElementByJid(1)
 		elem.AddHandlers(benchUnhandledClickHandler{})
 		elem.Freeze()
-		var value strings.Builder
-		value.WriteString("1 2 5 name")
-		for range repeatedCount {
-			value.WriteByte('\t')
-			value.WriteString(elem.Jid().String())
-		}
-		msg := wire.WsMsg{What: what.Click, Data: value.String()}
+		msg := benchRepeatedClickMsg(b, elem, repeatedCount)
 		eventCallCh := make(chan eventFnCall, 1)
 
 		b.ReportAllocs()
@@ -3752,8 +3799,9 @@ func BenchmarkRequestIncomingEventQueue(b *testing.B) {
 	})
 }
 
-// BenchmarkRequestEventCallChannelAllocation measures the backing storage for
-// eventCallCh at the capacities used by a Request with zero or 1,000 Elements.
+// BenchmarkRequestEventCallChannelAllocation measures the fixed allocation for
+// an empty eventCallCh at the capacities used by a Request with zero or 1,000
+// Elements.
 func BenchmarkRequestEventCallChannelAllocation(b *testing.B) {
 	for _, elemCount := range []int{0, 1000} {
 		capacity := 4 + elemCount*4
@@ -3767,9 +3815,9 @@ func BenchmarkRequestEventCallChannelAllocation(b *testing.B) {
 	}
 }
 
-// BenchmarkRequestEventDispatch measures the request-level event path that
-// resolves Jids and reads a frozen Element's handlers. The bubbled case exercises
-// the per-candidate eligibility checks before every handler returns unhandled.
+// BenchmarkRequestEventDispatch measures synchronous target resolution and
+// handler invocation. The bubbled cases exercise eligibility and deduplication
+// before every handler returns unhandled.
 func BenchmarkRequestEventDispatch(b *testing.B) {
 	for _, n := range []int{1, 1000} {
 		b.Run("direct/elems="+strconv.Itoa(n), func(b *testing.B) {
@@ -3789,47 +3837,40 @@ func BenchmarkRequestEventDispatch(b *testing.B) {
 		})
 	}
 
-	const (
-		elemCount      = 1000
-		candidateCount = 8
-	)
-	b.Run("bubbled/candidates=8/elems=1000", func(b *testing.B) {
-		rq := newBenchRequest(b, elemCount)
-		var value strings.Builder
-		value.WriteString("1 2 5 name")
-		for id := elemCount - candidateCount + 1; id <= elemCount; id++ {
-			elem := rq.GetElementByJid(Jid(id))
-			elem.AddHandlers(benchUnhandledClickHandler{})
-			elem.Freeze()
+	const elemCount = 1000
+	for _, candidateCount := range []int{8, 16, 32, 34} {
+		b.Run("bubbled/candidates="+strconv.Itoa(candidateCount)+"/elems=1000", func(b *testing.B) {
+			rq := newBenchRequest(b, elemCount)
+			var value strings.Builder
+			value.WriteString("1 2 5 name")
+			for id := elemCount - candidateCount + 1; id <= elemCount; id++ {
+				elem := rq.GetElementByJid(Jid(id))
+				elem.AddHandlers(benchUnhandledClickHandler{})
+				elem.Freeze()
+				value.WriteByte('\t')
+				value.WriteString(elem.Jid().String())
+			}
 			value.WriteByte('\t')
-			value.WriteString(elem.Jid().String())
-		}
-		value.WriteByte('\t')
-		clickValue := value.String()
+			clickValue := value.String()
 
-		var err error
-		b.ReportAllocs()
-		for b.Loop() {
-			err = rq.callAllEventHandlers(0, what.Click, clickValue)
-		}
-		if err != nil {
-			b.Fatal(err)
-		}
-	})
+			var err error
+			b.ReportAllocs()
+			for b.Loop() {
+				err = rq.callAllEventHandlers(0, what.Click, clickValue)
+			}
+			if err != nil {
+				b.Fatal(err)
+			}
+		})
+	}
 
-	const repeatedCount = 3600
-	b.Run("bubbled/repeated=3600/elems=1000", func(b *testing.B) {
+	const repeatedCount = 4000
+	b.Run("bubbled/repeated=4000/elems=1000", func(b *testing.B) {
 		rq := newBenchRequest(b, elemCount)
-		elem := rq.GetElementByJid(elemCount)
+		elem := rq.GetElementByJid(1)
 		elem.AddHandlers(benchUnhandledClickHandler{})
 		elem.Freeze()
-		var value strings.Builder
-		value.WriteString("1 2 5 name")
-		for range repeatedCount {
-			value.WriteByte('\t')
-			value.WriteString(elem.Jid().String())
-		}
-		data := value.String()
+		data := benchRepeatedClickMsg(b, elem, repeatedCount).Data
 
 		var err error
 		b.ReportAllocs()

--- a/request.go
+++ b/request.go
@@ -108,9 +108,10 @@ type Request struct {
 }
 
 type eventFnCall struct {
-	jid  Jid
-	wht  what.What
-	data string
+	jid   Jid
+	elems []*Element
+	wht   what.What
+	data  string
 }
 
 // reqState is the lifecycle state of a [Request], stored in Request.state as an

--- a/request.go
+++ b/request.go
@@ -108,7 +108,6 @@ type Request struct {
 }
 
 type eventFnCall struct {
-	jid  Jid
 	elem *Element
 	more []*Element
 	wht  what.What

--- a/request.go
+++ b/request.go
@@ -108,10 +108,11 @@ type Request struct {
 }
 
 type eventFnCall struct {
-	jid   Jid
-	elems []*Element
-	wht   what.What
-	data  string
+	jid  Jid
+	elem *Element
+	more []*Element
+	wht  what.What
+	data string
 }
 
 // reqState is the lifecycle state of a [Request], stored in Request.state as an

--- a/request_test.go
+++ b/request_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"testing/synctest"
 	"time"
-	"unsafe"
 
 	"github.com/coder/websocket"
 	"github.com/linkdata/deadlock"
@@ -2501,47 +2500,6 @@ func TestRequest_handleIncomingSkipsEventsWithoutTargets(t *testing.T) {
 				t.Fatalf("FIFO entry = %#v, want sentinel", got)
 			}
 		})
-	}
-}
-
-func TestRequest_handleIncomingClonesLargeEventRoute(t *testing.T) {
-	rq := newTestRequest(t)
-	defer rq.Close()
-
-	targetTag := tag.Tag(t.Name())
-	if err := rq.UI(testDivWidget{inner: "target"}, targetTag); err != nil {
-		t.Fatal(err)
-	}
-	targets := rq.GetElements(targetTag)
-	if len(targets) != 1 {
-		t.Fatalf("target elements = %d, want 1", len(targets))
-	}
-	target := targets[0]
-
-	const wantData = "1 2 0 name"
-	routeTarget := "\t" + target.Jid().String()
-	repeats := minEventRouteCloneSavingsBytes/len(routeTarget) + 1
-	msg := wire.WsMsg{What: what.Click, Data: wantData + strings.Repeat(routeTarget, repeats)}
-	if got := len(msg.Append(nil)); got > webSocketReadLimit {
-		t.Fatalf("encoded message size = %d, limit %d", got, webSocketReadLimit)
-	}
-
-	eventCallCh := make(chan eventFnCall, 1)
-	rq.handleIncoming(msg, eventCallCh)
-	var call eventFnCall
-	select {
-	case call = <-eventCallCh:
-	default:
-		t.Fatal("event was not queued")
-	}
-	if call.elem != target || len(call.more) != 0 {
-		t.Fatalf("event targets = %v, %v; want only %v", call.elem, call.more, target)
-	}
-	if call.data != wantData {
-		t.Fatalf("event data = %q, want %q", call.data, wantData)
-	}
-	if unsafe.StringData(call.data) == unsafe.StringData(msg.Data) { // #nosec G103 -- test intentionally inspects string backing storage
-		t.Fatal("event data retains the routed message backing storage")
 	}
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -2373,8 +2373,10 @@ func TestRequest_queueEventOverloadCancels(t *testing.T) {
 	rq := jw.NewRequest(nil)
 	defer jw.recycle(rq)
 
+	first := rq.NewElement(&testUi{})
+	second := rq.NewElement(&testUi{})
 	full := make(chan eventFnCall) // unbuffered, no receiver: send fails at once
-	rq.queueEvent(full, eventFnCall{jid: 1, wht: what.Input, data: "x"})
+	rq.queueEvent(full, eventFnCall{elem: first, more: []*Element{second}, wht: what.Input, data: "x"})
 
 	cause := context.Cause(rq.Context())
 	if !errors.Is(cause, ErrRequestOverloaded) {
@@ -2382,6 +2384,9 @@ func TestRequest_queueEventOverloadCancels(t *testing.T) {
 	}
 	if !errors.Is(cause, ErrRequestCancelled) {
 		t.Fatalf("cause = %v, want it to wrap ErrRequestCancelled", cause)
+	}
+	if !strings.Contains(cause.Error(), "Targets=2") {
+		t.Fatalf("cause = %v, want target count", cause)
 	}
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"testing/synctest"
 	"time"
+	"unsafe"
 
 	"github.com/coder/websocket"
 	"github.com/linkdata/deadlock"
@@ -2061,16 +2062,25 @@ func TestRequest_IncomingRemovePreservesAcceptedEventOrder(t *testing.T) {
 
 func TestRequest_EventRouteOrderAndDeduplication(t *testing.T) {
 	for _, wht := range []what.What{what.Click, what.ContextMenu} {
-		for _, uniqueCount := range []int{2, 33, 34} {
-			t.Run(wht.String()+"/unique="+strconv.Itoa(uniqueCount), func(t *testing.T) {
+		for _, tc := range []struct {
+			name           string
+			uniqueCount    int
+			duplicateIndex int
+		}{
+			{name: "inline", uniqueCount: 2, duplicateIndex: 0},
+			{name: "linear", uniqueCount: 2, duplicateIndex: 1},
+			{name: "map-seeded", uniqueCount: 33, duplicateIndex: 1},
+			{name: "map-inserted", uniqueCount: 34, duplicateIndex: 33},
+		} {
+			t.Run(wht.String()+"/"+tc.name, func(t *testing.T) {
 				rq := newTestRequest(t)
 				defer rq.Close()
 				var calls []string
 				var route strings.Builder
 				route.WriteString("1 2 0 name")
-				want := make([]string, 0, uniqueCount)
-				var first Jid
-				for i := range uniqueCount {
+				want := make([]string, 0, tc.uniqueCount)
+				targets := make([]Jid, 0, tc.uniqueCount)
+				for i := range tc.uniqueCount {
 					name := strconv.Itoa(i)
 					if err := rq.UI(testDivWidget{inner: "target"}, requestRouteOrderHandler{
 						name: name, calls: &calls, err: ErrEventUnhandled,
@@ -2078,16 +2088,14 @@ func TestRequest_EventRouteOrderAndDeduplication(t *testing.T) {
 						t.Fatal(err)
 					}
 					elem := rq.GetElementByJid(Jid(i + 1))
-					if i == 0 {
-						first = elem.Jid()
-					}
+					targets = append(targets, elem.Jid())
 					route.WriteByte('\t')
 					route.WriteString(elem.Jid().String())
 					want = append(want, name)
 				}
 				route.WriteByte('\t')
-				// Repeating the first target verifies first-occurrence deduplication.
-				route.WriteString(first.String())
+				// Repeating a selected target verifies first-occurrence deduplication.
+				route.WriteString(targets[tc.duplicateIndex].String())
 				if err := rq.callAllEventHandlers(0, wht, route.String()); err != nil {
 					t.Fatal(err)
 				}
@@ -2493,6 +2501,47 @@ func TestRequest_handleIncomingSkipsEventsWithoutTargets(t *testing.T) {
 				t.Fatalf("FIFO entry = %#v, want sentinel", got)
 			}
 		})
+	}
+}
+
+func TestRequest_handleIncomingClonesLargeEventRoute(t *testing.T) {
+	rq := newTestRequest(t)
+	defer rq.Close()
+
+	targetTag := tag.Tag(t.Name())
+	if err := rq.UI(testDivWidget{inner: "target"}, targetTag); err != nil {
+		t.Fatal(err)
+	}
+	targets := rq.GetElements(targetTag)
+	if len(targets) != 1 {
+		t.Fatalf("target elements = %d, want 1", len(targets))
+	}
+	target := targets[0]
+
+	const wantData = "1 2 0 name"
+	routeTarget := "\t" + target.Jid().String()
+	repeats := minEventRouteCloneSavingsBytes/len(routeTarget) + 1
+	msg := wire.WsMsg{What: what.Click, Data: wantData + strings.Repeat(routeTarget, repeats)}
+	if got := len(msg.Append(nil)); got > webSocketReadLimit {
+		t.Fatalf("encoded message size = %d, limit %d", got, webSocketReadLimit)
+	}
+
+	eventCallCh := make(chan eventFnCall, 1)
+	rq.handleIncoming(msg, eventCallCh)
+	var call eventFnCall
+	select {
+	case call = <-eventCallCh:
+	default:
+		t.Fatal("event was not queued")
+	}
+	if call.elem != target || len(call.more) != 0 {
+		t.Fatalf("event targets = %v, %v; want only %v", call.elem, call.more, target)
+	}
+	if call.data != wantData {
+		t.Fatalf("event data = %q, want %q", call.data, wantData)
+	}
+	if unsafe.StringData(call.data) == unsafe.StringData(msg.Data) { // #nosec G103 -- test intentionally inspects string backing storage
+		t.Fatal("event data retains the routed message backing storage")
 	}
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -1915,6 +1915,25 @@ func (h *requestEventOrderHandler) JawsContextMenu(*Element, Click) error {
 	return nil
 }
 
+type requestRouteOrderHandler struct {
+	name  string
+	calls *[]string
+	err   error
+}
+
+func (h requestRouteOrderHandler) call() error {
+	*h.calls = append(*h.calls, h.name)
+	return h.err
+}
+
+func (h requestRouteOrderHandler) JawsClick(*Element, Click) error {
+	return h.call()
+}
+
+func (h requestRouteOrderHandler) JawsContextMenu(*Element, Click) error {
+	return h.call()
+}
+
 type requestClickHandlerFunc func(*Element, Click) error
 
 func (fn requestClickHandlerFunc) JawsClick(elem *Element, click Click) error {
@@ -2037,6 +2056,31 @@ func TestRequest_IncomingRemovePreservesAcceptedEventOrder(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestRequest_EventRouteOrder(t *testing.T) {
+	for _, wht := range []what.What{what.Click, what.ContextMenu} {
+		t.Run(wht.String(), func(t *testing.T) {
+			rq := newTestRequest(t)
+			defer rq.Close()
+			var calls []string
+			first := requestRouteOrderHandler{name: "first", calls: &calls, err: ErrEventUnhandled}
+			second := requestRouteOrderHandler{name: "second", calls: &calls}
+			if err := rq.UI(testDivWidget{inner: "first"}, first); err != nil {
+				t.Fatal(err)
+			}
+			if err := rq.UI(testDivWidget{inner: "second"}, second); err != nil {
+				t.Fatal(err)
+			}
+			data := "1 2 0 name\tJid.1\tJid.2"
+			if err := rq.callAllEventHandlers(0, wht, data); err != nil {
+				t.Fatal(err)
+			}
+			if want := []string{"first", "second"}; !reflect.DeepEqual(calls, want) {
+				t.Fatalf("handler order = %v, want %v", calls, want)
+			}
+		})
 	}
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -1901,6 +1901,145 @@ func TestRequest_IncomingRemove(t *testing.T) {
 	})
 }
 
+type requestEventOrderHandler struct {
+	calls atomic.Int32
+}
+
+func (h *requestEventOrderHandler) JawsClick(*Element, Click) error {
+	h.calls.Add(1)
+	return nil
+}
+
+func (h *requestEventOrderHandler) JawsContextMenu(*Element, Click) error {
+	h.calls.Add(1)
+	return nil
+}
+
+type requestClickHandlerFunc func(*Element, Click) error
+
+func (fn requestClickHandlerFunc) JawsClick(elem *Element, click Click) error {
+	return fn(elem, click)
+}
+
+func TestRequest_IncomingRemovePreservesAcceptedEventOrder(t *testing.T) {
+	for _, wht := range []what.What{what.Input, what.Set, what.Click, what.ContextMenu} {
+		for _, removeFirst := range []bool{false, true} {
+			name := wht.String() + " before Remove"
+			wantCalls := int32(1)
+			if removeFirst {
+				name = "Remove before " + wht.String()
+				wantCalls = 0
+			}
+			t.Run(name, func(t *testing.T) {
+				th := newTestHelper(t)
+				rq := newTestRequest(t)
+				defer rq.Close()
+				render := func(name string, ui UI, params ...any) *Element {
+					t.Helper()
+					tagValue := tag.Tag(name)
+					params = append([]any{tagValue}, params...)
+					if err := rq.UI(ui, params...); err != nil {
+						t.Fatal(err)
+					}
+					elems := rq.GetElements(tagValue)
+					if len(elems) != 1 {
+						t.Fatalf("rendered %q elements = %d, want 1", name, len(elems))
+					}
+					return elems[0]
+				}
+
+				started := make(chan struct{})
+				release := make(chan struct{})
+				var releaseOnce sync.Once
+				releaseBlocker := func() { releaseOnce.Do(func() { close(release) }) }
+				defer releaseBlocker()
+
+				blocker := render("blocker", &testDivWidget{inner: "blocker"}, requestClickHandlerFunc(func(*Element, Click) error {
+					close(started)
+					<-release
+					return nil
+				}))
+				container := render("container", &testDivWidget{inner: "container"})
+				var calls func() int32
+				var value func() string
+				var target *Element
+				if wht == what.Input || wht == what.Set {
+					setter := newTestSetter("old")
+					target = render("target", newTestTextInputWidget(setter))
+					calls = func() int32 { return int32(setter.SetCount()) }
+					value = setter.Get
+				} else {
+					handler := &requestEventOrderHandler{}
+					target = render("target", &testDivWidget{inner: "target"}, handler)
+					calls = handler.calls.Load
+				}
+				drained := make(chan struct{})
+				barrier := render("barrier", &testDivWidget{inner: "barrier"}, requestClickHandlerFunc(func(*Element, Click) error {
+					close(drained)
+					return nil
+				}))
+
+				send := func(msg wire.WsMsg) {
+					t.Helper()
+					select {
+					case rq.InCh <- msg:
+					case <-th.C:
+						th.Timeout()
+					}
+				}
+
+				send(wire.WsMsg{What: what.Click, Data: "0 0 0 blocker\t" + blocker.Jid().String()})
+				select {
+				case <-started:
+				case <-th.C:
+					th.Timeout()
+				}
+
+				event := wire.WsMsg{Jid: target.Jid(), What: wht, Data: "new"}
+				if wht == what.Click || wht == what.ContextMenu {
+					event.Jid = 0
+					event.Data = "1 2 0 name\t" + target.Jid().String() + "\t" + container.Jid().String()
+				}
+				remove := wire.WsMsg{Jid: container.Jid(), What: what.Remove, Data: target.Jid().String()}
+				if !removeFirst {
+					send(event)
+				}
+				send(remove)
+				if removeFirst {
+					send(event)
+				}
+				send(wire.WsMsg{What: what.Click, Data: "0 0 0 barrier\t" + barrier.Jid().String()})
+
+				if !target.Deleted() {
+					t.Fatal("Remove was not processed while the event caller was blocked")
+				}
+				releaseBlocker()
+				select {
+				case <-drained:
+				case <-th.C:
+					th.Timeout()
+				}
+
+				if got := calls(); got != wantCalls {
+					t.Fatalf("handler calls = %d, want %d", got, wantCalls)
+				}
+				if value != nil {
+					want := "new"
+					if removeFirst {
+						want = "old"
+					}
+					if got := value(); got != want {
+						t.Fatalf("bound value = %q, want %q", got, want)
+					}
+				}
+				if got := rq.GetElementByJid(target.Jid()); got != nil {
+					t.Fatalf("removed target remains registered: %+v", got)
+				}
+			})
+		}
+	}
+}
+
 func TestRequest_DirtyElementUpdatesOwningRequest(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		rq := newTestRequest(t)

--- a/request_test.go
+++ b/request_test.go
@@ -2059,28 +2059,81 @@ func TestRequest_IncomingRemovePreservesAcceptedEventOrder(t *testing.T) {
 	}
 }
 
-func TestRequest_EventRouteOrder(t *testing.T) {
+func TestRequest_EventRouteOrderAndDeduplication(t *testing.T) {
 	for _, wht := range []what.What{what.Click, what.ContextMenu} {
-		t.Run(wht.String(), func(t *testing.T) {
-			rq := newTestRequest(t)
-			defer rq.Close()
-			var calls []string
-			first := requestRouteOrderHandler{name: "first", calls: &calls, err: ErrEventUnhandled}
-			second := requestRouteOrderHandler{name: "second", calls: &calls}
-			if err := rq.UI(testDivWidget{inner: "first"}, first); err != nil {
-				t.Fatal(err)
-			}
-			if err := rq.UI(testDivWidget{inner: "second"}, second); err != nil {
-				t.Fatal(err)
-			}
-			data := "1 2 0 name\tJid.1\tJid.2"
-			if err := rq.callAllEventHandlers(0, wht, data); err != nil {
-				t.Fatal(err)
-			}
-			if want := []string{"first", "second"}; !reflect.DeepEqual(calls, want) {
-				t.Fatalf("handler order = %v, want %v", calls, want)
-			}
-		})
+		for _, uniqueCount := range []int{2, 33, 34} {
+			t.Run(wht.String()+"/unique="+strconv.Itoa(uniqueCount), func(t *testing.T) {
+				rq := newTestRequest(t)
+				defer rq.Close()
+				var calls []string
+				var route strings.Builder
+				route.WriteString("1 2 0 name")
+				want := make([]string, 0, uniqueCount)
+				var first Jid
+				for i := range uniqueCount {
+					name := strconv.Itoa(i)
+					if err := rq.UI(testDivWidget{inner: "target"}, requestRouteOrderHandler{
+						name: name, calls: &calls, err: ErrEventUnhandled,
+					}); err != nil {
+						t.Fatal(err)
+					}
+					elem := rq.GetElementByJid(Jid(i + 1))
+					if i == 0 {
+						first = elem.Jid()
+					}
+					route.WriteByte('\t')
+					route.WriteString(elem.Jid().String())
+					want = append(want, name)
+				}
+				route.WriteByte('\t')
+				// Repeating the first target verifies first-occurrence deduplication.
+				route.WriteString(first.String())
+				if err := rq.callAllEventHandlers(0, wht, route.String()); err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(calls, want) {
+					t.Fatalf("handler order = %v, want %v", calls, want)
+				}
+			})
+		}
+	}
+}
+
+func TestRequest_AcceptedEventSurvivesDeleteElement(t *testing.T) {
+	rq := newTestRequest(t)
+	defer rq.Close()
+
+	setter := newTestSetter("old")
+	targetTag := tag.Tag(t.Name())
+	if err := rq.UI(newTestTextInputWidget(setter), targetTag); err != nil {
+		t.Fatal(err)
+	}
+	targets := rq.GetElements(targetTag)
+	if len(targets) != 1 {
+		t.Fatalf("target elements = %d, want 1", len(targets))
+	}
+	target := targets[0]
+	eventCallCh := make(chan eventFnCall, 1)
+	rq.handleIncoming(wire.WsMsg{Jid: target.Jid(), What: what.Input, Data: "new"}, eventCallCh)
+
+	rq.DeleteElement(target)
+	if !target.Deleted() || rq.GetElementByJid(target.Jid()) != nil {
+		t.Fatal("DeleteElement did not unregister target")
+	}
+	var call eventFnCall
+	select {
+	case call = <-eventCallCh:
+	default:
+		t.Fatal("accepted event was not queued")
+	}
+	if err := call.invoke(); err != nil {
+		t.Fatal(err)
+	}
+	if got := setter.SetCount(); got != 1 {
+		t.Fatalf("setter calls = %d, want 1", got)
+	}
+	if got := setter.Get(); got != "new" {
+		t.Fatalf("bound value = %q, want %q", got, "new")
 	}
 }
 
@@ -2387,6 +2440,59 @@ func TestRequest_queueEventOverloadCancels(t *testing.T) {
 	}
 	if !strings.Contains(cause.Error(), "Targets=2") {
 		t.Fatalf("cause = %v, want target count", cause)
+	}
+	if !strings.Contains(cause.Error(), "FirstTarget="+first.Jid().String()) {
+		t.Fatalf("cause = %v, want first target Jid", cause)
+	}
+}
+
+func TestRequest_handleIncomingSkipsEventsWithoutTargets(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		msg  func(*Request) wire.WsMsg
+	}{
+		{
+			name: "unknown direct target",
+			msg: func(*Request) wire.WsMsg {
+				return wire.WsMsg{Jid: 1, What: what.Input, Data: "value"}
+			},
+		},
+		{
+			name: "unknown bubbled target",
+			msg: func(*Request) wire.WsMsg {
+				return wire.WsMsg{What: what.Click, Data: "1 2 0 name\tJid.1"}
+			},
+		},
+		{
+			name: "deleted direct target",
+			msg: func(rq *Request) wire.WsMsg {
+				elem := rq.NewElement(&testUi{})
+				elem.Freeze()
+				rq.DeleteElement(elem)
+				return wire.WsMsg{Jid: elem.Jid(), What: what.Input, Data: "value"}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			jw, err := New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer jw.Close()
+			rq := jw.NewRequest(nil)
+			defer jw.recycle(rq)
+
+			full := make(chan eventFnCall, 1)
+			full <- eventFnCall{wht: what.Hook, data: "sentinel"}
+			rq.handleIncoming(tc.msg(rq), full)
+
+			if cause := context.Cause(rq.Context()); cause != nil {
+				t.Fatalf("Request canceled by targetless event: %v", cause)
+			}
+			if got := <-full; got.data != "sentinel" {
+				t.Fatalf("FIFO entry = %#v, want sentinel", got)
+			}
+		})
 	}
 }
 

--- a/requestloop.go
+++ b/requestloop.go
@@ -3,9 +3,9 @@ package jaws
 // This file implements the per-request runtime: the message-processing loop that
 // runs on a Request's own goroutines while its WebSocket is connected.
 //
-// [Request.process] is the select loop. Inbound client messages are dispatched by
-// callAllEventHandlers and executed on the event goroutine via eventCaller;
-// broadcasts and tag messages are applied by handleBroadcast and handleRemove;
+// [Request.process] is the select loop. Inbound client events are resolved by
+// resolveEventFnCall and executed on the event goroutine via eventCaller;
+// broadcasts and removal reports are applied by handleBroadcast and handleRemove;
 // dirty elements are rendered into the outbound queue by getSendMsgs, sendQueue
 // and makeUpdateList. onConnect runs the user ConnectFn once the socket is up.
 
@@ -112,7 +112,7 @@ func (rq *Request) handleIncoming(wsmsg wire.WsMsg, eventCallCh chan eventFnCall
 	if wsmsg.Jid.IsValid() {
 		switch wsmsg.What {
 		case what.Input, what.Click, what.ContextMenu, what.Set:
-			rq.queueEvent(eventCallCh, eventFnCall{jid: wsmsg.Jid, wht: wsmsg.What, data: wsmsg.Data})
+			rq.queueEvent(eventCallCh, rq.resolveEventFnCall(wsmsg.Jid, wsmsg.What, wsmsg.Data))
 		case what.Remove:
 			rq.handleRemove(wsmsg.Jid, wsmsg.Data)
 		}
@@ -175,7 +175,7 @@ func (rq *Request) handleBroadcast(tagmsg wire.Message, eventCallCh chan eventFn
 			// they won't be sent out on the WebSocket, but will queue up a
 			// call to the event function (if any).
 			// primary usecase is tests.
-			rq.queueEvent(eventCallCh, eventFnCall{jid: elem.Jid(), wht: tagmsg.What, data: tagmsg.Data})
+			rq.queueEvent(eventCallCh, rq.resolveEventFnCall(elem.Jid(), tagmsg.What, tagmsg.Data))
 		case what.Hook:
 			// Hook messages synchronously invoke the element's event handler; see
 			// [what.Hook]. They exist for testing: the JaWS client never sends Hook,
@@ -245,47 +245,62 @@ func (rq *Request) queue(msg wire.WsMsg) {
 	rq.muQueue.Unlock()
 }
 
-// callAllEventHandlers dispatches a single incoming event to the target
-// element(s) and returns the first result that is not ErrEventUnhandled. A zero
-// id with a Click or ContextMenu carries a tab-separated list of bubbled element
-// jids, which are resolved and tried in order; any other id resolves to a single
-// element. Only frozen Elements are selected, so the atomic frozen load publishes
-// the completed handler slice before it is read without a lock. ErrEventUnhandled
-// is normalized to nil. rq.mu is held only for the element lookups; the handlers
-// themselves run unlocked.
-func (rq *Request) callAllEventHandlers(id Jid, wht what.What, value string) (err error) {
-	var elems []*Element
+// resolveEventFnCall resolves a single incoming event to its eligible target
+// Elements. A zero id with a Click or ContextMenu carries a tab-separated list of
+// bubbled element jids, which are resolved in order; any other id resolves to a
+// single element. Only live, frozen Elements are selected, so the atomic frozen
+// load publishes the completed handler slice before its later lock-free read.
+//
+// Resolution happens before the call enters the event FIFO. This preserves wire
+// order when a later Remove message unregisters an accepted event's target, while
+// events accepted after removal still resolve to no targets. rq.mu is held only
+// for the element lookups.
+func (rq *Request) resolveEventFnCall(id Jid, wht what.What, value string) (call eventFnCall) {
+	call.jid = id
+	call.wht = wht
+	call.data = value
 	rq.mu.RLock()
 	if id == 0 {
 		if wht == what.Click || wht == what.ContextMenu {
 			var after string
 			var found bool
-			value, after, found = strings.Cut(value, "\t")
+			call.data, after, found = strings.Cut(value, "\t")
 			for found {
 				var jidStr string
 				jidStr, after, found = strings.Cut(after, "\t")
 				if id = jid.ParseString(jidStr); id > 0 {
 					if e := rq.getElementByJidLocked(id); e != nil && !e.deleted.Load() && e.frozen.Load() {
-						elems = append(elems, e)
+						call.elems = append(call.elems, e)
 					}
 				}
 			}
 		}
 	} else {
 		if e := rq.getElementByJidLocked(id); e != nil && !e.deleted.Load() && e.frozen.Load() {
-			elems = append(elems, e)
+			call.elems = append(call.elems, e)
 		}
 	}
 	rq.mu.RUnlock()
+	return
+}
 
-	for _, e := range elems {
-		if err = CallEventHandlers(e.UI(), e, wht, value); !errors.Is(err, ErrEventUnhandled) {
+// invoke calls the resolved Elements in order and returns the first result that
+// is not ErrEventUnhandled. ErrEventUnhandled is normalized to nil.
+func (call eventFnCall) invoke() (err error) {
+	for _, e := range call.elems {
+		if err = CallEventHandlers(e.UI(), e, call.wht, call.data); !errors.Is(err, ErrEventUnhandled) {
 			return
 		}
 	}
 	if errors.Is(err, ErrEventUnhandled) {
 		err = nil
 	}
+	return
+}
+
+// callAllEventHandlers resolves and dispatches a single event synchronously.
+func (rq *Request) callAllEventHandlers(id Jid, wht what.What, value string) (err error) {
+	err = rq.resolveEventFnCall(id, wht, value).invoke()
 	return
 }
 
@@ -300,7 +315,7 @@ func (rq *Request) queueEvent(eventCallCh chan eventFnCall, call eventFnCall) {
 	select {
 	case eventCallCh <- call:
 	default:
-		rq.cancel(fmt.Errorf("%w: %v: eventCallCh full sending %v", ErrRequestOverloaded, rq, call))
+		rq.cancel(fmt.Errorf("%w: %v: eventCallCh full sending Jid=%v What=%v Data=%q", ErrRequestOverloaded, rq, call.jid, call.wht, call.data))
 	}
 }
 
@@ -496,7 +511,7 @@ func (rq *Request) eventCaller(eventCallCh <-chan eventFnCall, outboundMsgCh cha
 			continue
 		default:
 		}
-		if err := rq.Jaws.Log(rq.callAllEventHandlers(call.jid, call.wht, call.data)); err != nil {
+		if err := rq.Jaws.Log(call.invoke()); err != nil {
 			var m wire.WsMsg
 			m.FillAlert(err)
 			// This error alert is best-effort: unlike queueEvent, which cancels the

--- a/requestloop.go
+++ b/requestloop.go
@@ -22,6 +22,8 @@ import (
 	"github.com/linkdata/jaws/lib/wire"
 )
 
+const minEventRouteCloneSavingsBytes = 1024
+
 // process is the main message processing loop. Will unsubscribe broadcastMsgCh and close outboundMsgCh on exit.
 func (rq *Request) process(broadcastMsgCh chan wire.Message, incomingMsgCh <-chan wire.WsMsg, outboundMsgCh chan<- wire.WsMsg) {
 	jawsDoneCh := rq.Jaws.Done()
@@ -112,7 +114,16 @@ func (rq *Request) handleIncoming(wsmsg wire.WsMsg, eventCallCh chan eventFnCall
 	if wsmsg.Jid.IsValid() {
 		switch wsmsg.What {
 		case what.Input, what.Click, what.ContextMenu, what.Set:
-			rq.queueEvent(eventCallCh, rq.resolveEventFnCall(wsmsg.Jid, wsmsg.What, wsmsg.Data))
+			call := rq.resolveEventFnCall(wsmsg.Jid, wsmsg.What, wsmsg.Data)
+			if wsmsg.Jid == 0 && call.elem != nil {
+				routeBytes := len(wsmsg.Data) - len(call.data)
+				if routeBytes >= minEventRouteCloneSavingsBytes && routeBytes >= len(call.data) {
+					// The click payload is a prefix of wsmsg.Data. Detach it when the
+					// queued call would otherwise retain a much larger client route.
+					call.data = strings.Clone(call.data)
+				}
+			}
+			rq.queueEvent(eventCallCh, call)
 		case what.Remove:
 			rq.handleRemove(wsmsg.Jid, wsmsg.Data)
 		}
@@ -247,36 +258,66 @@ func (rq *Request) queue(msg wire.WsMsg) {
 
 // resolveEventFnCall resolves a single incoming event to its eligible target
 // Elements. A zero id with a Click or ContextMenu carries a tab-separated list of
-// bubbled element jids, which are resolved in order; any other id resolves to a
-// single element. Only live, frozen Elements are selected, so the atomic frozen
-// load publishes the completed handler slice before its later lock-free read.
+// bubbled element jids, whose live targets are resolved once each in
+// first-occurrence order; any other id resolves to a single element. Only live,
+// frozen Elements are selected, so the atomic frozen load publishes the completed
+// handler slice before its later lock-free read.
 //
-// Resolution happens before the call enters the event FIFO. This preserves wire
-// order when a later Remove message unregisters an accepted event's target, while
-// events accepted after removal still resolve to no targets. rq.mu is held only
-// for the element lookups.
+// Resolution happens before the call enters the event FIFO, fixing target
+// eligibility at acceptance. Later removal from any source does not cancel an
+// accepted event, while an Element removed first cannot be selected. rq.mu
+// protects target lookup; handlers run later without it.
 func (rq *Request) resolveEventFnCall(id Jid, wht what.What, value string) (call eventFnCall) {
 	call.wht = wht
 	call.data = value
 	rq.mu.RLock()
 	if id == 0 {
 		if wht == what.Click || wht == what.ContextMenu {
+			const linearDedupLimit = 32
 			var after string
 			var found bool
+			var seenMap map[*Element]struct{}
 			call.data, after, found = strings.Cut(value, "\t")
-			// Bound speculative allocation from the client-controlled route.
-			remainingCap := min(strings.Count(after, "\t"), 8)
 			for found {
 				var jidStr string
 				jidStr, after, found = strings.Cut(after, "\t")
 				if id = jid.ParseString(jidStr); id > 0 {
 					if e := rq.getElementByJidLocked(id); e != nil && !e.deleted.Load() && e.frozen.Load() {
-						if call.elem == nil {
-							call.elem = e
-						} else {
-							if call.more == nil {
-								call.more = make([]*Element, 0, remainingCap)
+						duplicate := e == call.elem
+						if !duplicate {
+							if seenMap == nil {
+								duplicate = slices.Contains(call.more, e)
+							} else {
+								_, duplicate = seenMap[e]
 							}
+						}
+						if duplicate {
+							continue
+						}
+						if seenMap == nil && call.elem != nil && 1+len(call.more) == linearDedupLimit && after != "" {
+							// Avoid separate deduplication storage for ordinary routes,
+							// then switch before a client-controlled deep route becomes quadratic.
+							seenMap = make(map[*Element]struct{}, linearDedupLimit+1)
+							seenMap[call.elem] = struct{}{}
+							for _, seenElem := range call.more {
+								seenMap[seenElem] = struct{}{}
+							}
+						}
+						if seenMap != nil {
+							seenMap[e] = struct{}{}
+						}
+						switch {
+						case call.elem == nil:
+							call.elem = e
+						case call.more == nil:
+							remainingCap := 1
+							if after != "" {
+								remainingCap += 1 + strings.Count(after, "\t")
+							}
+							// Bound speculative allocation from the client-controlled route.
+							call.more = make([]*Element, 0, min(remainingCap, 8))
+							call.more = append(call.more, e)
+						default:
 							call.more = append(call.more, e)
 						}
 					}
@@ -323,16 +364,16 @@ func (rq *Request) callAllEventHandlers(id Jid, wht what.What, value string) (er
 // fallen too far behind to stay consistent (an event would be lost), so it is
 // cancelled rather than dropping the event, mirroring the broadcast back-pressure
 // path in [Jaws.ServeWithTimeout]. cancel takes rq.mu, which the process loop does
-// not hold when calling this.
+// not hold when calling this. Calls without a resolved target are ignored.
 func (rq *Request) queueEvent(eventCallCh chan eventFnCall, call eventFnCall) {
+	if call.elem == nil {
+		return
+	}
 	select {
 	case eventCallCh <- call:
 	default:
-		targets := len(call.more)
-		if call.elem != nil {
-			targets++
-		}
-		rq.cancel(fmt.Errorf("%w: %v: eventCallCh full sending Targets=%d What=%v Data=%q", ErrRequestOverloaded, rq, targets, call.wht, call.data))
+		targets := 1 + len(call.more)
+		rq.cancel(fmt.Errorf("%w: %v: eventCallCh full sending FirstTarget=%v Targets=%d What=%v Data=%q", ErrRequestOverloaded, rq, call.elem.Jid(), targets, call.wht, call.data))
 	}
 }
 

--- a/requestloop.go
+++ b/requestloop.go
@@ -265,19 +265,28 @@ func (rq *Request) resolveEventFnCall(id Jid, wht what.What, value string) (call
 			var after string
 			var found bool
 			call.data, after, found = strings.Cut(value, "\t")
+			// Bound speculative allocation from the client-controlled route.
+			remainingCap := min(strings.Count(after, "\t"), 8)
 			for found {
 				var jidStr string
 				jidStr, after, found = strings.Cut(after, "\t")
 				if id = jid.ParseString(jidStr); id > 0 {
 					if e := rq.getElementByJidLocked(id); e != nil && !e.deleted.Load() && e.frozen.Load() {
-						call.elems = append(call.elems, e)
+						if call.elem == nil {
+							call.elem = e
+						} else {
+							if call.more == nil {
+								call.more = make([]*Element, 0, remainingCap)
+							}
+							call.more = append(call.more, e)
+						}
 					}
 				}
 			}
 		}
 	} else {
 		if e := rq.getElementByJidLocked(id); e != nil && !e.deleted.Load() && e.frozen.Load() {
-			call.elems = append(call.elems, e)
+			call.elem = e
 		}
 	}
 	rq.mu.RUnlock()
@@ -287,7 +296,12 @@ func (rq *Request) resolveEventFnCall(id Jid, wht what.What, value string) (call
 // invoke calls the resolved Elements in order and returns the first result that
 // is not ErrEventUnhandled. ErrEventUnhandled is normalized to nil.
 func (call eventFnCall) invoke() (err error) {
-	for _, e := range call.elems {
+	if call.elem != nil {
+		if err = CallEventHandlers(call.elem.UI(), call.elem, call.wht, call.data); !errors.Is(err, ErrEventUnhandled) {
+			return
+		}
+	}
+	for _, e := range call.more {
 		if err = CallEventHandlers(e.UI(), e, call.wht, call.data); !errors.Is(err, ErrEventUnhandled) {
 			return
 		}

--- a/requestloop.go
+++ b/requestloop.go
@@ -22,8 +22,6 @@ import (
 	"github.com/linkdata/jaws/lib/wire"
 )
 
-const minEventRouteCloneSavingsBytes = 1024
-
 // process is the main message processing loop. Will unsubscribe broadcastMsgCh and close outboundMsgCh on exit.
 func (rq *Request) process(broadcastMsgCh chan wire.Message, incomingMsgCh <-chan wire.WsMsg, outboundMsgCh chan<- wire.WsMsg) {
 	jawsDoneCh := rq.Jaws.Done()
@@ -114,16 +112,7 @@ func (rq *Request) handleIncoming(wsmsg wire.WsMsg, eventCallCh chan eventFnCall
 	if wsmsg.Jid.IsValid() {
 		switch wsmsg.What {
 		case what.Input, what.Click, what.ContextMenu, what.Set:
-			call := rq.resolveEventFnCall(wsmsg.Jid, wsmsg.What, wsmsg.Data)
-			if wsmsg.Jid == 0 && call.elem != nil {
-				routeBytes := len(wsmsg.Data) - len(call.data)
-				if routeBytes >= minEventRouteCloneSavingsBytes && routeBytes >= len(call.data) {
-					// The click payload is a prefix of wsmsg.Data. Detach it when the
-					// queued call would otherwise retain a much larger client route.
-					call.data = strings.Clone(call.data)
-				}
-			}
-			rq.queueEvent(eventCallCh, call)
+			rq.queueEvent(eventCallCh, rq.resolveEventFnCall(wsmsg.Jid, wsmsg.What, wsmsg.Data))
 		case what.Remove:
 			rq.handleRemove(wsmsg.Jid, wsmsg.Data)
 		}

--- a/requestloop.go
+++ b/requestloop.go
@@ -256,7 +256,6 @@ func (rq *Request) queue(msg wire.WsMsg) {
 // events accepted after removal still resolve to no targets. rq.mu is held only
 // for the element lookups.
 func (rq *Request) resolveEventFnCall(id Jid, wht what.What, value string) (call eventFnCall) {
-	call.jid = id
 	call.wht = wht
 	call.data = value
 	rq.mu.RLock()
@@ -329,7 +328,11 @@ func (rq *Request) queueEvent(eventCallCh chan eventFnCall, call eventFnCall) {
 	select {
 	case eventCallCh <- call:
 	default:
-		rq.cancel(fmt.Errorf("%w: %v: eventCallCh full sending Jid=%v What=%v Data=%q", ErrRequestOverloaded, rq, call.jid, call.wht, call.data))
+		targets := len(call.more)
+		if call.elem != nil {
+			targets++
+		}
+		rq.cancel(fmt.Errorf("%w: %v: eventCallCh full sending Targets=%d What=%v Data=%q", ErrRequestOverloaded, rq, targets, call.wht, call.data))
 	}
 }
 


### PR DESCRIPTION
## Summary

- resolve each incoming event's live, frozen Element targets before placing it on the event FIFO
- retain accepted targets across every later unregister path, while events accepted after removal remain ignored
- keep removal cleanup synchronous instead of making registry cleanup wait for application handlers
- skip targetless calls and deduplicate bubbled routes in first-occurrence order
- preserve useful overload diagnostics without storing the original Jid in every queued call
- document that an accepted handler may receive an Element that has since been deleted

## Design

Target resolution and removal serialize on `Request.mu`. Whichever happens first determines eligibility: a live target retained at acceptance remains eligible for that event, while an Element removed first is excluded. This rule applies to inbound `Remove`, `Request.DeleteElement`/`DeleteElements`, `Element.Remove`, and container pruning.

Snapshotting the target Elements is the smallest change that preserves event order without delaying cleanup. Frozen Elements have stable UI and handler references, Request identities are never reused, and the bounded event FIFO bounds pointer retention. Serializing removal behind handlers would leave DOM-gone Elements registered while arbitrary application code runs, permitting stale updates and handlers that wait for cleanup to deadlock.

The common direct target is stored inline. Bubbled routes keep their first target inline and additional targets in a slice. Duplicate live targets are suppressed. Routes through 32 distinct targets use the retained list for deduplication; deeper client-controlled routes switch to a map to keep lookup bounded. Targetless resolved calls do not consume FIFO capacity or trigger overload cancellation.

## Testing

The ordering regression blocks the event goroutine, then exercises both event-before-removal and removal-before-event for:

- `Input`
- `Set`
- bubbled `Click`
- bubbled `ContextMenu`

It verifies handler count, bound value, immediate registry cleanup, and final absence of the target. Additional regressions cover:

- an accepted input surviving public `Request.DeleteElement`
- first-occurrence route order and deduplication for `Click` and `ContextMenu` across the inline, linear-slice, seeded-map, and post-switch map paths (2, 33, and 34 unique targets)
- unknown and deleted targets leaving a full FIFO untouched without cancelling the Request
- valid-target overload diagnostics reporting both the first target and target count

## Benchmarks

The committed benchmark source was applied unchanged to main `68cf99f` and final commit `0e5a831`. Results are from six one-second runs on one Apple M5 Max CPU.

```text
go test -run '^$' -bench '^BenchmarkRequest(EventCallChannelAllocation|IncomingEventQueue|IncomingEventDispatch|EventDispatch)$' -benchmem -benchtime=1s -count=6 -cpu=1 .
benchstat main.txt final.txt
```

### Complete FIFO path

Each iteration runs from `handleIncoming` through the real FIFO and `eventCaller`, and waits for the handler to finish.

| Case | Main | Final | Change | Bytes/op | Allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| direct `Input` | 173.1 ns | 163.8 ns | -5.35% | 8 -> 0 | 1 -> 0 |
| direct `Set` | 172.7 ns | 166.3 ns | -3.71% | 8 -> 0 | 1 -> 0 |
| bubbled `Click`, 8 targets | 1.073 us | 1.109 us | +3.36% | 64 -> 64 | 1 -> 1 |
| bubbled `ContextMenu`, 8 targets | 1.082 us | 1.113 us | +2.82% | 64 -> 64 | 1 -> 1 |
| 4,000 repeated route entries | 485.9 us | 107.8 us | -77.81% | 105,536 -> 8 | 12 -> 1 |

The repeated-route frame is encoded with `wire.WsMsg.Append` during setup and asserted to remain within the server's 32 KiB WebSocket limit. It contains 4,000 copies of one live Jid followed by a completion target; main invokes every duplicate, while final invokes each target once.

A separate six-run comparison with the discarded route-prefix clone found no measurable timing change. Removing it reduced the repeated complete path from 24 B/2 allocations to 8 B/1 allocation, and producer acceptance from 16 B/1 allocation to 0 B/0 allocations.

Producer-only timings increase because resolution moves from `eventCaller` to the process goroutine. Final producer allocations remain 0 for direct, one-target, and repeated-target events; 8 targets use 64 B/1 allocation, 16 use 192 B/2 allocations, and 32-33 use 448 B/3 allocations. The map-backed 34-target case uses 2,200 B/8 allocations. In the complete synchronous resolution-and-handler benchmark, that deep-route boundary is 17.00% slower than main; the bounded cost prevents client-controlled deduplication from becoming quadratic.

### Fixed per-request FIFO allocation

On 64-bit systems, `eventFnCall` grows from 32 bytes on main to 56 bytes in the final implementation. The committed benchmark measures the fixed allocation for an empty channel at production capacities; dynamic target slices and transient deduplication storage are covered by the event benchmarks above.

| Event FIFO | Main | Final | Change |
| --- | ---: | ---: | ---: |
| 4 entries (0 Elements) | 240 B | 336 B | +40.00% (+96 B) |
| 4,004 entries (1,000 Elements) | 128.1 KiB | 224.1 KiB | +74.94% (+96.0 KiB) |

The KiB values are measured `B/op` divided by 1,024 and include channel metadata plus allocator size-class rounding. The raw 4,004-entry payload grows by 96,096 bytes (93.84 KiB), from 128,128 to 224,224 bytes; measured allocation grows by exactly 96.0 KiB.

This per-connected-Request increase is accepted because retaining resolved Element pointers is what preserves accepted-event ordering. Keeping the direct target inline avoids a per-event allocation, and removing the unused Jid recovers 32.0 KiB at 4,004 entries relative to the initial 64-byte snapshot representation. The FIFO remains bounded.

## Verification

- `go generate ./...`
- `gofmt -l .`
- `gofumpt -l .`
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`
- `go build ./...`
- `JAWS_REQUIRE_NODE=1 go test ./...`
- `JAWS_REQUIRE_NODE=1 go test -race -coverprofile=... ./...` (99.8% root-package coverage)
- `GOOS=linux GOARCH=386 CGO_ENABLED=0 go test -exec=true ./lib/bind/... ./lib/ui/...`

Fixes #288
