### PR TITLE
session: make deletion identity-aware

### DIFF
--- a/session.go
+++ b/session.go
@@ -221,7 +221,7 @@ func (sess *Session) addCookie(w http.ResponseWriter, r *http.Request) {
 // non-nil [Session] it returns a non-nil deletion cookie.
 func (sess *Session) Close() (cookie *http.Cookie) {
 	if sess != nil {
-		sess.jw.deleteSession(sess.sessionID)
+		sess.jw.deleteSessionIfCurrent(sess)
 
 		sess.mu.Lock()
 		sess.cookie.MaxAge = -1 // #nosec G124 -- marks the already initialized session cookie for deletion.
@@ -440,6 +440,12 @@ func (jw *Jaws) newSession(w http.ResponseWriter, r *http.Request) (sess *Sessio
 //
 // The caller must hold jw.mu and publish the Session before releasing it.
 func (jw *Jaws) newSessionLocked(remoteIP netip.Addr, secure bool) (sess *Session) {
+	// Retired IDs deliberately remain eligible for reuse. A natural 64-bit random
+	// collision can therefore make a stale cookie name a later Session. Preventing
+	// every reuse would require unbounded tombstones; if this probability/space
+	// tradeoff changes, widen or add a generation to the cookie token instead.
+	// Replacing crypto/rand.Reader to force a repeat is dependency fault injection,
+	// not a supported-use reproduction of the default random source's behavior.
 	for sess == nil {
 		sessionID := jw.nonZeroRandomLocked()
 		if _, ok := jw.sessions[sessionID]; !ok {
@@ -449,9 +455,14 @@ func (jw *Jaws) newSessionLocked(remoteIP netip.Addr, secure bool) (sess *Sessio
 	return
 }
 
-func (jw *Jaws) deleteSession(sessionID key.Key) {
+// deleteSessionIfCurrent unregisters sess only while it still owns its ID.
+// Session pointers can outlive registration, so a stale Close must not remove a
+// later Session that received the same numeric ID.
+func (jw *Jaws) deleteSessionIfCurrent(sess *Session) {
 	jw.mu.Lock()
-	delete(jw.sessions, sessionID)
+	if jw.sessions[sess.sessionID] == sess {
+		delete(jw.sessions, sess.sessionID)
+	}
 	jw.mu.Unlock()
 }
 

--- a/session_test.go
+++ b/session_test.go
@@ -231,7 +231,7 @@ func TestSession_AddCookieRejectsUnavailableSession(t *testing.T) {
 				sess.mu.Lock()
 				sess.deadline = time.Now().Add(24 * time.Hour)
 				sess.mu.Unlock()
-				jw.deleteSession(sess.sessionID)
+				jw.deleteSessionIfCurrent(sess)
 			},
 			wantRegistered: false,
 			wantDead:       false,
@@ -1758,6 +1758,47 @@ func TestSession_CloseDetachesRequestSession(t *testing.T) {
 	}
 
 	jw.recycle(rq)
+}
+
+func TestSession_CloseDoesNotDeleteSameIDReplacement(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+	go jw.Serve()
+	waitForServeLoop(t, jw)
+
+	const sessionID = key.Key(0x1122334455667788)
+	remoteIP := netip.MustParseAddr("192.0.2.1")
+	stale := newSession(jw, sessionID, remoteIP, false)
+	jw.mu.Lock()
+	jw.sessions[sessionID] = stale
+	jw.mu.Unlock()
+	jw.deleteSessionIfCurrent(stale)
+
+	replacement := newSession(jw, sessionID, remoteIP, false)
+	jw.mu.Lock()
+	jw.sessions[sessionID] = replacement
+	jw.mu.Unlock()
+
+	if cookie := stale.Close(); cookie == nil || cookie.MaxAge != -1 {
+		t.Fatalf("stale Close cookie = %#v, want deletion cookie", cookie)
+	}
+	if got := jw.SessionCount(); got != 1 {
+		t.Fatalf("SessionCount() = %d, want replacement retained", got)
+	}
+	request := httptest.NewRequest(http.MethodGet, "http://example.test/", nil)
+	request.RemoteAddr = remoteIP.String() + ":1234"
+	request.AddCookie(replacement.Cookie())
+	if got := jw.GetSession(request); got != replacement {
+		t.Fatalf("GetSession() = %p, want replacement %p", got, replacement)
+	}
+
+	replacement.Close()
+	if got := jw.SessionCount(); got != 0 {
+		t.Fatalf("SessionCount() after current Close = %d, want 0", got)
+	}
 }
 
 func TestSession_ReplacesOld(t *testing.T) {


### PR DESCRIPTION
## Summary

- unregister a Session only when the registry still contains that exact `*Session`
- preserve a later same-ID replacement when a retained stale Session is closed
- record the deliberate retired-ID reuse tradeoff beside allocation, including why forcing `crypto/rand.Reader` is dependency fault injection rather than a supported-use reproduction
- add a deterministic internal ABA regression without replacing the random source

## Scope

#306 is closed as invalid because forcing the process-global CSPRNG does not meet the supported-use reproduction requirement. This PR retains the independently useful stale-handle deletion hardening. It intentionally does not change the 64-bit cookie token or prevent retired cookie IDs from being reissued.

## Verification

- `go generate ./...`
- `gofmt -l .`
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec -quiet ./...`
- `JAWS_REQUIRE_NODE=1 go test -race -count=1 -coverprofile=/private/tmp/jaws-issue-306-coverage.out ./...`
- `JAWS_REQUIRE_NODE=1 go test -count=1 ./...`
- `go build -v ./...`
- `GOOS=linux GOARCH=386 CGO_ENABLED=0 go test -count=1 -exec=/usr/bin/true ./lib/bind/... ./lib/ui/...`
- focused regression repeated 20 times under the race detector
- rendered `go doc` review for `Session.Close`, `Jaws.NewSession`, and `Session.ID`

Refs #306.
