### PR TITLE
wire: deliver batched WebSocket records

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,12 +335,12 @@ rules. `JsVar` deliberately does not choose one of those policies.
 
 ### WebSocket wire format notes
 
-JaWS WebSocket messages are line-based and field-delimited:
-`What<TAB>Jid<TAB>Data<LF>`. Keep these invariants in mind when changing
-client/server protocol code:
+JaWS WebSocket protocol records are line-based and field-delimited:
+`What<TAB>Jid<TAB>Data<LF>`. A text message may carry multiple records. Keep
+these invariants in mind when changing client/server protocol code:
 
-* The browser is not trusted. Incoming frames are validated (`What`, `Jid`,
-  framing, quoting) and invalid frames are ignored/dropped.
+* The browser is not trusted. Incoming records are validated (`What`, `Jid`,
+  delimiters, quoting), and malformed records are skipped independently.
 * Each inbound WebSocket message is limited to 32 KiB. The bundled client does
   not chunk `Input`, `Set`, `Click`, `ContextMenu`, or `Remove`; an oversized
   message closes the connection. The limit covers the complete protocol payload

--- a/lib/wire/doc.go
+++ b/lib/wire/doc.go
@@ -2,16 +2,16 @@
 //
 // The package has two message types. [Message] is the in-process dispatch
 // record: a command plus payload routed to a destination ([Message.Dest]).
-// [WsMsg] is the serialized frame produced by [WsMsg.Append] and recovered by
-// [Parse] — the bytes that actually travel over the WebSocket.
+// [WsMsg] represents a protocol record; [WsMsg.Append] serializes it, and
+// [Parse] recovers it. A WebSocket text message may carry multiple records.
 //
-// Each frame is encoded as What<TAB>Jid<TAB>Data<LF>. Data for most commands is
+// Each record is encoded as What<TAB>Jid<TAB>Data<LF>. Data for most commands is
 // written by [WsMsg.Append] as a JSON-compatible quoted string so the browser can
 // decode it with JSON.parse. [Parse] decodes quoted inbound data with
 // strconv.Unquote for the common case, falls back to JSON string decoding for
 // browser-valid strings that strconv rejects, and sanitizes the result as valid
 // UTF-8. [AppendJSONQuote] stays inside the overlap between those string grammars
-// so server-generated frames round-trip through either decoder.
+// so server-generated records round-trip through either decoder.
 //
 // The Set and Call commands carry path/function payloads directly, so callers
 // must keep those payloads free of raw tabs and newlines. The path/function side

--- a/lib/wire/wsio.go
+++ b/lib/wire/wsio.go
@@ -1,6 +1,7 @@
 package wire
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -10,11 +11,14 @@ import (
 )
 
 // writeBatchLimit is the maximum number of bytes WriteLoop coalesces into a
-// single outbound WebSocket text frame before flushing.
+// single outbound WebSocket text message before flushing.
 const writeBatchLimit = 32 * 1024
 
-// ReadLoop reads WebSocket text messages, parses them, and sends parsed
-// messages on incomingMsgCh.
+// ReadLoop reads WebSocket text messages and sends each valid protocol record
+// on incomingMsgCh.
+//
+// Records are LF-terminated and delivered in order. A text message may contain
+// multiple records; malformed records are skipped independently.
 //
 // Closes incomingMsgCh on exit.
 //
