### PR TITLE
javascript: always execute Replace commands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,9 @@ jobs:
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
+        with:
+          # Partial cache invalidation can corrupt Staticcheck package facts.
+          skip-cache: true
 
       - name: Run Gosec Security Scanner
         uses: securego/gosec@4a3bd8af174872c778439083ded7adbf3747e770 # v2.26.1

--- a/broadcast.go
+++ b/broadcast.go
@@ -267,8 +267,11 @@ func (jw *Jaws) broadcastTo(target any, w what.What, data string) {
 	})
 }
 
-// SetInner sends a request to replace the inner HTML of
-// all HTML elements matching target.
+// SetInner replaces the inner HTML of all elements matching target.
+//
+// When the HTML exactly matches an element's current serialized inner HTML,
+// JaWS leaves its existing descendants and their live state unchanged. Use
+// [Element.Replace] when matching markup must still create new nodes.
 func (jw *Jaws) SetInner(target any, innerHTML template.HTML) {
 	jw.broadcastTo(target, what.Inner, string(innerHTML))
 }

--- a/element.go
+++ b/element.go
@@ -346,6 +346,9 @@ func (elem *Element) JsCall(jsfunc, jsonstr string) {
 
 // Replace replaces the [Element]'s entire HTML DOM node with new HTML code.
 //
+// A valid call always creates a new DOM node, even when htmlCode matches the
+// current serialized HTML.
+//
 // The trusted HTML should preserve the element identity by putting the element's
 // own JaWS id on the replacement root element, normally as id="Jid.N". Replace is
 // not an HTML validator: it performs only a lightweight textual guard for that

--- a/element.go
+++ b/element.go
@@ -314,7 +314,7 @@ func (elem *Element) RemoveClass(cls string) {
 // imminent. To change the [Element] in response to a browser event, mark it dirty
 // with [Request.Dirty] instead: a change queued directly from an event handler is
 // flushed only when the processing loop is next woken, which on an otherwise-idle
-// request is not guaranteed to be prompt (see [Element.queue]).
+// request is not guaranteed to be prompt.
 func (elem *Element) SetInner(innerHTML template.HTML) {
 	elem.queue(what.Inner, string(innerHTML))
 }
@@ -357,7 +357,7 @@ func (elem *Element) JsCall(jsfunc, jsonstr string) {
 //
 // A replacement node bearing an existing JaWS ID keeps that server-side
 // [Element] registration and UI state; omitted descendant IDs are unregistered.
-// Retained nodes are not rerendered separately, so their markup must match that
+// Retained Elements are not rerendered separately, so their markup must match that
 // state and each reused ID must identify the same logical Element.
 //
 // The trusted HTML should preserve the element identity by putting the element's
@@ -371,7 +371,7 @@ func (elem *Element) JsCall(jsfunc, jsonstr string) {
 // imminent. To change the [Element] in response to a browser event, mark it dirty
 // with [Request.Dirty] instead: a change queued directly from an event handler is
 // flushed only when the processing loop is next woken, which on an otherwise-idle
-// request is not guaranteed to be prompt (see [Element.queue]).
+// request is not guaranteed to be prompt.
 func (elem *Element) Replace(htmlCode template.HTML) {
 	if !elem.deleted.Load() {
 		var b []byte

--- a/element.go
+++ b/element.go
@@ -304,8 +304,11 @@ func (elem *Element) RemoveClass(cls string) {
 	elem.queue(what.RClass, cls)
 }
 
-// SetInner queues sending new inner HTML content
-// to the browser for the [Element].
+// SetInner queues new inner HTML content for the [Element].
+//
+// When innerHTML exactly matches the browser's current serialized inner HTML,
+// JaWS leaves the existing descendants and their live state unchanged. Use
+// [Element.Replace] when matching markup must still create new nodes.
 //
 // Call this while the [Element] is rendering or updating, when a send pass is
 // imminent. To change the [Element] in response to a browser event, mark it dirty
@@ -346,11 +349,19 @@ func (elem *Element) JsCall(jsfunc, jsonstr string) {
 
 // Replace replaces the [Element]'s entire HTML DOM node with new HTML code.
 //
-// A valid call always creates a new DOM node, even when htmlCode matches the
-// current serialized HTML.
+// A valid call recreates the target subtree even when htmlCode matches its
+// current serialization. Browser-only state on replaced nodes, including focus,
+// selection, scroll position, live form-control properties, programmatic
+// listeners, expando properties, and custom-element instances, is not preserved.
+// JaWS reattaches its own managed browser behavior.
+//
+// A replacement node bearing an existing JaWS ID keeps that server-side
+// [Element] registration and UI state; omitted descendant IDs are unregistered.
+// Retained nodes are not rerendered separately, so their markup must match that
+// state and each reused ID must identify the same logical Element.
 //
 // The trusted HTML should preserve the element identity by putting the element's
-// own JaWS id on the replacement root element, normally as id="Jid.N". Replace is
+// own JaWS ID on the replacement root element, normally as id="Jid.N". Replace is
 // not an HTML validator: it performs only a lightweight textual guard for that
 // expected id attribute. If the guard does not find it, the call is a programming
 // error: debug builds panic and production builds report it via [Jaws.MustLog]

--- a/lib/assets/jaws.js
+++ b/lib/assets/jaws.js
@@ -179,20 +179,35 @@ function jawsForgetName(elem) {
 	}
 }
 
-function jawsRemoving(topElem) {
+function jawsManagedElements(topElem) {
+	return topElem.querySelectorAll('[id^="' + jawsIdPrefix + '"]');
+}
+
+function jawsRemoving(topElem, retainedTopElem) {
 	if (!jawsIsJid(topElem.id)) {
 		return;
 	}
-	// Report the descendants being removed and drop any JsVar name routes they own,
-	// so a later browser write does not target a deleted element. topElem itself
-	// survives an Inner update, so its own name is dropped by the callers that
-	// actually remove it (Delete/Replace/Remove), not here.
-	const elements = topElem.querySelectorAll('[id^="' + jawsIdPrefix + '"]');
+	let retainedIds = null;
+	if (retainedTopElem !== undefined) {
+		retainedIds = new Set();
+		const retainedElements = jawsManagedElements(retainedTopElem);
+		for (let i = 0; i < retainedElements.length; i++) {
+			if (jawsIsJid(retainedElements[i].id)) {
+				retainedIds.add(retainedElements[i].id);
+			}
+		}
+	}
+	// Every old descendant node loses its browser name route. Attachment recreates
+	// routes for retained Jids; only absent Jids are reported to the server. topElem
+	// survives an Inner update, so callers that remove it drop its route themselves.
+	const elements = jawsManagedElements(topElem);
 	const ids = [];
 	for (let i = 0; i < elements.length; i++) {
 		if (jawsIsJid(elements[i].id)) {
-			ids.push(elements[i].id);
 			jawsForgetName(elements[i]);
+			if (retainedIds === null || !retainedIds.has(elements[i].id)) {
+				ids.push(elements[i].id);
+			}
 		}
 	}
 	if (ids.length === 0) {
@@ -237,7 +252,7 @@ function jawsAttach(elem) {
 }
 
 function jawsAttachChildren(topElem) {
-	topElem.querySelectorAll('[id^="' + jawsIdPrefix + '"]').forEach(jawsAttach);
+	jawsManagedElements(topElem).forEach(jawsAttach);
 	topElem.querySelectorAll('[data-jawsonchangesubmit]').forEach(elem => {
 		elem.addEventListener('change', function() { this.form.submit(); });
 	});
@@ -468,9 +483,9 @@ function jawsMessage(e) {
 	}
 }
 
-function jawsWarnDirtyNoChange(id, operation) {
+function jawsWarnSameHTML(id, operation, effect) {
 	if (jawsDebug) {
-		console.warn("jaws: " + operation + " " + id + ": a jaws.Element was marked dirty but it generated the same HTML");
+		console.warn("jaws: " + operation + " " + id + ": requested HTML matches the current serialized HTML; " + effect);
 	}
 }
 
@@ -571,7 +586,7 @@ function jawsPerform(what, id, data) {
 				elem.innerHTML = data;
 				jawsAttachChildren(elem);
 			} else {
-				jawsWarnDirtyNoChange(id, what);
+				jawsWarnSameHTML(id, what, "the DOM update was skipped");
 			}
 			return;
 		case 'Value':
@@ -581,13 +596,15 @@ function jawsPerform(what, id, data) {
 			elem.appendChild(jawsAttachChildren(jawsElement(data)));
 			return;
 		case 'Replace':
-			// Equal serialized markup still requires a new node, but its managed
-			// descendants retain the same Jids and must remain registered.
-			if (elem.outerHTML !== data) {
-				jawsRemoving(elem);
+			const replacement = jawsElement(data);
+			if (jawsDebug && elem.outerHTML === data) {
+				jawsWarnSameHTML(id, what, "the DOM node is still recreated");
 			}
+			// Every old node loses its browser name route. Retained Jids keep their
+			// server Elements, and attaching the fragment recreates their routes.
+			jawsRemoving(elem, replacement);
 			jawsForgetName(elem);
-			elem.replaceWith(jawsAttachChildren(jawsElement(data)));
+			elem.replaceWith(jawsAttachChildren(replacement));
 			return;
 		case 'Delete':
 			jawsRemoving(elem);

--- a/lib/assets/jaws.js
+++ b/lib/assets/jaws.js
@@ -197,7 +197,7 @@ function jawsRemoving(topElem, retainedTopElem) {
 			}
 		}
 	}
-	// Every old descendant node loses its browser name route. Attachment recreates
+	// Drop name routes from all old managed descendants. Attachment recreates
 	// routes for retained Jids; only absent Jids are reported to the server. topElem
 	// survives an Inner update, so callers that remove it drop its route themselves.
 	const elements = jawsManagedElements(topElem);
@@ -600,7 +600,7 @@ function jawsPerform(what, id, data) {
 			if (jawsDebug && elem.outerHTML === data) {
 				jawsWarnSameHTML(id, what, "the DOM node is still recreated");
 			}
-			// Every old node loses its browser name route. Retained Jids keep their
+			// Drop name routes from all old managed nodes. Retained Jids keep their
 			// server Elements, and attaching the fragment recreates their routes.
 			jawsRemoving(elem, replacement);
 			jawsForgetName(elem);

--- a/lib/assets/jaws.js
+++ b/lib/assets/jaws.js
@@ -581,13 +581,13 @@ function jawsPerform(what, id, data) {
 			elem.appendChild(jawsAttachChildren(jawsElement(data)));
 			return;
 		case 'Replace':
+			// Equal serialized markup still requires a new node, but its managed
+			// descendants retain the same Jids and must remain registered.
 			if (elem.outerHTML !== data) {
 				jawsRemoving(elem);
-				jawsForgetName(elem);
-				elem.replaceWith(jawsAttachChildren(jawsElement(data)));
-			} else {
-				jawsWarnDirtyNoChange(id, what);
 			}
+			jawsForgetName(elem);
+			elem.replaceWith(jawsAttachChildren(jawsElement(data)));
 			return;
 		case 'Delete':
 			jawsRemoving(elem);

--- a/lib/assets/js_test.go
+++ b/lib/assets/js_test.go
@@ -1703,6 +1703,9 @@ child.parentElement = parent;
 
 const replaceParent = makeNode("parent");
 const oldNode = makeNode("Jid.4");
+const oldDescendant = makeNode("Jid.6");
+oldNode.children.push(oldDescendant);
+oldDescendant.parentElement = oldNode;
 replaceParent.children.push(oldNode);
 oldNode.parentElement = replaceParent;
 
@@ -1717,6 +1720,7 @@ process.stdout.write(JSON.stringify({
 	parentChildren: parent.children.map(function(child) { return child.id; }),
 	replacedChildren: replaceParent.children.map(function(child) { return child.id; }),
 	removeFrame: jaws.sent[0] || "",
+	replaceRemoveFrame: jaws.sent[1] || "",
 	childStillRegistered: Boolean(nodes["Jid.2"]),
 	oldStillRegistered: Boolean(nodes["Jid.4"])
 }));
@@ -1726,6 +1730,7 @@ process.stdout.write(JSON.stringify({
 		ParentChildren       []string `json:"parentChildren"`
 		ReplacedChildren     []string `json:"replacedChildren"`
 		RemoveFrame          string   `json:"removeFrame"`
+		ReplaceRemoveFrame   string   `json:"replaceRemoveFrame"`
 		ChildStillRegistered bool     `json:"childStillRegistered"`
 		OldStillRegistered   bool     `json:"oldStillRegistered"`
 	}
@@ -1747,6 +1752,13 @@ process.stdout.write(JSON.stringify({
 	}
 	if msg.What != what.Remove || msg.Jid != 2 || msg.Data != "Jid.3" {
 		t.Fatalf("unexpected removal frame: %+v", msg)
+	}
+	msg, ok = wire.Parse([]byte(got.ReplaceRemoveFrame))
+	if !ok {
+		t.Fatalf("Replace removal frame must be parseable by wire.Parse, got %q", got.ReplaceRemoveFrame)
+	}
+	if msg.What != what.Remove || msg.Jid != 4 || msg.Data != "Jid.6" {
+		t.Fatalf("unexpected Replace removal frame: %+v", msg)
 	}
 }
 
@@ -3034,86 +3046,30 @@ process.stdout.write(JSON.stringify({
 	}
 }
 
-func TestJawsJS_ReplaceComparesAndUpdatesWhenDebugDisabled(t *testing.T) {
-	raw := runJawsJSSnippet(t, `
-jawsDebug = false;
-const warnings = [];
-console.warn = function(msg) { warnings.push(msg); };
-let outerReads = 0;
-let replaceCalls = 0;
-let outerValue = "<div id=\"Jid.1\"><i>old</i></div>";
-const elem = {
-	id: "Jid.1",
-	querySelectorAll: function() { return []; },
-	replaceWith: function() { replaceCalls++; }
-};
-Object.defineProperty(elem, "outerHTML", {
-	get: function() {
-		outerReads++;
-		return outerValue;
-	},
-	enumerable: true,
-	configurable: true,
-});
-document.getElementById = function(id) { return id === "Jid.1" ? elem : null; };
-document.createElement = function(tag) {
-	if (tag !== "template") throw new Error("unexpected tag " + tag);
-	const template = {
-		content: {
-			querySelectorAll: function() { return []; }
-		}
-	};
-	Object.defineProperty(template, "innerHTML", {
-		get: function() { return this._inner || ""; },
-		set: function(v) { this._inner = v; },
-		enumerable: true,
-		configurable: true,
-	});
-	return template;
-};
-
-jawsPerform("Replace", "Jid.1", JSON.stringify("<div id=\"Jid.1\"></div>"));
-process.stdout.write(JSON.stringify({ outerReads: outerReads, replaceCalls: replaceCalls, warningCount: warnings.length }));
-`)
-
-	var got struct {
-		OuterReads   int `json:"outerReads"`
-		ReplaceCalls int `json:"replaceCalls"`
-		WarningCount int `json:"warningCount"`
-	}
-	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &got); err != nil {
-		t.Fatalf("failed to parse snippet output %q: %v", raw, err)
-	}
-	if got.OuterReads != 1 {
-		t.Fatalf("outerHTML reads = %d, want 1", got.OuterReads)
-	}
-	if got.ReplaceCalls != 1 {
-		t.Fatalf("replace calls = %d, want 1", got.ReplaceCalls)
-	}
-	if got.WarningCount != 0 {
-		t.Fatalf("warnings = %d, want 0", got.WarningCount)
-	}
-}
-
 func TestJawsJS_InnerWarnsWhenDebugEnabledAndHTMLUnchanged(t *testing.T) {
 	raw := runJawsJSSnippet(t, `
 jawsDebug = true;
 const warnings = [];
 console.warn = function(msg) { warnings.push(msg); };
+let writes = 0;
 const elem = {
 	id: "Jid.1",
 	querySelectorAll: function() { return []; },
-	innerHTML: "<b>x</b>"
 };
+Object.defineProperty(elem, "innerHTML", {
+	get: function() { return "<b>x</b>"; },
+	set: function() { writes++; },
+});
 document.getElementById = function(id) { return id === "Jid.1" ? elem : null; };
 
 jawsPerform("Inner", "Jid.1", JSON.stringify("<b>x</b>"));
-process.stdout.write(JSON.stringify({ warnings: warnings, innerHTML: elem.innerHTML }));
+process.stdout.write(JSON.stringify({ warnings: warnings, innerHTML: elem.innerHTML, writes: writes }));
 `)
 
 	var got struct {
 		Warnings  []string `json:"warnings"`
 		InnerHTML string   `json:"innerHTML"`
+		Writes    int      `json:"writes"`
 	}
 	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &got); err != nil {
 		t.Fatalf("failed to parse snippet output %q: %v", raw, err)
@@ -3127,56 +3083,153 @@ process.stdout.write(JSON.stringify({ warnings: warnings, innerHTML: elem.innerH
 	if got.InnerHTML != "<b>x</b>" {
 		t.Fatalf("innerHTML = %q, want unchanged", got.InnerHTML)
 	}
+	if got.Writes != 0 {
+		t.Fatalf("innerHTML writes = %d, want 0", got.Writes)
+	}
 }
 
-func TestJawsJS_ReplaceWarnsWhenDebugEnabledAndHTMLUnchanged(t *testing.T) {
+func TestJawsJS_ReplaceRecreatesNodeWhenHTMLUnchanged(t *testing.T) {
 	raw := runJawsJSSnippet(t, `
 jawsDebug = true;
-let replaceCalls = 0;
 const warnings = [];
 console.warn = function(msg) { warnings.push(msg); };
-const elem = {
-	id: "Jid.1",
-	querySelectorAll: function() { return []; },
-	outerHTML: "<div id=\"Jid.1\"></div>",
-	replaceWith: function() { replaceCalls++; }
+function FakeSocket() { this.readyState = 1; this.sent = []; }
+FakeSocket.prototype.send = function(msg) { this.sent.push(msg); };
+WebSocket = FakeSocket;
+jaws = new FakeSocket();
+
+const replacement = '<div id="Jid.1"><input id="Jid.2" type="text" value="server"></div>';
+const beforeInput = {
+	id: "Jid.2",
+	tagName: "INPUT",
+	type: "text",
+	value: "client edit",
+	defaultValue: "server",
+	dataset: {},
+	hasAttribute: function() { return false; },
 };
-document.getElementById = function(id) { return id === "Jid.1" ? elem : null; };
+const before = {
+	id: "Jid.1",
+	tagName: "DIV",
+	dataset: {},
+	outerHTML: replacement,
+	hasAttribute: function() { return false; },
+	querySelectorAll: function(selector) {
+		if (selector === '[id^="' + jawsIdPrefix + '"]') return [beforeInput];
+		return [];
+	},
+	replaceWith: function(fragment) {
+		current = fragment.root;
+		currentInput = fragment.input;
+	},
+};
+let current = before;
+let currentInput = beforeInput;
+document.getElementById = function(id) {
+	if (id === "Jid.1") return current;
+	if (id === "Jid.2") return currentInput;
+	return null;
+};
 document.createElement = function(tag) {
 	if (tag !== "template") throw new Error("unexpected tag " + tag);
+	const afterInput = {
+		id: "Jid.2",
+		tagName: "INPUT",
+		type: "text",
+		value: "server",
+		defaultValue: "server",
+		dataset: {},
+		listeners: [],
+		hasAttribute: function() { return false; },
+		addEventListener: function(name) { this.listeners.push(name); },
+		querySelectorAll: function() { return []; },
+	};
+	const after = {
+		id: "Jid.1",
+		tagName: "DIV",
+		dataset: {},
+		listeners: [],
+		hasAttribute: function() { return false; },
+		addEventListener: function(name) { this.listeners.push(name); },
+		querySelectorAll: function(selector) {
+			if (selector === '[id^="' + jawsIdPrefix + '"]') return [afterInput];
+			return [];
+		},
+	};
+	const fragment = {
+		root: after,
+		input: afterInput,
+		querySelectorAll: function(selector) {
+			if (selector === '[id^="' + jawsIdPrefix + '"]') return [after, afterInput];
+			return [];
+		},
+	};
 	const template = {
-		content: {
-			querySelectorAll: function() { return []; }
-		}
+		content: fragment,
 	};
 	Object.defineProperty(template, "innerHTML", {
-		get: function() { return this._inner || ""; },
-		set: function(v) { this._inner = v; },
+		set: function(v) {
+			if (v !== replacement) throw new Error("unexpected replacement " + v);
+		},
 		enumerable: true,
 		configurable: true,
 	});
 	return template;
 };
 
-jawsPerform("Replace", "Jid.1", JSON.stringify("<div id=\"Jid.1\"></div>"));
-process.stdout.write(JSON.stringify({ warnings: warnings, replaceCalls: replaceCalls }));
+jawsPerform("Replace", "Jid.1", JSON.stringify(replacement));
+const after = document.getElementById("Jid.1");
+const afterInput = document.getElementById("Jid.2");
+process.stdout.write(JSON.stringify({
+	warnings: warnings,
+	sameNode: before === after,
+	id: after.id,
+	sameInput: beforeInput === afterInput,
+	inputID: afterInput.id,
+	value: afterInput.value,
+	defaultValue: afterInput.defaultValue,
+	listeners: afterInput.listeners,
+	frames: jaws.sent,
+}));
 `)
 
 	var got struct {
 		Warnings     []string `json:"warnings"`
-		ReplaceCalls int      `json:"replaceCalls"`
+		SameNode     bool     `json:"sameNode"`
+		ID           string   `json:"id"`
+		SameInput    bool     `json:"sameInput"`
+		InputID      string   `json:"inputID"`
+		Value        string   `json:"value"`
+		DefaultValue string   `json:"defaultValue"`
+		Listeners    []string `json:"listeners"`
+		Frames       []string `json:"frames"`
 	}
 	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &got); err != nil {
 		t.Fatalf("failed to parse snippet output %q: %v", raw, err)
 	}
-	if len(got.Warnings) != 1 {
-		t.Fatalf("warnings = %d, want 1", len(got.Warnings))
+	if len(got.Warnings) != 0 {
+		t.Fatalf("warnings = %q, want none", got.Warnings)
 	}
-	if !strings.Contains(got.Warnings[0], "marked dirty but it generated the same HTML") {
-		t.Fatalf("unexpected warning text %q", got.Warnings[0])
+	if got.SameNode {
+		t.Fatal("Replace kept the existing DOM node")
 	}
-	if got.ReplaceCalls != 0 {
-		t.Fatalf("replace calls = %d, want 0", got.ReplaceCalls)
+	if got.ID != "Jid.1" {
+		t.Fatalf("replacement id = %q, want %q", got.ID, "Jid.1")
+	}
+	if got.SameInput {
+		t.Fatal("Replace kept the existing managed input")
+	}
+	if got.InputID != "Jid.2" {
+		t.Fatalf("replacement input id = %q, want %q", got.InputID, "Jid.2")
+	}
+	if got.Value != "server" || got.DefaultValue != "server" {
+		t.Fatalf("replacement values = (%q, %q), want server defaults", got.Value, got.DefaultValue)
+	}
+	if !reflect.DeepEqual(got.Listeners, []string{"input"}) {
+		t.Fatalf("replacement listeners = %q, want [input]", got.Listeners)
+	}
+	if len(got.Frames) != 0 {
+		t.Fatalf("Replace reported retained descendants as removed: %q", got.Frames)
 	}
 }
 

--- a/lib/assets/js_test.go
+++ b/lib/assets/js_test.go
@@ -1662,14 +1662,22 @@ function FakeSocket() { this.readyState = 1; this.sent = []; }
 FakeSocket.prototype.send = function(msg) { this.sent.push(msg); };
 WebSocket = FakeSocket;
 jaws = new FakeSocket();
+jawsDebug = true;
+const warnings = [];
+console.warn = function(msg) { warnings.push(msg); };
 
 const nodes = {};
-function makeNode(id, tagName) {
+function makeNode(id, name) {
 	const node = new Node();
 	node.id = id;
-	node.tagName = tagName || "DIV";
+	node.tagName = "DIV";
+	node.dataset = name ? { jawsname: name } : {};
 	node.children = [];
 	node.parentElement = null;
+	node.hasAttribute = function(attr) {
+		return attr === "data-jawsname" && Boolean(name);
+	};
+	node.addEventListener = function() {};
 	node.querySelectorAll = function(selector) {
 		if (selector === '[id^="' + jawsIdPrefix + '"]') {
 			return this.children.filter(function(child) { return String(child.id || "").startsWith(jawsIdPrefix); });
@@ -1681,13 +1689,18 @@ function makeNode(id, tagName) {
 		child.parentElement = null;
 		delete nodes[child.id];
 	};
-	node.replaceWith = function(newNode) {
+	node.replaceWith = function(fragment) {
 		const parent = this.parentElement;
 		const idx = parent.children.indexOf(this);
-		parent.children[idx] = newNode;
-		newNode.parentElement = parent;
+		parent.children[idx] = fragment.root;
+		fragment.root.parentElement = parent;
 		delete nodes[this.id];
-		nodes[newNode.id] = newNode;
+		for (let i = 0; i < this.children.length; i++) {
+			delete nodes[this.children[i].id];
+		}
+		for (let i = 0; i < fragment.managed.length; i++) {
+			nodes[fragment.managed[i].id] = fragment.managed[i];
+		}
 	};
 	nodes[id] = node;
 	return node;
@@ -1702,37 +1715,78 @@ parent.children.push(child);
 child.parentElement = parent;
 
 const replaceParent = makeNode("parent");
-const oldNode = makeNode("Jid.4");
-const oldDescendant = makeNode("Jid.6");
-oldNode.children.push(oldDescendant);
-oldDescendant.parentElement = oldNode;
+const oldNode = makeNode("Jid.4", "oldRoot");
+const retainedDescendant = makeNode("Jid.6", "oldChild");
+const removedDescendant = makeNode("Jid.7", "removedChild");
+oldNode.outerHTML = '<section id="Jid.4" data-jawsname="oldRoot"><div id="Jid.6" data-jawsname="oldChild"></div><div id="Jid.7" data-jawsname="removedChild"></div></section>';
+oldNode.children.push(retainedDescendant, removedDescendant);
+retainedDescendant.parentElement = oldNode;
+removedDescendant.parentElement = oldNode;
 replaceParent.children.push(oldNode);
 oldNode.parentElement = replaceParent;
+jawsAttach(oldNode);
+jawsAttach(retainedDescendant);
+jawsAttach(removedDescendant);
 
 document.getElementById = function(id) { return nodes[id] || null; };
-jawsElement = function(html) { return makeNode("Jid.5"); };
-jawsAttachChildren = function(node) { return node; };
+let replacementRoot = null;
+let replacementRetained = null;
+const replacement = '<section id="Jid.4" data-jawsname="newRoot"><div id="Jid.6" data-jawsname="newChild"></div><div id="Jid.8" data-jawsname="addedChild"></div></section>';
+jawsElement = function(html) {
+	if (html !== replacement) throw new Error("unexpected replacement " + html);
+	replacementRoot = makeNode("Jid.4", "newRoot");
+	replacementRetained = makeNode("Jid.6", "newChild");
+	const addedDescendant = makeNode("Jid.8", "addedChild");
+	replacementRoot.children.push(replacementRetained, addedDescendant);
+	replacementRetained.parentElement = replacementRoot;
+	addedDescendant.parentElement = replacementRoot;
+	const managed = [replacementRoot, replacementRetained, addedDescendant];
+	return {
+		root: replacementRoot,
+		managed: managed,
+		querySelectorAll: function(selector) {
+			if (selector === '[id^="' + jawsIdPrefix + '"]') return managed;
+			return [];
+		},
+	};
+};
 
 jawsPerform("Remove", "Jid.1", JSON.stringify("Jid.2"));
-jawsPerform("Replace", "Jid.4", JSON.stringify('<div id="Jid.5"></div>'));
+jawsPerform("Replace", "Jid.4", JSON.stringify(replacement));
 
 process.stdout.write(JSON.stringify({
 	parentChildren: parent.children.map(function(child) { return child.id; }),
 	replacedChildren: replaceParent.children.map(function(child) { return child.id; }),
 	removeFrame: jaws.sent[0] || "",
 	replaceRemoveFrame: jaws.sent[1] || "",
+	frameCount: jaws.sent.length,
+	warnings: warnings,
 	childStillRegistered: Boolean(nodes["Jid.2"]),
-	oldStillRegistered: Boolean(nodes["Jid.4"])
+	rootRecreated: replaceParent.children[0] === replacementRoot && oldNode !== replacementRoot,
+	oldRootRoute: window.jawsNames.get("oldRoot") || null,
+	oldChildRoute: window.jawsNames.get("oldChild") || null,
+	removedChildRoute: window.jawsNames.get("removedChild") || null,
+	newRootRoute: window.jawsNames.get("newRoot") || null,
+	newChildRoute: window.jawsNames.get("newChild") || null,
+	addedChildRoute: window.jawsNames.get("addedChild") || null,
 }));
 `)
 
 	var got struct {
-		ParentChildren       []string `json:"parentChildren"`
-		ReplacedChildren     []string `json:"replacedChildren"`
-		RemoveFrame          string   `json:"removeFrame"`
-		ReplaceRemoveFrame   string   `json:"replaceRemoveFrame"`
-		ChildStillRegistered bool     `json:"childStillRegistered"`
-		OldStillRegistered   bool     `json:"oldStillRegistered"`
+		ParentChildren     []string `json:"parentChildren"`
+		ReplacedChildren   []string `json:"replacedChildren"`
+		RemoveFrame        string   `json:"removeFrame"`
+		ReplaceRemoveFrame string   `json:"replaceRemoveFrame"`
+		FrameCount         int      `json:"frameCount"`
+		Warnings           []string `json:"warnings"`
+		ChildRegistered    bool     `json:"childStillRegistered"`
+		RootRecreated      bool     `json:"rootRecreated"`
+		OldRootRoute       []string `json:"oldRootRoute"`
+		OldChildRoute      []string `json:"oldChildRoute"`
+		RemovedChildRoute  []string `json:"removedChildRoute"`
+		NewRootRoute       []string `json:"newRootRoute"`
+		NewChildRoute      []string `json:"newChildRoute"`
+		AddedChildRoute    []string `json:"addedChildRoute"`
 	}
 	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &got); err != nil {
 		t.Fatalf("failed to parse snippet output %q: %v", raw, err)
@@ -1740,11 +1794,28 @@ process.stdout.write(JSON.stringify({
 	if len(got.ParentChildren) != 0 {
 		t.Fatalf("Remove left children behind: %+v", got.ParentChildren)
 	}
-	if !reflect.DeepEqual(got.ReplacedChildren, []string{"Jid.5"}) {
-		t.Fatalf("Replace children = %+v, want [Jid.5]", got.ReplacedChildren)
+	if !reflect.DeepEqual(got.ReplacedChildren, []string{"Jid.4"}) {
+		t.Fatalf("Replace children = %+v, want [Jid.4]", got.ReplacedChildren)
 	}
-	if got.ChildStillRegistered || got.OldStillRegistered {
-		t.Fatalf("removed/replaced nodes still registered: %+v", got)
+	if got.FrameCount != 2 {
+		t.Fatalf("frames = %d, want one Remove frame per operation", got.FrameCount)
+	}
+	if len(got.Warnings) != 0 {
+		t.Fatalf("changed Replace warnings = %q, want none", got.Warnings)
+	}
+	if got.ChildRegistered {
+		t.Fatal("removed node is still registered")
+	}
+	if !got.RootRecreated {
+		t.Fatalf("Replace did not insert the replacement DOM: %+v", got)
+	}
+	if got.OldRootRoute != nil || got.OldChildRoute != nil || got.RemovedChildRoute != nil {
+		t.Fatalf("Replace retained old name routes: %+v", got)
+	}
+	if !reflect.DeepEqual(got.NewRootRoute, []string{"Jid.4"}) ||
+		!reflect.DeepEqual(got.NewChildRoute, []string{"Jid.6"}) ||
+		!reflect.DeepEqual(got.AddedChildRoute, []string{"Jid.8"}) {
+		t.Fatalf("replacement name routes = root %v, child %v, added %v", got.NewRootRoute, got.NewChildRoute, got.AddedChildRoute)
 	}
 	msg, ok := wire.Parse([]byte(got.RemoveFrame))
 	if !ok {
@@ -1757,7 +1828,7 @@ process.stdout.write(JSON.stringify({
 	if !ok {
 		t.Fatalf("Replace removal frame must be parseable by wire.Parse, got %q", got.ReplaceRemoveFrame)
 	}
-	if msg.What != what.Remove || msg.Jid != 4 || msg.Data != "Jid.6" {
+	if msg.What != what.Remove || msg.Jid != 4 || msg.Data != "Jid.7" {
 		t.Fatalf("unexpected Replace removal frame: %+v", msg)
 	}
 }
@@ -3077,7 +3148,7 @@ process.stdout.write(JSON.stringify({ warnings: warnings, innerHTML: elem.innerH
 	if len(got.Warnings) != 1 {
 		t.Fatalf("warnings = %d, want 1", len(got.Warnings))
 	}
-	if !strings.Contains(got.Warnings[0], "marked dirty but it generated the same HTML") {
+	if got.Warnings[0] != "jaws: Inner Jid.1: requested HTML matches the current serialized HTML; the DOM update was skipped" {
 		t.Fatalf("unexpected warning text %q", got.Warnings[0])
 	}
 	if got.InnerHTML != "<b>x</b>" {
@@ -3097,37 +3168,52 @@ function FakeSocket() { this.readyState = 1; this.sent = []; }
 FakeSocket.prototype.send = function(msg) { this.sent.push(msg); };
 WebSocket = FakeSocket;
 jaws = new FakeSocket();
+window.app = { state: 0 };
 
-const replacement = '<div id="Jid.1"><input id="Jid.2" type="text" value="server"></div>';
+const replacement = '<div id="Jid.1" data-jawsname="app"><input id="Jid.2" type="text" value="server"><input id="Jid.3" type="checkbox" checked></div>';
 const beforeInput = {
 	id: "Jid.2",
 	tagName: "INPUT",
 	type: "text",
 	value: "client edit",
-	defaultValue: "server",
 	dataset: {},
 	hasAttribute: function() { return false; },
 };
+const beforeCheckbox = {
+	id: "Jid.3",
+	tagName: "INPUT",
+	type: "checkbox",
+	checked: false,
+	dataset: {},
+	hasAttribute: function() { return false; },
+};
+let outerHTMLReads = 0;
 const before = {
 	id: "Jid.1",
 	tagName: "DIV",
-	dataset: {},
-	outerHTML: replacement,
-	hasAttribute: function() { return false; },
+	dataset: { jawsname: "app" },
+	hasAttribute: function(attr) { return attr === "data-jawsname"; },
 	querySelectorAll: function(selector) {
-		if (selector === '[id^="' + jawsIdPrefix + '"]') return [beforeInput];
+		if (selector === '[id^="' + jawsIdPrefix + '"]') return [beforeInput, beforeCheckbox];
 		return [];
 	},
 	replaceWith: function(fragment) {
 		current = fragment.root;
 		currentInput = fragment.input;
+		currentCheckbox = fragment.checkbox;
 	},
 };
+Object.defineProperty(before, "outerHTML", {
+	get: function() { outerHTMLReads++; return replacement; },
+});
 let current = before;
 let currentInput = beforeInput;
+let currentCheckbox = beforeCheckbox;
+jawsAttach(before);
 document.getElementById = function(id) {
 	if (id === "Jid.1") return current;
 	if (id === "Jid.2") return currentInput;
+	if (id === "Jid.3") return currentCheckbox;
 	return null;
 };
 document.createElement = function(tag) {
@@ -3137,7 +3223,17 @@ document.createElement = function(tag) {
 		tagName: "INPUT",
 		type: "text",
 		value: "server",
-		defaultValue: "server",
+		dataset: {},
+		listeners: [],
+		hasAttribute: function() { return false; },
+		addEventListener: function(name) { this.listeners.push(name); },
+		querySelectorAll: function() { return []; },
+	};
+	const afterCheckbox = {
+		id: "Jid.3",
+		tagName: "INPUT",
+		type: "checkbox",
+		checked: true,
 		dataset: {},
 		listeners: [],
 		hasAttribute: function() { return false; },
@@ -3147,20 +3243,21 @@ document.createElement = function(tag) {
 	const after = {
 		id: "Jid.1",
 		tagName: "DIV",
-		dataset: {},
+		dataset: { jawsname: "app" },
 		listeners: [],
-		hasAttribute: function() { return false; },
+		hasAttribute: function(attr) { return attr === "data-jawsname"; },
 		addEventListener: function(name) { this.listeners.push(name); },
 		querySelectorAll: function(selector) {
-			if (selector === '[id^="' + jawsIdPrefix + '"]') return [afterInput];
+			if (selector === '[id^="' + jawsIdPrefix + '"]') return [afterInput, afterCheckbox];
 			return [];
 		},
 	};
 	const fragment = {
 		root: after,
 		input: afterInput,
+		checkbox: afterCheckbox,
 		querySelectorAll: function(selector) {
-			if (selector === '[id^="' + jawsIdPrefix + '"]') return [after, afterInput];
+			if (selector === '[id^="' + jawsIdPrefix + '"]') return [after, afterInput, afterCheckbox];
 			return [];
 		},
 	};
@@ -3180,35 +3277,48 @@ document.createElement = function(tag) {
 jawsPerform("Replace", "Jid.1", JSON.stringify(replacement));
 const after = document.getElementById("Jid.1");
 const afterInput = document.getElementById("Jid.2");
+const afterCheckbox = document.getElementById("Jid.3");
+jawsVar("app.state", 7);
 process.stdout.write(JSON.stringify({
 	warnings: warnings,
+	outerHTMLReads: outerHTMLReads,
 	sameNode: before === after,
 	id: after.id,
 	sameInput: beforeInput === afterInput,
+	sameCheckbox: beforeCheckbox === afterCheckbox,
 	inputID: afterInput.id,
 	value: afterInput.value,
-	defaultValue: afterInput.defaultValue,
-	listeners: afterInput.listeners,
+	inputListeners: afterInput.listeners,
+	checked: afterCheckbox.checked,
+	checkboxListeners: afterCheckbox.listeners,
+	nameRoute: window.jawsNames.get("app") || null,
 	frames: jaws.sent,
 }));
 `)
 
 	var got struct {
-		Warnings     []string `json:"warnings"`
-		SameNode     bool     `json:"sameNode"`
-		ID           string   `json:"id"`
-		SameInput    bool     `json:"sameInput"`
-		InputID      string   `json:"inputID"`
-		Value        string   `json:"value"`
-		DefaultValue string   `json:"defaultValue"`
-		Listeners    []string `json:"listeners"`
-		Frames       []string `json:"frames"`
+		Warnings          []string `json:"warnings"`
+		OuterHTMLReads    int      `json:"outerHTMLReads"`
+		SameNode          bool     `json:"sameNode"`
+		ID                string   `json:"id"`
+		SameInput         bool     `json:"sameInput"`
+		SameCheckbox      bool     `json:"sameCheckbox"`
+		InputID           string   `json:"inputID"`
+		Value             string   `json:"value"`
+		InputListeners    []string `json:"inputListeners"`
+		Checked           bool     `json:"checked"`
+		CheckboxListeners []string `json:"checkboxListeners"`
+		NameRoute         []string `json:"nameRoute"`
+		Frames            []string `json:"frames"`
 	}
 	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &got); err != nil {
 		t.Fatalf("failed to parse snippet output %q: %v", raw, err)
 	}
-	if len(got.Warnings) != 0 {
-		t.Fatalf("warnings = %q, want none", got.Warnings)
+	if len(got.Warnings) != 1 || got.Warnings[0] != "jaws: Replace Jid.1: requested HTML matches the current serialized HTML; the DOM node is still recreated" {
+		t.Fatalf("warnings = %q, want one recreation warning", got.Warnings)
+	}
+	if got.OuterHTMLReads != 1 {
+		t.Fatalf("outerHTML reads = %d, want 1 in debug mode", got.OuterHTMLReads)
 	}
 	if got.SameNode {
 		t.Fatal("Replace kept the existing DOM node")
@@ -3219,14 +3329,130 @@ process.stdout.write(JSON.stringify({
 	if got.SameInput {
 		t.Fatal("Replace kept the existing managed input")
 	}
+	if got.SameCheckbox {
+		t.Fatal("Replace kept the existing managed checkbox")
+	}
 	if got.InputID != "Jid.2" {
 		t.Fatalf("replacement input id = %q, want %q", got.InputID, "Jid.2")
 	}
-	if got.Value != "server" || got.DefaultValue != "server" {
-		t.Fatalf("replacement values = (%q, %q), want server defaults", got.Value, got.DefaultValue)
+	if got.Value != "server" {
+		t.Fatalf("replacement input value = %q, want server", got.Value)
 	}
-	if !reflect.DeepEqual(got.Listeners, []string{"input"}) {
-		t.Fatalf("replacement listeners = %q, want [input]", got.Listeners)
+	if !reflect.DeepEqual(got.InputListeners, []string{"input"}) {
+		t.Fatalf("replacement input listeners = %q, want [input]", got.InputListeners)
+	}
+	if !got.Checked {
+		t.Fatal("replacement checkbox did not use the checked markup state")
+	}
+	if !reflect.DeepEqual(got.CheckboxListeners, []string{"input"}) {
+		t.Fatalf("replacement checkbox listeners = %q, want [input]", got.CheckboxListeners)
+	}
+	if !reflect.DeepEqual(got.NameRoute, []string{"Jid.1"}) {
+		t.Fatalf("replacement name route = %q, want [Jid.1]", got.NameRoute)
+	}
+	if len(got.Frames) != 1 {
+		t.Fatalf("frames = %q, want one Set and no Remove", got.Frames)
+	}
+	if msg, ok := wire.Parse([]byte(got.Frames[0])); !ok || msg.What != what.Set || msg.Jid != 1 || msg.Data != "state=7" {
+		t.Fatalf("write after Replace routed to %+v, parseable %t; want Jid.1 state=7", msg, ok)
+	}
+}
+
+func TestJawsJS_ReplaceRetainsJidsAcrossBrowserSerialization(t *testing.T) {
+	raw := runJawsJSSnippet(t, `
+jawsDebug = false;
+const warnings = [];
+console.warn = function(msg) { warnings.push(msg); };
+function FakeSocket() { this.readyState = 1; this.sent = []; }
+FakeSocket.prototype.send = function(msg) { this.sent.push(msg); };
+WebSocket = FakeSocket;
+jaws = new FakeSocket();
+
+const source = '<button id="Jid.1" disabled><span id="Jid.2"></span></button>';
+const beforeChild = { id: "Jid.2", dataset: {} };
+let outerHTMLReads = 0;
+const before = {
+	id: "Jid.1",
+	dataset: {},
+	hasAttribute: function() { return false; },
+	querySelectorAll: function(selector) {
+		if (selector === '[id^="' + jawsIdPrefix + '"]') return [beforeChild];
+		return [];
+	},
+	replaceWith: function(fragment) {
+		current = fragment.root;
+		currentChild = fragment.child;
+	},
+};
+Object.defineProperty(before, "outerHTML", {
+	get: function() {
+		outerHTMLReads++;
+		return '<button id="Jid.1" disabled=""><span id="Jid.2"></span></button>';
+	},
+});
+
+const afterChild = {
+	id: "Jid.2",
+	tagName: "SPAN",
+	dataset: {},
+	hasAttribute: function() { return false; },
+	addEventListener: function() {},
+};
+const after = {
+	id: "Jid.1",
+	tagName: "BUTTON",
+	dataset: {},
+	hasAttribute: function() { return false; },
+	addEventListener: function() {},
+};
+const fragment = {
+	root: after,
+	child: afterChild,
+	querySelectorAll: function(selector) {
+		if (selector === '[id^="' + jawsIdPrefix + '"]') return [after, afterChild];
+		return [];
+	},
+};
+let current = before;
+let currentChild = beforeChild;
+document.getElementById = function(id) {
+	if (id === "Jid.1") return current;
+	if (id === "Jid.2") return currentChild;
+	return null;
+};
+jawsElement = function(html) {
+	if (html !== source) throw new Error("unexpected replacement " + html);
+	return fragment;
+};
+
+jawsPerform("Replace", "Jid.1", JSON.stringify(source));
+process.stdout.write(JSON.stringify({
+	rootRecreated: current === after && current !== before,
+	childRecreated: currentChild === afterChild && currentChild !== beforeChild,
+	outerHTMLReads: outerHTMLReads,
+	warnings: warnings,
+	frames: jaws.sent,
+}));
+`)
+
+	var got struct {
+		RootRecreated  bool     `json:"rootRecreated"`
+		ChildRecreated bool     `json:"childRecreated"`
+		OuterHTMLReads int      `json:"outerHTMLReads"`
+		Warnings       []string `json:"warnings"`
+		Frames         []string `json:"frames"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &got); err != nil {
+		t.Fatalf("failed to parse snippet output %q: %v", raw, err)
+	}
+	if !got.RootRecreated || !got.ChildRecreated {
+		t.Fatalf("Replace did not recreate browser-normalized markup: %+v", got)
+	}
+	if got.OuterHTMLReads != 0 {
+		t.Fatalf("outerHTML reads = %d, want none outside debug mode", got.OuterHTMLReads)
+	}
+	if len(got.Warnings) != 0 {
+		t.Fatalf("warnings = %q, want none outside debug mode", got.Warnings)
 	}
 	if len(got.Frames) != 0 {
 		t.Fatalf("Replace reported retained descendants as removed: %q", got.Frames)


### PR DESCRIPTION
## Summary

- execute every valid `Replace` command, even when the replacement HTML equals the current `outerHTML`
- retain server-side registrations for descendant JaWS IDs present in both DOM trees
- keep the serialized-HTML no-op behavior for `Inner`
- warn in debug mode when `Replace` recreates an identically serialized subtree
- document the browser-state and retained-element contracts for `Replace` and `SetInner`

## Behavior

`Replace` parses the supplied fragment once and reports only previously managed descendant IDs absent from the replacement. JaWS IDs present in both subtrees keep their server-side `Element` registrations and UI state while JaWS rebuilds its browser listeners and `JsVar` bindings. The supplied markup initializes every new DOM node; retained Elements are not rerendered separately, so reused IDs and markup must remain consistent with the same logical Elements.

Replacement does not preserve browser-only state in the subtree, including focus, selection, scroll position, live form-control properties, programmatic listeners, expando properties, and custom-element instances. In debug mode, an exact serialized match produces an informational warning but still performs the replacement. When debug mode is disabled, `Replace` does not read `outerHTML`.

`Inner` remains a no-op when its HTML exactly matches the browser's current serialized inner HTML, preserving the existing descendants and their live state.

## CI reliability

golangci-lint v2.12.2 can restore partially invalidated Staticcheck package facts that lose `testing.T.Fatal`'s terminating behavior. The action's cache is disabled; the separately pinned Staticcheck step and all golangci linters remain enabled.

## Verification

- `go generate ./...`
- `go build ./...`
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run` with a fresh cache
- `gosec ./...`
- `gofmt` and `gofumpt`
- `JAWS_REQUIRE_NODE=1 go test -race -count=1 -coverprofile=/tmp/jaws-issue290-full.cover ./...` (99.8% overall; `lib/assets` 100.0%)
- `JAWS_REQUIRE_NODE=1 go test -count=1 ./...`
- `go mod verify`

Fixes #290
