### PR TITLE
assets: bound stalled reconnect pings

### DIFF
--- a/lib/assets/jaws.js
+++ b/lib/assets/jaws.js
@@ -15,6 +15,7 @@ var jawsIdPrefix = 'Jid.';
 var jawsDebug = false;
 const jawsJidRx = /^[1-9]\d*$/;
 const jawsMaxJid = '9223372036854775807';
+// Milliseconds; bounds reconnect probes that never receive a network result.
 const jawsReconnectTimeout = 10 * 1000;
 
 function jawsIsJid(v) {

--- a/lib/assets/jaws.js
+++ b/lib/assets/jaws.js
@@ -15,6 +15,7 @@ var jawsIdPrefix = 'Jid.';
 var jawsDebug = false;
 const jawsJidRx = /^[1-9]\d*$/;
 const jawsMaxJid = '9223372036854775807';
+const jawsReconnectTimeout = 10 * 1000;
 
 function jawsIsJid(v) {
 	if (typeof v === 'string' && v.startsWith(jawsIdPrefix)) {
@@ -359,19 +360,18 @@ function jawsLost() {
 }
 
 function jawsHandleReconnect(e) {
-	if (e.currentTarget.readyState === 4) {
-		if (e.currentTarget.status === 204) {
-			window.location.reload();
-		} else {
-			jawsLost();
-		}
+	if (e.currentTarget.status === 204) {
+		window.location.reload();
+	} else {
+		jawsLost();
 	}
 }
 
 function jawsReconnect() {
 	const req = new XMLHttpRequest();
 	req.open("GET", window.location.protocol + "//" + window.location.host + "/jaws/.ping", true);
-	req.addEventListener('readystatechange', jawsHandleReconnect);
+	req.timeout = jawsReconnectTimeout;
+	req.addEventListener('loadend', jawsHandleReconnect, { once: true });
 	req.send(null);
 }
 

--- a/lib/assets/js_test.go
+++ b/lib/assets/js_test.go
@@ -1843,7 +1843,7 @@ process.stdout.write(JSON.stringify({
 	}
 }
 
-func TestJawsJS_FailedSocketPingsAndReloadsOnReconnect(t *testing.T) {
+func TestJawsJS_ReconnectXHRResultsAreHandledOnce(t *testing.T) {
 	raw := runJawsJSSnippet(t, `
 function FakeSocket() {}
 WebSocket = FakeSocket;
@@ -1851,45 +1851,130 @@ jaws = new FakeSocket();
 
 let reloaded = 0;
 window.location.reload = function() { reloaded++; };
+let lost = 0;
+let lostElem = null;
+document.querySelector = function(selector) {
+	return selector === "[data-jaws-lost]" ? lostElem : null;
+};
+document.body = {
+	scrollTop: 10,
+	prepend: function(elem) { lostElem = elem; }
+};
+document.documentElement = { scrollTop: 10 };
+jawsElement = function(html) { return { innerHTML: html }; };
+const originalJawsLost = jawsLost;
+jawsLost = function() {
+	lost++;
+	originalJawsLost();
+};
 
+let timers = 0;
+setTimeout = function() { timers++; };
+const requests = [];
+let sends = 0;
 function FakeXHR() {
 	this.readyState = 0;
 	this.status = 0;
-	this.cb = null;
+	this.timeout = 0;
+	this.timeoutAtSend = 0;
+	this.listeners = {};
+	requests.push(this);
 }
 FakeXHR.prototype.open = function(method, url, async) {
 	this.method = method;
 	this.url = url;
 	this.async = async;
 };
-FakeXHR.prototype.addEventListener = function(name, cb) {
-	if (name === "readystatechange") {
-		this.cb = cb;
-	}
+FakeXHR.prototype.addEventListener = function(name, cb, options) {
+	this.listeners[name] = { cb: cb, once: Boolean(options && options.once) };
 };
 FakeXHR.prototype.send = function() {
+	sends++;
+	this.timeoutAtSend = this.timeout;
+	// Stay pending until the test simulates a browser terminal event.
+};
+FakeXHR.prototype.dispatch = function(name) {
+	const listener = this.listeners[name];
+	if (!listener) return;
+	if (listener.once) delete this.listeners[name];
+	listener.cb({ type: name, currentTarget: this });
+};
+FakeXHR.prototype.finish = function(name, status) {
 	this.readyState = 4;
-	this.status = 204;
-	this.cb({ currentTarget: this });
+	this.status = status;
+	this.dispatch("readystatechange");
+	this.dispatch(name);
+	this.dispatch("loadend");
 };
 XMLHttpRequest = FakeXHR;
 
 jawsFailed();
+for (let i = 1; i < 5; i++) jawsReconnect();
+const pending = { timers: timers, lost: lost, reloaded: reloaded };
+
+requests[0].finish("timeout", 0);
+requests[1].finish("error", 0);
+requests[2].finish("abort", 0);
+requests[3].finish("load", 503);
+requests[4].finish("load", 204);
+const firstPass = { timers: timers, lost: lost, reloaded: reloaded };
+
+// One-shot completion prevents stale terminal events from changing the result.
+requests.forEach(function(req) { req.finish("timeout", 0); });
+
 process.stdout.write(JSON.stringify({
 	jawsIsDate: jaws instanceof Date,
-	reloaded: reloaded
+	requests: requests.length,
+	sends: sends,
+	pending: pending,
+	timeouts: requests.map(function(req) { return req.timeoutAtSend; }),
+	firstPass: firstPass,
+	final: { timers: timers, lost: lost, reloaded: reloaded },
+	lostHTML: lostElem && lostElem.innerHTML
 }));
 `)
 
+	type counts struct {
+		Timers   int `json:"timers"`
+		Lost     int `json:"lost"`
+		Reloaded int `json:"reloaded"`
+	}
 	var got struct {
-		JawsIsDate bool `json:"jawsIsDate"`
-		Reloaded   int  `json:"reloaded"`
+		JawsIsDate bool      `json:"jawsIsDate"`
+		Requests   int       `json:"requests"`
+		Sends      int       `json:"sends"`
+		Pending    counts    `json:"pending"`
+		Timeouts   []float64 `json:"timeouts"`
+		FirstPass  counts    `json:"firstPass"`
+		Final      counts    `json:"final"`
+		LostHTML   string    `json:"lostHTML"`
 	}
 	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &got); err != nil {
 		t.Fatalf("failed to parse snippet output %q: %v", raw, err)
 	}
-	if !got.JawsIsDate || got.Reloaded != 1 {
-		t.Fatalf("unexpected reconnect behavior: %+v", got)
+	if !got.JawsIsDate {
+		t.Fatal("failed socket did not enter reconnect state")
+	}
+	if got.Requests != 5 || got.Sends != 5 {
+		t.Fatalf("reconnect attempts = %d requests, %d sends; want 5 each", got.Requests, got.Sends)
+	}
+	if got.Pending != (counts{}) {
+		t.Fatalf("pending reconnect changed state: %+v", got.Pending)
+	}
+	if len(got.Timeouts) != 5 {
+		t.Fatalf("reconnect timeouts = %v, want five attempts", got.Timeouts)
+	}
+	for i, timeout := range got.Timeouts {
+		if timeout <= 0 || timeout != got.Timeouts[0] {
+			t.Fatalf("reconnect timeout[%d] = %v, want the same positive timeout", i, timeout)
+		}
+	}
+	want := counts{Timers: 4, Lost: 4, Reloaded: 1}
+	if got.FirstPass != want || got.Final != want {
+		t.Fatalf("reconnect results = first %+v, final %+v; want %+v", got.FirstPass, got.Final, want)
+	}
+	if !strings.Contains(got.LostHTML, "Server connection lost") {
+		t.Fatalf("lost indicator = %q", got.LostHTML)
 	}
 }
 

--- a/lib/assets/js_test.go
+++ b/lib/assets/js_test.go
@@ -1791,35 +1791,41 @@ process.stdout.write(JSON.stringify({ selectors: selectors, appended: appended }
 	}
 }
 
-func TestJawsJS_LostUsesDataAttributeHook(t *testing.T) {
-	raw := runJawsJSSnippet(t, `
-const selectors = [];
-let existing = null;
-let created = "";
-let prepended = 0;
+const lostIndicatorStubs = `
+const lostIndicatorSelectors = [];
+let lostIndicatorElem = null;
+let lostIndicatorCreated = "";
+let lostIndicatorPrepended = 0;
 document.querySelector = function(selector) {
-	selectors.push(selector);
-	return selector === "[data-jaws-lost]" ? existing : null;
+	lostIndicatorSelectors.push(selector);
+	return selector === "[data-jaws-lost]" ? lostIndicatorElem : null;
 };
 document.body = {
 	scrollTop: 10,
-	prepend: function() { prepended++; }
+	prepend: function(elem) {
+		lostIndicatorPrepended++;
+		lostIndicatorElem = elem;
+	}
 };
 document.documentElement = { scrollTop: 10 };
 jawsElement = function(html) {
-	created = html;
-	return {};
+	lostIndicatorCreated = html;
+	return { innerHTML: html };
 };
+`
+
+func TestJawsJS_LostUsesDataAttributeHook(t *testing.T) {
+	raw := runJawsJSSnippet(t, lostIndicatorStubs+`
 setTimeout = function() {};
 
 jawsLost();
-existing = { innerHTML: "old" };
+lostIndicatorElem = { innerHTML: "old" };
 jawsLost();
 process.stdout.write(JSON.stringify({
-	selectors: selectors,
-	created: created,
-	prepended: prepended,
-	existingHTML: existing.innerHTML
+	selectors: lostIndicatorSelectors,
+	created: lostIndicatorCreated,
+	prepended: lostIndicatorPrepended,
+	existingHTML: lostIndicatorElem.innerHTML
 }));
 `)
 
@@ -1844,7 +1850,7 @@ process.stdout.write(JSON.stringify({
 }
 
 func TestJawsJS_ReconnectXHRResultsAreHandledOnce(t *testing.T) {
-	raw := runJawsJSSnippet(t, `
+	raw := runJawsJSSnippet(t, lostIndicatorStubs+`
 function FakeSocket() {}
 WebSocket = FakeSocket;
 jaws = new FakeSocket();
@@ -1852,16 +1858,6 @@ jaws = new FakeSocket();
 let reloaded = 0;
 window.location.reload = function() { reloaded++; };
 let lost = 0;
-let lostElem = null;
-document.querySelector = function(selector) {
-	return selector === "[data-jaws-lost]" ? lostElem : null;
-};
-document.body = {
-	scrollTop: 10,
-	prepend: function(elem) { lostElem = elem; }
-};
-document.documentElement = { scrollTop: 10 };
-jawsElement = function(html) { return { innerHTML: html }; };
 const originalJawsLost = jawsLost;
 jawsLost = function() {
 	lost++;
@@ -1869,7 +1865,11 @@ jawsLost = function() {
 };
 
 let timers = 0;
-setTimeout = function() { timers++; };
+const scheduled = [];
+setTimeout = function(fn, ms) {
+	timers++;
+	scheduled.push({ fn: fn, ms: ms });
+};
 const requests = [];
 let sends = 0;
 function FakeXHR() {
@@ -1913,24 +1913,36 @@ for (let i = 1; i < 5; i++) jawsReconnect();
 const pending = { timers: timers, lost: lost, reloaded: reloaded };
 
 requests[0].finish("timeout", 0);
+const results = [{ timers: timers, lost: lost, reloaded: reloaded }];
 requests[1].finish("error", 0);
+results.push({ timers: timers, lost: lost, reloaded: reloaded });
 requests[2].finish("abort", 0);
+results.push({ timers: timers, lost: lost, reloaded: reloaded });
 requests[3].finish("load", 503);
+results.push({ timers: timers, lost: lost, reloaded: reloaded });
 requests[4].finish("load", 204);
-const firstPass = { timers: timers, lost: lost, reloaded: reloaded };
+results.push({ timers: timers, lost: lost, reloaded: reloaded });
 
 // One-shot completion prevents stale terminal events from changing the result.
-requests.forEach(function(req) { req.finish("timeout", 0); });
+requests.slice(0, 5).forEach(function(req) { req.finish("timeout", 0); });
+
+scheduled[0].fn();
 
 process.stdout.write(JSON.stringify({
 	jawsIsDate: jaws instanceof Date,
-	requests: requests.length,
 	sends: sends,
 	pending: pending,
-	timeouts: requests.map(function(req) { return req.timeoutAtSend; }),
-	firstPass: firstPass,
+	attempts: requests.map(function(req) {
+		return {
+			method: req.method,
+			url: req.url,
+			async: req.async,
+			timeoutAtSend: req.timeoutAtSend
+		};
+	}),
+	results: results,
 	final: { timers: timers, lost: lost, reloaded: reloaded },
-	lostHTML: lostElem && lostElem.innerHTML
+	lostHTML: lostIndicatorElem && lostIndicatorElem.innerHTML
 }));
 `)
 
@@ -1939,13 +1951,18 @@ process.stdout.write(JSON.stringify({
 		Lost     int `json:"lost"`
 		Reloaded int `json:"reloaded"`
 	}
+	type attempt struct {
+		Method        string  `json:"method"`
+		URL           string  `json:"url"`
+		Async         bool    `json:"async"`
+		TimeoutAtSend float64 `json:"timeoutAtSend"`
+	}
 	var got struct {
 		JawsIsDate bool      `json:"jawsIsDate"`
-		Requests   int       `json:"requests"`
 		Sends      int       `json:"sends"`
 		Pending    counts    `json:"pending"`
-		Timeouts   []float64 `json:"timeouts"`
-		FirstPass  counts    `json:"firstPass"`
+		Attempts   []attempt `json:"attempts"`
+		Results    []counts  `json:"results"`
 		Final      counts    `json:"final"`
 		LostHTML   string    `json:"lostHTML"`
 	}
@@ -1955,23 +1972,32 @@ process.stdout.write(JSON.stringify({
 	if !got.JawsIsDate {
 		t.Fatal("failed socket did not enter reconnect state")
 	}
-	if got.Requests != 5 || got.Sends != 5 {
-		t.Fatalf("reconnect attempts = %d requests, %d sends; want 5 each", got.Requests, got.Sends)
+	if len(got.Attempts) != 6 || got.Sends != 6 {
+		t.Fatalf("reconnect attempts = %d requests, %d sends; want 6 each", len(got.Attempts), got.Sends)
 	}
 	if got.Pending != (counts{}) {
 		t.Fatalf("pending reconnect changed state: %+v", got.Pending)
 	}
-	if len(got.Timeouts) != 5 {
-		t.Fatalf("reconnect timeouts = %v, want five attempts", got.Timeouts)
-	}
-	for i, timeout := range got.Timeouts {
-		if timeout <= 0 || timeout != got.Timeouts[0] {
-			t.Fatalf("reconnect timeout[%d] = %v, want the same positive timeout", i, timeout)
+	for i, attempt := range got.Attempts {
+		if attempt.Method != "GET" || attempt.URL != "http://example.test/jaws/.ping" || !attempt.Async {
+			t.Fatalf("reconnect attempt[%d] = %+v, want async GET to /jaws/.ping", i, attempt)
+		}
+		if attempt.TimeoutAtSend != 10*1000 {
+			t.Fatalf("reconnect timeout[%d] = %v, want 10000", i, attempt.TimeoutAtSend)
 		}
 	}
-	want := counts{Timers: 4, Lost: 4, Reloaded: 1}
-	if got.FirstPass != want || got.Final != want {
-		t.Fatalf("reconnect results = first %+v, final %+v; want %+v", got.FirstPass, got.Final, want)
+	wants := []counts{
+		{Timers: 1, Lost: 1},
+		{Timers: 2, Lost: 2},
+		{Timers: 3, Lost: 3},
+		{Timers: 4, Lost: 4},
+		{Timers: 4, Lost: 4, Reloaded: 1},
+	}
+	if !reflect.DeepEqual(got.Results, wants) {
+		t.Fatalf("reconnect results = %+v, want %+v", got.Results, wants)
+	}
+	if want := wants[len(wants)-1]; got.Final != want {
+		t.Fatalf("reconnect final result = %+v, want %+v", got.Final, want)
 	}
 	if !strings.Contains(got.LostHTML, "Server connection lost") {
 		t.Fatalf("lost indicator = %q", got.LostHTML)


### PR DESCRIPTION
## Summary

- cap each reconnect `/jaws/.ping` request at 10 seconds
- handle HTTP completion, timeout, network error, and abort through one one-shot `loadend` path
- preserve 204 reloads and the existing elapsed-outage retry backoff
- add a deterministic pending-XHR regression covering every terminal result and stale duplicate notifications

## Design

`XMLHttpRequest` emits `loadend` after its mutually exclusive `load`, `timeout`, `error`, or `abort` result. A single `{ once: true }` listener therefore gives each probe one outcome without extra timers or shared completion state. Status 204 reloads the page; every other status enters `jawsLost`, updates the lost indicator, and schedules the existing retry.

The native XHR timeout terminates a blackholed probe. The next attempt remains serialized behind the existing retry timer, so the change does not introduce overlapping reconnect requests or alter the backoff policy.

## Testing

The Node-backed regression leaves `send()` pending and verifies that each request is an asynchronous same-origin `GET` with its 10-second timeout set before sending. It covers timeout, network error, abort, non-204 completion, 204 completion, and stale duplicate notifications independently. It also executes the scheduled retry and verifies that it creates a sixth request with the same bounded shape.

- `go generate ./...`
- `gofmt -l .`
- `gofumpt -l .`
- `node --check lib/assets/jaws.js`
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`
- `go build ./...`
- `JAWS_REQUIRE_NODE=1 go test ./...`
- `JAWS_REQUIRE_NODE=1 go test -race -coverprofile=... ./...`
- `GOOS=linux GOARCH=386 CGO_ENABLED=0 go test -exec=true ./lib/bind/... ./lib/ui/...`

Fixes #272