@@ -33,13 +37,15 @@ func ReadLoop(ctx context.Context, ccf context.CancelCauseFunc, doneCh <-chan st
 		// Only parse on a successful read; on error ws.Read returns no usable
 		// payload and the loop exits because the for condition fails.
 		if typ, txt, err = ws.Read(ctx); err == nil && typ == websocket.MessageText {
-			if msg, ok := Parse(txt); ok {
-				select {
-				case <-ctx.Done():
-					return
-				case <-doneCh:
-					return
-				case incomingMsgCh <- msg:
+			for record := range bytes.Lines(txt) {
+				if msg, ok := Parse(record); ok {
+					select {
+					case <-ctx.Done():
+						return
+					case <-doneCh:
+						return
+					case incomingMsgCh <- msg:
+					}
 				}
 			}
 		}
@@ -47,8 +53,10 @@ func ReadLoop(ctx context.Context, ccf context.CancelCauseFunc, doneCh <-chan st
 	reportError(ctx, doneCh, ccf, err)
 }
 
-// WriteLoop reads messages from outboundMsgCh, formats them, and writes them
-// to the WebSocket.
+// WriteLoop formats messages read from outboundMsgCh and writes them to the
+// WebSocket.
+//
+// Consecutive queued records may be coalesced into one text message.
 //
 // Closes the WebSocket on exit.
 //

--- a/lib/wire/wsio_test.go
+++ b/lib/wire/wsio_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 	"testing/synctest"
@@ -103,6 +104,164 @@ func TestReadLoop_RespectsDoneWhileReading(t *testing.T) {
 			t.Fatalf("parent context was canceled: %v", err)
 		}
 	})
+}
+
+func TestReadWriteLoop_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		want []WsMsg
+	}{
+		{
+			name: "single record",
+			want: []WsMsg{{Jid: 1, What: what.Input, Data: "value"}},
+		},
+		{
+			name: "batched records",
+			want: []WsMsg{
+				{Jid: 1, What: what.Input, Data: "line one\nline two"},
+				{Jid: 2, What: what.Set, Data: `state={"value":1}`},
+				{Jid: 3, What: what.Call, Data: `notify=["done"]`},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outCh := make(chan WsMsg, len(tt.want))
+			for _, msg := range tt.want {
+				outCh <- msg
+			}
+			close(outCh)
+
+			inCh := make(chan WsMsg, len(tt.want))
+			doneCh := make(chan struct{})
+			client, server := pipe(t)
+			defer func() { _ = client.CloseNow() }()
+			defer func() { _ = server.CloseNow() }()
+
+			ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+			defer cancel()
+
+			readDoneCh := make(chan struct{})
+			go func() {
+				defer close(readDoneCh)
+				ReadLoop(ctx, nil, doneCh, inCh, server)
+			}()
+			writeDoneCh := make(chan struct{})
+			go func() {
+				defer close(writeDoneCh)
+				WriteLoop(ctx, nil, doneCh, outCh, client)
+			}()
+
+			var got []WsMsg
+			for msg := range inCh {
+				got = append(got, msg)
+			}
+			waitDone(t, readDoneCh, "ReadLoop after peer close")
+			waitDone(t, writeDoneCh, "WriteLoop after outbound close")
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("round trip = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadLoop_SkipsMalformedRecords(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		want := []WsMsg{
+			{Jid: 1, What: what.Input, Data: "first"},
+			{Jid: 2, What: what.Set, Data: "state=second"},
+		}
+		payload := want[0].Append(nil)
+		payload = append(payload, "malformed\n\n"...)
+		payload = want[1].Append(payload)
+		payload = append(payload, "Input\tJid.3\t\"unterminated\""...)
+
+		ctx, cancel := context.WithCancelCause(t.Context())
+		doneCh := make(chan struct{})
+		inCh := make(chan WsMsg, len(want))
+		client, server := pipe(t)
+		loopDone := make(chan struct{})
+		defer closeWireBubble(cancel, client, server)()
+
+		go func() {
+			ReadLoop(ctx, cancel, doneCh, inCh, server)
+			close(loopDone)
+		}()
+		if err := client.Write(ctx, websocket.MessageText, payload); err != nil {
+			t.Fatal(err)
+		}
+		synctest.Wait()
+		if got := len(inCh); got != len(want) {
+			t.Fatalf("queued messages = %d, want %d", got, len(want))
+		}
+
+		close(doneCh)
+		synctest.Wait()
+		assertClosedNow(t, loopDone, "ReadLoop")
+		var got []WsMsg
+		for msg := range inCh {
+			got = append(got, msg)
+		}
+		if !slices.Equal(got, want) {
+			t.Fatalf("messages = %+v, want %+v", got, want)
+		}
+		if err := ctx.Err(); err != nil {
+			t.Fatalf("parent context was canceled: %v", err)
+		}
+	})
+}
+
+func TestReadLoop_BatchedDeliveryIsInterruptible(t *testing.T) {
+	for _, stop := range []string{"context", "done"} {
+		t.Run(stop, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				const count = 128
+				msg := WsMsg{Jid: 1, What: what.Input, Data: "value"}
+				payload := make([]byte, 0, count*len(msg.Format()))
+				for range count {
+					payload = msg.Append(payload)
+				}
+
+				ctx, cancel := context.WithCancelCause(t.Context())
+				doneCh := make(chan struct{})
+				inCh := make(chan WsMsg, 1)
+				client, server := pipe(t)
+				loopDone := make(chan struct{})
+				defer closeWireBubble(cancel, client, server)()
+
+				go func() {
+					ReadLoop(ctx, cancel, doneCh, inCh, server)
+					close(loopDone)
+				}()
+				if err := client.Write(ctx, websocket.MessageText, payload); err != nil {
+					t.Fatal(err)
+				}
+				// The first record is buffered and ReadLoop is blocked delivering the
+				// second record from the same WebSocket message.
+				synctest.Wait()
+				if stop == "context" {
+					cancel(nil)
+				} else {
+					close(doneCh)
+				}
+				synctest.Wait()
+				assertClosedNow(t, loopDone, "ReadLoop")
+
+				var got []WsMsg
+				for msg := range inCh {
+					got = append(got, msg)
+				}
+				if want := []WsMsg{msg}; !slices.Equal(got, want) {
+					t.Fatalf("messages = %+v, want %+v", got, want)
+				}
+				if stop == "done" {
+					if err := ctx.Err(); err != nil {
+						t.Fatalf("parent context was canceled: %v", err)
+					}
+				}
+			})
+		})
+	}
 }
 
 func TestWriteLoop_SendsThePayload(t *testing.T) {
@@ -283,10 +442,14 @@ func TestWriteLoop_SplitsAtBatchLimit(t *testing.T) {
 	if want := strings.Repeat(frame, count); string(total) != want {
 		t.Fatalf("reassembled %d bytes across %d frames, want %d bytes", len(total), len(frames), len(want))
 	}
-	// Every frame except the last coalesces up to the batch limit before flushing.
-	for i, f := range frames[:len(frames)-1] {
-		if len(f) < writeBatchLimit {
+	// Every frame is smaller than the soft limit plus one record, and every frame
+	// except the last coalesces up to the limit before flushing.
+	for i, f := range frames {
+		if i < len(frames)-1 && len(f) < writeBatchLimit {
 			t.Fatalf("frame %d is %d bytes, want >= writeBatchLimit (%d)", i, len(f), writeBatchLimit)
+		}
+		if len(f) >= writeBatchLimit+len(frame) {
+			t.Fatalf("frame %d is %d bytes, want < %d", i, len(f), writeBatchLimit+len(frame))
 		}
 	}
 }

--- a/lib/wire/wsmsg.go
+++ b/lib/wire/wsmsg.go
@@ -22,8 +22,9 @@ const hexDigits = "0123456789abcdef"
 // escapes; " and \ are escaped, and everything else
 // (including '<', '>', '&' and astral runes) is written as literal UTF-8 to keep
 // payloads compact. Invalid UTF-8 is replaced with U+FFFD so the result is always
-// valid JSON and a valid WebSocket text frame. The output remains decodable by
-// strconv.Unquote, so the server-side Append->Parse round trip is preserved.
+// valid JSON and valid UTF-8 for a WebSocket text message. The output remains
+// decodable by strconv.Unquote, so the server-side Append->Parse round trip is
+// preserved.
 func appendJSONQuote(b []byte, s string) []byte {
 	// PROVISIONAL: this hand-rolled quoter exists only because the stable standard
 	// library has no zero-allocation "append a non-HTML-escaped JSON string to a
@@ -58,16 +59,16 @@ func appendJSONQuote(b []byte, s string) []byte {
 	return append(b, '"')
 }
 
-// AppendJSONQuote appends s to b as a double-quoted JSON string literal that the
-// browser's JSON.parse accepts. Use it instead of strconv.AppendQuote when the
-// quoted data is written into a WebSocket frame: strconv emits Go-only escapes
-// (\xNN, \UXXXXXXXX) for control bytes, DEL and invalid UTF-8 that JSON.parse
-// rejects.
+// AppendJSONQuote appends s to b as a JSON string literal accepted by JSON.parse.
+//
+// Use it instead of [strconv.AppendQuote] when quoted data is written into a
+// protocol record: strconv emits Go-only escapes (\xNN, \UXXXXXXXX) for control
+// bytes, DEL, and invalid UTF-8 that JSON.parse rejects.
 func AppendJSONQuote(b []byte, s string) []byte {
 	return appendJSONQuote(b, s)
 }
 
-// WsMsg is a message sent to or from a WebSocket.
+// WsMsg is a protocol record sent to or from a WebSocket.
 type WsMsg struct {
 	Data string    // data to send
 	Jid  jid.Jid   // non-negative Jid to send
@@ -76,12 +77,12 @@ type WsMsg struct {
 
 // Append appends m in wire format to b and returns the extended buffer.
 //
-// The frame is What<TAB>Jid<TAB>Data<LF>, where the Jid field is empty if Jid
+// The record is What<TAB>Jid<TAB>Data<LF>, where the Jid field is empty if Jid
 // is zero. The Data field is written verbatim for [what.Set] and [what.Call] and
 // JSON-quoted for every other command. Append panics if Jid is negative.
 //
 // Verbatim Data must contain no tab or newline bytes, which would corrupt the
-// frame; ensuring that is the caller's responsibility.
+// record; ensuring that is the caller's responsibility.
 func (m *WsMsg) Append(b []byte) []byte {
 	if m.Jid < 0 {
 		panic("wire.WsMsg.Append: negative Jid")
@@ -109,7 +110,7 @@ func (m *WsMsg) Format() string {
 	return string(m.Append(nil))
 }
 
-// Parse parses an incoming text buffer into a message.
+// Parse parses one LF-terminated protocol record.
 //
 // The wire format mirrors [WsMsg.Append]. For commands other than [what.Set] and
 // [what.Call], if the Data field begins with a double quote it is decoded as a JSON
@@ -125,12 +126,12 @@ func (m *WsMsg) Format() string {
 // inside an inbound Set or Call payload truncates the field.
 func Parse(txt []byte) (WsMsg, bool) {
 	// Parse reports success with ok rather than an error: the only failure is "txt is
-	// not a valid frame", with no sub-cause any caller branches on, and the sole caller
-	// (ReadLoop) drops an unparseable frame without inspecting why — so a single
+	// not a valid record", with no sub-cause any caller branches on, and the sole caller
+	// (ReadLoop) drops an unparseable record without inspecting why — so a single
 	// always-equal error would carry nothing the bool does not.
 	//
 	// The len(txt) > 2 floor keeps the trailing-newline check and the two tab scans
-	// below from indexing out of range; a structurally minimal frame is What\t\t\n, and
+	// below from indexing out of range; a structurally minimal record is What\t\t\n, and
 	// any shorter or otherwise malformed input is rejected by the tab-field checks.
 	//
 	// Parse requires the two-tab What\tJid\tData form emitted by Append.
@@ -146,7 +147,7 @@ func Parse(txt []byte) (WsMsg, bool) {
 						if wht == what.Set || wht == what.Call {
 							// Set and Call data is taken verbatim and is best-effort:
 							// the field ends at the first tab, so drop any tab-separated
-							// suffix an untrusted frame appended past that boundary.
+							// suffix an untrusted record appended past that boundary.
 							if i := bytes.IndexByte(raw, '\t'); i >= 0 {
 								raw = raw[:i]
 							}

--- a/lib/wire/wsmsg_benchmark_test.go
+++ b/lib/wire/wsmsg_benchmark_test.go
@@ -11,7 +11,7 @@ var (
 	appendBenchSink []byte
 )
 
-// BenchmarkAppend guards the outbound frame-encoding hot path; it must stay
+// BenchmarkAppend guards the outbound record-encoding hot path; it must stay
 // allocation-light.
 func BenchmarkAppend(b *testing.B) {
 	m := WsMsg{
@@ -25,7 +25,7 @@ func BenchmarkAppend(b *testing.B) {
 	}
 }
 
-// BenchmarkParse guards the inbound parse hot path (run on every WebSocket frame)
+// BenchmarkParse guards the inbound parse hot path (run on every protocol record)
 // across the common command shapes, including the lone-surrogate case that decodes
 // via the JSON fallback rather than being dropped. The common quoted and unquoted
 // paths must stay allocation-light; only the rare surrogate case pays the


### PR DESCRIPTION
## Summary

- deliver every valid LF-terminated protocol record from a WebSocket text message, in order
- isolate malformed records so they do not discard later valid records in the same message
- preserve `WriteLoop` coalescing and its bounded batch behavior
- document the distinction between protocol records and WebSocket messages

## Design

`ReadLoop` still reads one complete WebSocket text message at a time. It uses the standard library's `bytes.Lines` iterator to parse and dispatch the records contained in that message. `WriteLoop` and `writeData` are unchanged, so browser-facing updates remain coalesced into a single WebSocket message rather than being split into smaller messages.

## Verification

- real `WriteLoop` to WebSocket to `ReadLoop` round trips for one record and a same-message batch
- quoted `Input` plus verbatim `Set` and `Call` records, with exact ordering
- malformed, blank, and unterminated record isolation
- context and `doneCh` interruption while blocked between records in one batch
- outbound batch lower and upper bounds
- `go test -race -coverprofile=... ./...` (`lib/wire`: 100%, repository: 99.8%)
- `go test ./...`
- `go build ./...`
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`
- Linux/386 CI compile/test leg

Fixes #279
