### PR TITLE
named: release Bools omitted by WriteLocked

### DIFF
--- a/lib/named/namedboolarray.go
+++ b/lib/named/namedboolarray.go
@@ -50,12 +50,12 @@ func (nba *BoolArray) ReadLocked(fn func(nbl []*Bool)) {
 }
 
 // WriteLocked calls fn with the [BoolArray] locked for writing and replaces
-// the internal []*Bool slice with the return value.
+// the array contents with the returned values.
 //
-// The returned slice and its backing array become internal storage after fn
-// returns and must not be retained or accessed outside [BoolArray.ReadLocked]
-// and [BoolArray.WriteLocked] callbacks. Nil entries are discarded without
-// changing the relative order of non-nil entries.
+// Ownership of the returned slice and its backing array transfers to the
+// BoolArray when fn returns; callers must not retain or access that storage
+// afterward. Nil entries are discarded without changing the relative order of
+// non-nil entries.
 //
 // Omitting a [Bool] from the returned slice does not detach it from nba:
 // [Bool.Array] continues to return nba, and [Bool.JawsSet] continues to apply
@@ -72,9 +72,14 @@ func (nba *BoolArray) ReadLocked(fn func(nbl []*Bool)) {
 func (nba *BoolArray) WriteLocked(fn func(nbl []*Bool) []*Bool) {
 	nba.mu.Lock()
 	defer nba.mu.Unlock()
-	nba.data = slices.DeleteFunc(fn(nba.data), func(nb *Bool) bool {
+	old := nba.data
+	data := slices.DeleteFunc(fn(old), func(nb *Bool) bool {
 		return nb == nil
 	})
+	// data may share old's backing array, so detach it before clearing old.
+	data = slices.Clone(data)
+	clear(old[:cap(old)])
+	nba.data = data
 }
 
 // JawsContains returns the option widgets for a select backed by nba.

--- a/lib/named/namedboolarray_storage_test.go
+++ b/lib/named/namedboolarray_storage_test.go
@@ -1,0 +1,66 @@
+package named
+
+import (
+	"html/template"
+	"slices"
+	"testing"
+)
+
+func TestBoolArrayWriteLockedReleasesReplacedStorage(t *testing.T) {
+	tests := []struct {
+		name         string
+		selectValues func([]*Bool) []*Bool
+		want         []int
+	}{
+		{
+			name: "shorter prefix",
+			selectValues: func(values []*Bool) []*Bool {
+				return values[:1]
+			},
+			want: []int{0},
+		},
+		{
+			name: "overlapping middle",
+			selectValues: func(values []*Bool) []*Bool {
+				return values[1:4]
+			},
+			want: []int{1, 2, 3},
+		},
+		{
+			name: "nil filtering",
+			selectValues: func(values []*Bool) []*Bool {
+				return []*Bool{nil, values[3], nil, values[1], nil}
+			},
+			want: []int{3, 1},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			nba := NewBoolArray(false)
+			for _, name := range []string{"a", "b", "c", "d", "e"} {
+				nba.Add(name, template.HTML(name))
+			}
+			oldStorage := nba.data[:cap(nba.data)]
+			want := make([]*Bool, len(tc.want))
+			for i, wantIndex := range tc.want {
+				want[i] = nba.data[wantIndex]
+			}
+
+			nba.WriteLocked(tc.selectValues)
+
+			if !slices.Equal(nba.data, want) {
+				t.Fatalf("data = %v, want %v", nba.data, want)
+			}
+			nonNil := func(value *Bool) bool { return value != nil }
+			if i := slices.IndexFunc(oldStorage, nonNil); i >= 0 {
+				t.Fatalf("old storage[%d] retains Bool %q", i, oldStorage[i].Name())
+			}
+			ownedStorage := nba.data[:cap(nba.data)]
+			if i := slices.IndexFunc(ownedStorage[len(nba.data):], nonNil); i >= 0 {
+				i += len(nba.data)
+				t.Fatalf("owned storage[%d] retains Bool %q past len %d", i, ownedStorage[i].Name(), len(nba.data))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- detach `BoolArray.WriteLocked` results with `slices.Clone` before replacing storage
- clear the prior backing array through its full capacity so omitted `Bool` references are released
- document the callback-result ownership boundary without promising storage identity

## Design

`slices.DeleteFunc` can clear nil entries only within the callback result's length. If the callback returns a shorter prefix or middle subslice, pointers outside that view remain in the backing allocation and are still scanned by the garbage collector.

The fix filters the callback result, shallow-clones it, clears the complete old backing array, and then installs the clone. Cloning must precede clearing because a supported callback result may overlap the old storage. This uses the standard `slices` package for both filtering and detachment.

`WriteLocked` is a structural mutation API. The deliberate cost is one shallow slice allocation and copy for each non-empty result; the regression tests the live-reference invariant directly rather than making a throughput claim.

## Testing

The new package-internal regression covers:

- a shortened prefix
- an overlapping middle subslice
- nil filtering and relative order
- complete clearing of old full-capacity storage
- zeroed unused capacity in the replacement storage

Verification:

- `go test -race -run '^TestBoolArrayWriteLockedReleasesReplacedStorage$' -count=100 ./lib/named`
- `go test -race -coverprofile=coverage.out ./...`
- `go test ./...`
- `go generate ./...`
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`
- `go build ./...`

Fixes #278
