### PR TITLE
setup: ignore nil SetupFunc extras

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -42,6 +42,8 @@ func makeAbsPath(prefix string, u *url.URL) *url.URL {
 // []*staticserve.StaticServe URL resources, or a setup function matching
 // [SetupFunc] such as jawsboot.Setup.
 //
+// A nil [SetupFunc] extra is ignored.
+//
 // It calls [Jaws.GenerateHeadHTML] with the final list of URLs, with any
 // relative URL paths prefixed with prefix.
 //
@@ -90,10 +92,12 @@ func (jw *Jaws) Setup(handleFn HandleFunc, prefix string, extras ...any) (err er
 		case *staticserve.StaticServe:
 			handleStaticServe(extra)
 		case SetupFunc:
-			setupURLs, setupErr := extra(jw, setupHandleFn, prefix)
-			err = errors.Join(err, setupErr)
-			for _, u := range setupURLs {
-				urls = append(urls, makeAbsPath(prefix, u))
+			if extra != nil {
+				setupURLs, setupErr := extra(jw, setupHandleFn, prefix)
+				err = errors.Join(err, setupErr)
+				for _, u := range setupURLs {
+					urls = append(urls, makeAbsPath(prefix, u))
+				}
 			}
 		default:
 			err = errors.Join(err, fmt.Errorf("jaws.Setup: expected a string, *url.URL, *staticserve.StaticServe, []*staticserve.StaticServe or jaws.SetupFunc, not %T", extra))

--- a/setup_external_test.go
+++ b/setup_external_test.go
@@ -1,0 +1,43 @@
+package jaws_test
+
+import (
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/linkdata/jaws"
+)
+
+func TestJawsSetupIgnoresNilSetupFunc(t *testing.T) {
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+
+	var nilSetup jaws.SetupFunc
+	if err = jw.Setup(nil, "", nilSetup); err != nil {
+		t.Fatalf("Setup(nil SetupFunc) error = %v, want nil", err)
+	}
+
+	firstErr := errors.New("first setup error")
+	secondErr := errors.New("second setup error")
+	var calls int
+	first := jaws.SetupFunc(func(_ *jaws.Jaws, _ jaws.HandleFunc, _ string) (urls []*url.URL, err error) {
+		calls++
+		err = firstErr
+		return
+	})
+	second := jaws.SetupFunc(func(_ *jaws.Jaws, _ jaws.HandleFunc, _ string) (urls []*url.URL, err error) {
+		calls++
+		err = secondErr
+		return
+	})
+	err = jw.Setup(nil, "", first, nilSetup, second)
+	if calls != 2 {
+		t.Fatalf("Setup called %d non-nil setup functions, want 2", calls)
+	}
+	if !errors.Is(err, firstErr) || !errors.Is(err, secondErr) {
+		t.Fatalf("Setup error = %v, want both setup errors", err)
+	}
+}


### PR DESCRIPTION
## Summary

- ignore typed-nil `SetupFunc` extras instead of invoking them and panicking
- document the nil-extra behavior on `Jaws.Setup`
- add a public-API regression proving nil-only success, continued callback processing, and preserved error accumulation

## Verification

- `go generate ./...`
- `gofmt -l .`
- `gofumpt -l .`
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec -quiet ./...`
- `go test -race . -run '^TestJawsSetupIgnoresNilSetupFunc$' -count=20`
- `JAWS_REQUIRE_NODE=1 go test -race -count=1 -coverprofile=/private/tmp/jaws-issue-307-coverage.out ./...`
- `JAWS_REQUIRE_NODE=1 go test -count=1 ./...`
- `go build -v ./...`
- `GOOS=linux GOARCH=386 CGO_ENABLED=0 go test -count=1 -exec=/usr/bin/true ./lib/bind/... ./lib/ui/...`
- rendered `go doc` review for `Jaws.Setup` and `SetupFunc`

Closes #307.
