### PR TITLE
request: wrap WebSocket transport cancellation

### DIFF
--- a/request.go
+++ b/request.go
@@ -1174,16 +1174,18 @@ func (rq *Request) runWebSocket(ws *websocket.Conn, pingInterval, wsTimeout time
 
 	if err = rq.onConnect(); err == nil {
 		incomingMsgCh := make(chan wire.WsMsg)
-		// Snapshot ctx and cancelFn after onConnect so a context installed by the
-		// callback governs all WebSocket loops.
+		// Snapshot ctx after onConnect so a context installed by the callback
+		// governs all WebSocket loops.
 		rq.mu.RLock()
 		ctx := rq.ctx
-		cancelFn := rq.cancelFn
 		rq.mu.RUnlock()
+		// The request-aware path wraps and logs the first WebSocket failure to win
+		// cancellation; the canceled context suppresses errors from the other loops.
+		cancelRequest := rq.cancel
 		outboundMsgCh := make(chan wire.WsMsg, cap(pendingSubscription))
-		go wire.ReadLoop(ctx, cancelFn, rq.Jaws.Done(), incomingMsgCh, ws)  // closes incomingMsgCh
-		go wire.WriteLoop(ctx, cancelFn, rq.Jaws.Done(), outboundMsgCh, ws) // calls ws.Close()
-		go wire.PingLoop(ctx, cancelFn, rq.Jaws.Done(), pingInterval, wsTimeout, ws)
+		go wire.ReadLoop(ctx, cancelRequest, rq.Jaws.Done(), incomingMsgCh, ws)  // closes incomingMsgCh
+		go wire.WriteLoop(ctx, cancelRequest, rq.Jaws.Done(), outboundMsgCh, ws) // calls ws.Close()
+		go wire.PingLoop(ctx, cancelRequest, rq.Jaws.Done(), pingInterval, wsTimeout, ws)
 		broadcastMsgCh := pendingSubscription
 		pendingSubscription = nil
 		rq.process(broadcastMsgCh, incomingMsgCh, outboundMsgCh) // unsubscribes broadcastMsgCh, closes outboundMsgCh

--- a/request_test.go
+++ b/request_test.go
@@ -4033,6 +4033,117 @@ func TestWS_ConnectFnFailureRefreshesClaimedSessionGrace(t *testing.T) {
 	}
 }
 
+func TestWS_PeerCloseWrapsRequestCancellation(t *testing.T) {
+	logger := &eventErrorLogger{}
+	ts := newTestServerWithLogger(t, logger)
+	defer ts.Close()
+	rqCtx := ts.rq.Context()
+
+	conn, resp, err := ts.Dial()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusSwitchingProtocols)
+	}
+	select {
+	case <-ts.connectedCh:
+	case <-time.After(testTimeout):
+		t.Fatal("timeout waiting for websocket connect")
+	}
+	loggedBeforeClose := len(logger.loggedErrors())
+
+	if err = conn.Close(websocket.StatusNormalClosure, "done"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-rqCtx.Done():
+	case <-time.After(testTimeout):
+		t.Fatal("timeout waiting for Request cancellation")
+	}
+	cause := context.Cause(rqCtx)
+	if !errors.Is(cause, ErrRequestCancelled) {
+		t.Fatalf("cause = %v, want ErrRequestCancelled", cause)
+	}
+	var closeErr websocket.CloseError
+	if !errors.As(cause, &closeErr) {
+		t.Fatalf("cause = %v, want websocket.CloseError", cause)
+	}
+	if closeErr.Code != websocket.StatusNormalClosure || closeErr.Reason != "done" {
+		t.Fatalf("close error = %#v, want code %v and reason %q", closeErr, websocket.StatusNormalClosure, "done")
+	}
+
+	waitForRequestCount(t, ts.jw, 0, testTimeout)
+	deadline := time.Now().Add(testTimeout)
+	for len(logger.loggedErrors()) == loggedBeforeClose && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	logged := logger.loggedErrors()[loggedBeforeClose:]
+	if len(logged) != 1 {
+		t.Fatalf("logged errors = %v, want one cancellation", logged)
+	}
+	if !errors.Is(logged[0], ErrRequestCancelled) {
+		t.Fatalf("logged error = %v, want ErrRequestCancelled", logged[0])
+	}
+	closeErr = websocket.CloseError{}
+	if !errors.As(logged[0], &closeErr) {
+		t.Fatalf("logged error = %v, want websocket.CloseError", logged[0])
+	}
+	if closeErr.Code != websocket.StatusNormalClosure || closeErr.Reason != "done" {
+		t.Fatalf("logged close error = %#v, want code %v and reason %q", closeErr, websocket.StatusNormalClosure, "done")
+	}
+}
+
+func TestWS_JawsCloseDoesNotReportTransportError(t *testing.T) {
+	logger := &eventErrorLogger{}
+	ts := newTestServerWithLogger(t, logger)
+	defer ts.Close()
+	rqCtx := ts.rq.Context()
+
+	conn, resp, err := ts.Dial()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.CloseNow() }()
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusSwitchingProtocols)
+	}
+	select {
+	case <-ts.connectedCh:
+	case <-time.After(testTimeout):
+		t.Fatal("timeout waiting for websocket connect")
+	}
+	loggedBeforeClose := len(logger.loggedErrors())
+
+	ts.jw.Close()
+	select {
+	case <-rqCtx.Done():
+	case <-time.After(testTimeout):
+		t.Fatal("timeout waiting for Request cancellation")
+	}
+	cause := context.Cause(rqCtx)
+	if !errors.Is(cause, context.Canceled) {
+		t.Fatalf("cause = %v, want context.Canceled", cause)
+	}
+	if errors.Is(cause, ErrRequestCancelled) {
+		t.Fatalf("cause = %v, unexpectedly matches ErrRequestCancelled", cause)
+	}
+
+	readCtx, cancelRead := context.WithTimeout(t.Context(), testTimeout)
+	defer cancelRead()
+	if _, _, err = conn.Read(readCtx); err == nil {
+		t.Fatal("WebSocket remained open after Jaws.Close")
+	}
+	if readCtx.Err() != nil {
+		t.Fatalf("WebSocket closed only when the client read timed out: %v", err)
+	}
+	waitForRequestCount(t, ts.jw, 0, testTimeout)
+	logged := logger.loggedErrors()
+	if len(logged) != loggedBeforeClose {
+		t.Fatalf("Jaws.Close logged transport errors: %v", logged[loggedBeforeClose:])
+	}
+}
+
 func TestWS_NormalExchange(t *testing.T) {
 	th := newTestHelper(t)
 	logger := &eventErrorLogger{}
@@ -4159,7 +4270,8 @@ func TestWS_PingDisabledKeepsIdleConnection(t *testing.T) {
 // installs and cancels a child context; the client must then observe the server
 // close without sending any unrelated wake-up message.
 func TestWS_SetContextCancellationClosesIdleConnection(t *testing.T) {
-	ts := newTestServerNoSession(t)
+	logger := &eventErrorLogger{}
+	ts := newTestServerWithSession(t, false, logger)
 	defer ts.Close()
 	ts.jw.WebSocketPingInterval = 0
 
@@ -4197,6 +4309,7 @@ func TestWS_SetContextCancellationClosesIdleConnection(t *testing.T) {
 	case <-time.After(testTimeout):
 		t.Fatal("request loop did not select on the old context")
 	}
+	loggedBeforeCancel := len(logger.loggedErrors())
 
 	ts.rq.SetContext(func(old context.Context) context.Context {
 		ctx, cancel := context.WithCancel(old)
@@ -4218,6 +4331,17 @@ func TestWS_SetContextCancellationClosesIdleConnection(t *testing.T) {
 		t.Fatalf("idle WebSocket closed only when the client read timed out: %v", err)
 	}
 	waitForRequestCount(t, ts.jw, 0, testTimeout)
+	cause := context.Cause(ts.rq.Context())
+	if !errors.Is(cause, context.Canceled) {
+		t.Fatalf("cause = %v, want context.Canceled", cause)
+	}
+	if errors.Is(cause, ErrRequestCancelled) {
+		t.Fatalf("cause = %v, unexpectedly matches ErrRequestCancelled", cause)
+	}
+	logged := logger.loggedErrors()
+	if len(logged) != loggedBeforeCancel {
+		t.Fatalf("SetContext cancellation logged transport errors: %v", logged[loggedBeforeCancel:])
+	}
 }
 
 // waitForRequestCount polls a Jaws served over a real WebSocket connection, so


### PR DESCRIPTION
## Summary

- route WebSocket read, write, and ping failures through the request-aware cancellation path
- preserve both `ErrRequestCancelled` and the underlying transport cause while logging only the first winning failure
- cover a real peer close and guard `Jaws.Close` and `Request.SetContext` cancellation against spurious transport reporting

## Verification

- `go generate ./...`
- `gofmt -l .`
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`
- `JAWS_REQUIRE_NODE=1 go test -race -count=1 -coverprofile=/private/tmp/jaws-issue-275-coverage.out ./...`
- `JAWS_REQUIRE_NODE=1 go test -count=1 ./...`
- `go build -v ./...`
- `GOOS=linux GOARCH=386 CGO_ENABLED=0 go test -count=1 -exec=/usr/bin/true ./lib/bind/... ./lib/ui/...`
- focused real-WebSocket race tests repeated 20 times
- rendered `go doc` review for affected exported behavior

Closes #275.
