### PR TITLE
htmlio: normalize NUL attribute values

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -366,7 +366,7 @@ The framework uses Go's `template.HTML` type to distinguish trusted HTML from un
 - **Input widgets** (Text, Textarea, Checkbox, Range, etc.) use `SetValue()` → sends `Value` command → client updates live form state (`value`, `checked`, or `selected`, depending on the element), not HTML
 - **Display widgets** (Span, Div, Label, etc.) use `SetInner()` → sends `Inner` command → client sets `elem.innerHTML`
 - `SetInner()` accepts `template.HTML`, meaning the developer has explicitly marked the content as trusted
-- Initial HTML rendering escapes generated attribute values with HTML entities and canonicalizes U+0000 to U+FFFD (`htmlio.AppendAttrValue`)
+- Initial HTML rendering escapes generated attribute values with HTML entities (`htmlio.AppendAttrValue`)
 
 **Convenience path — plain strings are trusted too.** The HTML-inner widget
 constructors and `RequestWriter` helpers (`NewSpan`/`Span`, `NewDiv`/`Div`, `A`,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -366,7 +366,7 @@ The framework uses Go's `template.HTML` type to distinguish trusted HTML from un
 - **Input widgets** (Text, Textarea, Checkbox, Range, etc.) use `SetValue()` → sends `Value` command → client updates live form state (`value`, `checked`, or `selected`, depending on the element), not HTML
 - **Display widgets** (Span, Div, Label, etc.) use `SetInner()` → sends `Inner` command → client sets `elem.innerHTML`
 - `SetInner()` accepts `template.HTML`, meaning the developer has explicitly marked the content as trusted
-- Initial HTML rendering escapes generated attribute values with HTML entities (`htmlio.AppendAttrValue`)
+- Initial HTML rendering escapes generated attribute values with HTML entities and canonicalizes U+0000 to U+FFFD (`htmlio.AppendAttrValue`)
 
 **Convenience path — plain strings are trusted too.** The HTML-inner widget
 constructors and `RequestWriter` helpers (`NewSpan`/`Span`, `NewDiv`/`Div`, `A`,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/linkdata/jaws
 
-go 1.25
+go 1.25.0
 
 require (
 	github.com/coder/websocket v1.8.15
@@ -8,6 +8,7 @@ require (
 	github.com/linkdata/jq v0.2.0
 	github.com/linkdata/secureheaders v1.5.0
 	github.com/linkdata/staticserve v1.1.8
+	golang.org/x/net v0.58.0
 )
 
 require github.com/petermattis/goid v0.0.0-20260330135022-df67b199bc81 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,3 +11,5 @@ github.com/linkdata/staticserve v1.1.8/go.mod h1:uOUrHkbNEkVXWvuw7gk0ydm39r9Y1Re
 github.com/petermattis/goid v0.0.0-20250813065127-a731cc31b4fe/go.mod h1:pxMtw7cyUw6B2bRH0ZBANSPg+AoSud1I1iyJHI69jH4=
 github.com/petermattis/goid v0.0.0-20260330135022-df67b199bc81 h1:WDsQxOJDy0N1VRAjXLpi8sCEZRSGarLWQevDxpTBRrM=
 github.com/petermattis/goid v0.0.0-20260330135022-df67b199bc81/go.mod h1:pxMtw7cyUw6B2bRH0ZBANSPg+AoSud1I1iyJHI69jH4=
+golang.org/x/net v0.58.0 h1:ynWG7rqYi4ccpTEuPZ2QGWHktVEM9DMCj9yzDE0Q7To=
+golang.org/x/net v0.58.0/go.mod h1:YwCddHnFlT7eLQqVprV19OnhLGtc5xOKgE0RyqgfWAU=

--- a/lib/htmlio/doc.go
+++ b/lib/htmlio/doc.go
@@ -1,9 +1,7 @@
 // Package htmlio writes the small HTML fragments used by standard JaWS widgets.
 //
-// Attribute values passed as ordinary strings are escaped for HTML source.
-// U+0000 is canonicalized to U+FFFD, and carriage returns are encoded so HTML
-// parsing preserves them. HTML tag names and template.HTMLAttr fragments are
-// trusted input and are written as-is; callers must not derive them from
-// untrusted user data. Use [Attr] or [AppendAttr] to build a fragment whose
-// value is escaped.
+// Generated attribute values are encoded by [AppendAttrValue]. HTML tag names
+// and template.HTMLAttr fragments are trusted and written as-is; callers must
+// not derive them from untrusted data. Use [Attr] or [AppendAttr] to build an
+// attribute whose value is escaped.
 package htmlio

--- a/lib/htmlio/doc.go
+++ b/lib/htmlio/doc.go
@@ -1,7 +1,9 @@
 // Package htmlio writes the small HTML fragments used by standard JaWS widgets.
 //
-// Attribute values passed as ordinary strings are HTML-escaped by this package.
-// HTML tag names and template.HTMLAttr fragments are trusted input and are
-// written as-is; callers must not derive them from untrusted user data. Use
-// [Attr] or [AppendAttr] to build a fragment whose value is escaped.
+// Attribute values passed as ordinary strings are escaped for HTML source.
+// U+0000 is canonicalized to U+FFFD, and carriage returns are encoded so HTML
+// parsing preserves them. HTML tag names and template.HTMLAttr fragments are
+// trusted input and are written as-is; callers must not derive them from
+// untrusted user data. Use [Attr] or [AppendAttr] to build a fragment whose
+// value is escaped.
 package htmlio

--- a/lib/htmlio/writehtml.go
+++ b/lib/htmlio/writehtml.go
@@ -83,18 +83,13 @@ func AppendAttrs(b []byte, attrs []template.HTMLAttr) []byte {
 
 // AppendAttrValue appends value as a double-quoted HTML attribute value.
 //
-// The value parameter must be the unescaped logical attribute value. It is
-// escaped for HTML source output by this function. Use [Attr] or [AppendAttr]
-// to build a complete name=value fragment.
-//
-// Carriage returns are emitted as the numeric character reference &#13;, because
-// browser input-stream preprocessing would otherwise rewrite a raw CR to LF
-// before parsing and change the value the DOM reports.
-//
-// U+0000 is canonicalized to U+FFFD because HTML source parsing produces
-// U+FFFD for both a raw NUL and a zero-valued character reference.
+// The value must be unescaped. It is escaped for HTML source, with carriage
+// returns emitted as &#13; and U+0000 replaced by U+FFFD. Use [Attr] or
+// [AppendAttr] to build a complete attribute.
 func AppendAttrValue(b []byte, value string) []byte {
 	b = append(b, '"')
+	// The template escaper replaces NUL with U+FFFD. A zero-valued character
+	// reference parses to the same value, so neither source form preserves NUL.
 	b = appendEscapeCR(b, template.HTMLEscapeString(value))
 	b = append(b, '"')
 	return b
@@ -104,8 +99,8 @@ func AppendAttrValue(b []byte, value string) []byte {
 //
 // The name parameter is written verbatim with no escaping or validation and
 // MUST NOT be derived from untrusted data, or it becomes an HTML-injection
-// primitive. The value parameter must be the unescaped logical attribute value
-// and is processed as documented by [AppendAttrValue].
+// primitive. The value parameter must be unescaped and is encoded by
+// [AppendAttrValue].
 func AppendAttr(b []byte, name, value string) []byte {
 	b = append(b, ' ')
 	b = append(b, name...)
@@ -118,8 +113,8 @@ func AppendAttr(b []byte, name, value string) []byte {
 //
 // The name parameter is written verbatim with no escaping or validation and
 // MUST NOT be derived from untrusted data, or it becomes an HTML-injection
-// primitive. The value parameter must be the unescaped logical attribute value
-// and is processed as documented by [AppendAttrValue].
+// primitive. The value parameter must be unescaped and is encoded by
+// [AppendAttrValue].
 func Attr(name, value string) template.HTMLAttr {
 	// AppendAttr writes a leading space (it is meant for joining onto a tag);
 	// [1:] drops that space since Attr returns the attribute on its own.
@@ -144,11 +139,10 @@ func appendHTMLTag(b []byte, jid jid.Jid, htmlTag, typeAttr, valueAttr string, a
 //
 // The htmlTag parameter is trusted and written verbatim with no escaping or
 // validation; it MUST NOT be derived from untrusted data. The typeAttr and
-// valueAttr parameters must be unescaped logical values and are processed as
-// documented by [AppendAttrValue]. The attrs parameter contains trusted raw
-// attribute fragments and is written verbatim with no escaping; it MUST NOT
-// contain untrusted data. Use [Attr] or [AppendAttr] to build attribute
-// fragments with an escaped value.
+// valueAttr parameters must be unescaped and are encoded by [AppendAttrValue].
+// The attrs parameter contains trusted raw attribute fragments and is written
+// verbatim with no escaping; it MUST NOT contain untrusted data. Use [Attr] or
+// [AppendAttr] to build attribute fragments with an escaped value.
 func WriteHTMLTag(w io.Writer, jid jid.Jid, htmlTag, typeAttr, valueAttr string, attrs []template.HTMLAttr) (err error) {
 	b := appendHTMLTag(nil, jid, htmlTag, typeAttr, valueAttr, attrs)
 	_, err = w.Write(b)
@@ -159,12 +153,11 @@ func WriteHTMLTag(w io.Writer, jid jid.Jid, htmlTag, typeAttr, valueAttr string,
 // raw attribute fragments. The id attribute is emitted only for a positive
 // [jid.Jid].
 //
-// The typeAttr and valueAttr parameters must be unescaped logical values and
-// are processed as documented by [AppendAttrValue]. The attrs parameter
-// contains trusted raw attribute fragments and is written verbatim with no
-// escaping; it MUST NOT contain untrusted data, nor must typeAttr be derived
-// from untrusted data. Use [Attr] or [AppendAttr] to build attribute fragments
-// with an escaped value.
+// The typeAttr and valueAttr parameters must be unescaped and are encoded by
+// [AppendAttrValue]. The attrs parameter contains trusted raw attribute
+// fragments and is written verbatim with no escaping; it MUST NOT contain
+// untrusted data. Use [Attr] or [AppendAttr] to build attribute fragments with
+// an escaped value.
 func WriteHTMLInput(w io.Writer, jid jid.Jid, typeAttr, valueAttr string, attrs []template.HTMLAttr) (err error) {
 	return WriteHTMLTag(w, jid, "input", typeAttr, valueAttr, attrs)
 }
@@ -182,28 +175,24 @@ func WriteHTMLInput(w io.Writer, jid jid.Jid, typeAttr, valueAttr string, attrs 
 // after the start tag. The parser strips that one LF, so a leading LF in
 // innerHTML is preserved instead of being consumed.
 //
-// Carriage returns in innerHTML are written verbatim, not encoded. A textarea
-// reports its value with every CR and CRLF normalized to LF (the HTML standard's
-// textarea value normalization), so carriage returns in textarea content cannot
-// round-trip through the value the browser sends back. Encoding them would also
-// be unsafe for pre, whose trusted markup may include script, comment, or other
-// contexts where character references are not decoded. Use [AppendAttrValue] for
-// logical values that must retain carriage returns.
+// Carriage returns in innerHTML are written verbatim. Browsers normalize them
+// to LF in textarea values. Use [AppendAttrValue] for attribute values that must
+// retain carriage returns.
 //
 // The htmlTag parameter is trusted and written verbatim with no escaping or
 // validation; it MUST NOT be derived from untrusted data. The typeAttr parameter
-// must be an unescaped logical value and is processed as documented by
-// [AppendAttrValue]. The attrs parameter contains trusted raw attribute
-// fragments and is written verbatim with no escaping; it MUST NOT contain
-// untrusted data. Use [Attr] or [AppendAttr] to build attribute fragments with
-// an escaped value.
+// must be unescaped and is encoded by [AppendAttrValue]. The attrs parameter
+// contains trusted raw attribute fragments and is written verbatim with no
+// escaping; it MUST NOT contain untrusted data. Use [Attr] or [AppendAttr] to
+// build attribute fragments with an escaped value.
 func WriteHTMLInner(w io.Writer, jid jid.Jid, htmlTag, typeAttr string, innerHTML template.HTML, attrs ...template.HTMLAttr) (err error) {
 	b := appendHTMLTag(nil, jid, htmlTag, typeAttr, "", attrs)
 	if needClosingTag(htmlTag) {
 		// The HTML parser strips one LF right after a textarea/pre start tag.
 		// Provide that parser-consumed prefix so a leading LF in innerHTML is
-		// preserved instead of being consumed. Carriage returns are written
-		// verbatim; the doc comment explains why they are not encoded here.
+		// preserved instead of being consumed. Keep carriage returns verbatim:
+		// textarea values normalize them, while rewriting trusted pre content
+		// can alter script and comment data.
 		if isNewlineSensitive(htmlTag) {
 			b = append(b, '\n')
 		}

--- a/lib/htmlio/writehtml.go
+++ b/lib/htmlio/writehtml.go
@@ -1,7 +1,6 @@
 package htmlio
 
 import (
-	"html"
 	"html/template"
 	"io"
 	"strings"
@@ -91,9 +90,12 @@ func AppendAttrs(b []byte, attrs []template.HTMLAttr) []byte {
 // Carriage returns are emitted as the numeric character reference &#13;, because
 // browser input-stream preprocessing would otherwise rewrite a raw CR to LF
 // before parsing and change the value the DOM reports.
+//
+// U+0000 is canonicalized to U+FFFD because HTML source parsing produces
+// U+FFFD for both a raw NUL and a zero-valued character reference.
 func AppendAttrValue(b []byte, value string) []byte {
 	b = append(b, '"')
-	b = appendEscapeCR(b, html.EscapeString(value))
+	b = appendEscapeCR(b, template.HTMLEscapeString(value))
 	b = append(b, '"')
 	return b
 }
@@ -102,8 +104,8 @@ func AppendAttrValue(b []byte, value string) []byte {
 //
 // The name parameter is written verbatim with no escaping or validation and
 // MUST NOT be derived from untrusted data, or it becomes an HTML-injection
-// primitive. The value parameter must be the unescaped logical attribute value;
-// it is escaped for HTML source output by this function.
+// primitive. The value parameter must be the unescaped logical attribute value
+// and is processed as documented by [AppendAttrValue].
 func AppendAttr(b []byte, name, value string) []byte {
 	b = append(b, ' ')
 	b = append(b, name...)
@@ -116,8 +118,8 @@ func AppendAttr(b []byte, name, value string) []byte {
 //
 // The name parameter is written verbatim with no escaping or validation and
 // MUST NOT be derived from untrusted data, or it becomes an HTML-injection
-// primitive. The value parameter must be the unescaped logical attribute value;
-// it is escaped for HTML source output by this function.
+// primitive. The value parameter must be the unescaped logical attribute value
+// and is processed as documented by [AppendAttrValue].
 func Attr(name, value string) template.HTMLAttr {
 	// AppendAttr writes a leading space (it is meant for joining onto a tag);
 	// [1:] drops that space since Attr returns the attribute on its own.
@@ -142,11 +144,11 @@ func appendHTMLTag(b []byte, jid jid.Jid, htmlTag, typeAttr, valueAttr string, a
 //
 // The htmlTag parameter is trusted and written verbatim with no escaping or
 // validation; it MUST NOT be derived from untrusted data. The typeAttr and
-// valueAttr parameters must be unescaped logical values; they are escaped for
-// HTML source output. The attrs parameter contains trusted raw attribute
-// fragments and is written verbatim with no escaping; it MUST NOT contain
-// untrusted data. Use [Attr] or [AppendAttr] to build attribute fragments with
-// an escaped value.
+// valueAttr parameters must be unescaped logical values and are processed as
+// documented by [AppendAttrValue]. The attrs parameter contains trusted raw
+// attribute fragments and is written verbatim with no escaping; it MUST NOT
+// contain untrusted data. Use [Attr] or [AppendAttr] to build attribute
+// fragments with an escaped value.
 func WriteHTMLTag(w io.Writer, jid jid.Jid, htmlTag, typeAttr, valueAttr string, attrs []template.HTMLAttr) (err error) {
 	b := appendHTMLTag(nil, jid, htmlTag, typeAttr, valueAttr, attrs)
 	_, err = w.Write(b)
@@ -157,11 +159,12 @@ func WriteHTMLTag(w io.Writer, jid jid.Jid, htmlTag, typeAttr, valueAttr string,
 // raw attribute fragments. The id attribute is emitted only for a positive
 // [jid.Jid].
 //
-// The typeAttr and valueAttr parameters must be unescaped logical values; they
-// are escaped for HTML source output. The attrs parameter contains trusted raw
-// attribute fragments and is written verbatim with no escaping; it MUST NOT
-// contain untrusted data, nor must typeAttr be derived from untrusted data. Use
-// [Attr] or [AppendAttr] to build attribute fragments with an escaped value.
+// The typeAttr and valueAttr parameters must be unescaped logical values and
+// are processed as documented by [AppendAttrValue]. The attrs parameter
+// contains trusted raw attribute fragments and is written verbatim with no
+// escaping; it MUST NOT contain untrusted data, nor must typeAttr be derived
+// from untrusted data. Use [Attr] or [AppendAttr] to build attribute fragments
+// with an escaped value.
 func WriteHTMLInput(w io.Writer, jid jid.Jid, typeAttr, valueAttr string, attrs []template.HTMLAttr) (err error) {
 	return WriteHTMLTag(w, jid, "input", typeAttr, valueAttr, attrs)
 }
@@ -189,10 +192,11 @@ func WriteHTMLInput(w io.Writer, jid jid.Jid, typeAttr, valueAttr string, attrs 
 //
 // The htmlTag parameter is trusted and written verbatim with no escaping or
 // validation; it MUST NOT be derived from untrusted data. The typeAttr parameter
-// must be an unescaped logical value; it is escaped for HTML source output. The
-// attrs parameter contains trusted raw attribute fragments and is written
-// verbatim with no escaping; it MUST NOT contain untrusted data. Use [Attr] or
-// [AppendAttr] to build attribute fragments with an escaped value.
+// must be an unescaped logical value and is processed as documented by
+// [AppendAttrValue]. The attrs parameter contains trusted raw attribute
+// fragments and is written verbatim with no escaping; it MUST NOT contain
+// untrusted data. Use [Attr] or [AppendAttr] to build attribute fragments with
+// an escaped value.
 func WriteHTMLInner(w io.Writer, jid jid.Jid, htmlTag, typeAttr string, innerHTML template.HTML, attrs ...template.HTMLAttr) (err error) {
 	b := appendHTMLTag(nil, jid, htmlTag, typeAttr, "", attrs)
 	if needClosingTag(htmlTag) {

--- a/lib/htmlio/writehtml_test.go
+++ b/lib/htmlio/writehtml_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/linkdata/jaws/lib/htmlio"
 	"github.com/linkdata/jaws/lib/jid"
+	xhtml "golang.org/x/net/html"
 )
 
 func Test_WriteHTMLInner(t *testing.T) {
@@ -214,9 +215,10 @@ func Test_WriteHTMLInner_NewlineSensitivePrefix(t *testing.T) {
 
 // FuzzAppendAttrValue guards the escaping invariant: for arbitrary input, the
 // bytes between the bounding double quotes must contain no raw '"' or '<' that
-// could break out of the attribute value or open a new tag.
+// could break out of the attribute value or open a new tag, nor any raw NUL
+// that an HTML parser would silently replace.
 func FuzzAppendAttrValue(f *testing.F) {
-	for _, seed := range []string{"", `"`, "<", `"&<>'`, "plain", "<script>"} {
+	for _, seed := range []string{"", `"`, "<", `"&<>'`, "plain", "<script>", "a\x00b"} {
 		f.Add(seed)
 	}
 	f.Fuzz(func(t *testing.T, value string) {
@@ -226,6 +228,9 @@ func FuzzAppendAttrValue(f *testing.F) {
 		}
 		if inner := got[1 : len(got)-1]; strings.ContainsAny(inner, "\"<") {
 			t.Fatalf("AppendAttrValue(%q) inner value %q contains raw '\"' or '<'", value, inner)
+		}
+		if strings.IndexByte(got, 0) >= 0 {
+			t.Fatalf("AppendAttrValue(%q) = %q, contains raw NUL", value, got)
 		}
 	})
 }
@@ -305,9 +310,9 @@ func Test_WriteHTMLInput(t *testing.T) {
 }
 
 func TestAppendAttr(t *testing.T) {
-	value := `"&<>'\` + "\n"
+	value := `"&<>'\` + "\n\x00"
 	got := string(htmlio.AppendAttr(nil, "data-x", value))
-	want := " data-x=\"&#34;&amp;&lt;&gt;&#39;\\\n\""
+	want := " data-x=\"&#34;&amp;&lt;&gt;&#39;\\\n\uFFFD\""
 	if got != want {
 		t.Fatalf("AppendAttr() = %q, want %q", got, want)
 	}
@@ -317,10 +322,10 @@ func TestAppendAttr(t *testing.T) {
 }
 
 func TestAttr(t *testing.T) {
-	value := `"&<>'\` + "\n"
+	value := `"&<>'\` + "\n\x00"
 	var attr template.HTMLAttr = htmlio.Attr("data-x", value)
 	got := string(attr)
-	want := "data-x=\"&#34;&amp;&lt;&gt;&#39;\\\n\""
+	want := "data-x=\"&#34;&amp;&lt;&gt;&#39;\\\n\uFFFD\""
 	if got != want {
 		t.Fatalf("Attr() = %q, want %q", got, want)
 	}
@@ -357,7 +362,17 @@ func TestAppendAttrValue(t *testing.T) {
 			want:  `"&#34;&amp;&lt;&gt;&#39;"`,
 		},
 		{
-			// html.EscapeString leaves CR raw, but browser preprocessing would
+			name:  "plus remains verbatim",
+			value: "+",
+			want:  `"+"`,
+		},
+		{
+			name:  "invalid UTF-8 remains verbatim",
+			value: string([]byte{'a', 0xff, 'b'}),
+			want:  string([]byte{'"', 'a', 0xff, 'b', '"'}),
+		},
+		{
+			// HTML escaping leaves CR raw, but browser preprocessing would
 			// rewrite it to LF; it must be a numeric character reference instead.
 			name:  "carriage return is encoded",
 			value: "a\rb",
@@ -367,6 +382,36 @@ func TestAppendAttrValue(t *testing.T) {
 			name:  "CRLF encodes only the CR",
 			value: "a\r\nb",
 			want:  "\"a&#13;\nb\"",
+		},
+		{
+			name:  "NUL is canonicalized",
+			value: "a\x00b",
+			want:  "\"a\uFFFDb\"",
+		},
+		{
+			name:  "NUL and CR are both canonicalized",
+			value: "\x00\r\x00",
+			want:  "\"\uFFFD&#13;\uFFFD\"",
+		},
+		{
+			name:  "each NUL is canonicalized",
+			value: "\x00\x00",
+			want:  "\"\uFFFD\uFFFD\"",
+		},
+		{
+			name:  "existing replacement character is preserved",
+			value: "a\uFFFDb",
+			want:  "\"a\uFFFDb\"",
+		},
+		{
+			name:  "zero-valued character reference text remains text",
+			value: "&#0;",
+			want:  "\"&amp;#0;\"",
+		},
+		{
+			name:  "NUL composes with metacharacters and CR",
+			value: "\x00\"&<>'\r",
+			want:  "\"\uFFFD&#34;&amp;&lt;&gt;&#39;&#13;\"",
 		},
 	}
 	for _, tt := range tests {
@@ -413,19 +458,52 @@ func normalizeCR(s string) string {
 	return strings.ReplaceAll(s, "\r", "\n")
 }
 
-// TestAppendAttrValue_DOMRoundTrip verifies that a logical attribute value with
-// carriage returns survives a browser parse unchanged, as getAttribute reports
-// it. It models the two browser steps that would otherwise corrupt a raw CR:
-// input-stream preprocessing (CR/CRLF to LF) followed by tokenizer
-// character-reference decoding, the latter using the standard library
-// html.UnescapeString.
-func TestAppendAttrValue_DOMRoundTrip(t *testing.T) {
-	values := []string{"", "plain", "a\rb", "a\r\nb", "\rlead", "trail\r", "x\ry\rz", `"&<>'` + "\r"}
+func parsedAttr(t *testing.T, source, name string) string {
+	t.Helper()
+	doc, err := xhtml.Parse(strings.NewReader(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var findAttr func(*xhtml.Node) (string, bool)
+	findAttr = func(node *xhtml.Node) (string, bool) {
+		if node.Type == xhtml.ElementNode {
+			for _, attr := range node.Attr {
+				if attr.Key == name {
+					return attr.Val, true
+				}
+			}
+		}
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			if value, ok := findAttr(child); ok {
+				return value, true
+			}
+		}
+		return "", false
+	}
+	if value, ok := findAttr(doc); ok {
+		return value
+	}
+	t.Fatalf("attribute %q not found in parsed source %q", name, source)
+	return ""
+}
+
+// TestAttr_DOMValue verifies the DOM attribute value exposed by an HTML
+// parser. Carriage returns round-trip, while U+0000 is deliberately
+// canonicalized to the U+FFFD value required by HTML parsing.
+func TestAttr_DOMValue(t *testing.T) {
+	values := []string{
+		"", "plain", "a\rb", "a\r\nb", "\rlead", "trail\r", "x\ry\rz",
+		`"&<>'` + "\r", "a\x00b", "\x00\r\x00", "\x00\x00", "a\uFFFDb",
+		"&#0;", "\x00\"&<>'\r",
+	}
 	for _, value := range values {
-		src := string(htmlio.AppendAttrValue(nil, value))
-		inner := src[1 : len(src)-1] // strip the bounding double quotes
-		if got := html.UnescapeString(normalizeCR(inner)); got != value {
-			t.Errorf("attribute value %q round-tripped to %q via source %q", value, got, src)
+		src := string(htmlio.Attr("data-x", value))
+		if strings.IndexByte(src, 0) >= 0 {
+			t.Fatalf("Attr(%q) = %q, contains raw NUL", value, src)
+		}
+		got := parsedAttr(t, "<div "+src+"></div>", "data-x")
+		if want := strings.ReplaceAll(value, "\x00", "\uFFFD"); got != want {
+			t.Errorf("attribute value %q parsed as %q, want %q (source %q)", value, got, want, src)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- canonicalize U+0000 to U+FFFD at the shared HTML attribute-value encoder so generated source contains no raw NUL
- preserve the existing CR `&#13;` handling and byte-for-byte behavior for HTML metacharacters, `+`, and invalid UTF-8
- document the source-parsing contract for `AppendAttrValue` and every generated-value helper that delegates to it
- add exact-source, fuzz, and real HTML-parser regressions covering `AppendAttrValue`, `AppendAttr`, and `Attr`

## Scope and compatibility

This changes logical string values rendered into initial HTML source. Trusted raw `template.HTMLAttr` fragments, trusted inner HTML, tag and attribute names, and live DOM update commands remain unchanged.

The DOM regression uses the official `golang.org/x/net/html` parser only from tests. Go has no test-only module requirements, so `x/net` appears as a direct module dependency; `go mod tidy` also normalizes the existing `go 1.25` directive to `go 1.25.0` without changing the minimum language version.

## Verification

- confirmed the new exact-source and fuzz regressions fail before the production change
- `go generate ./...`
- `gofmt -l .`
- `gofumpt -l .`
- `git diff --check`
- `go mod tidy -diff`
- `go mod verify`
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`
- `go test -race -count=1 -coverprofile=/private/tmp/jaws-issue-308-htmlio.cover ./lib/htmlio` (100.0% statements)
- focused attribute regressions repeated 50 times under the race detector
- `go test ./lib/htmlio -run '^$' -fuzz '^FuzzAppendAttrValue$' -fuzztime=10s` (about 6.9 million executions)
- `JAWS_REQUIRE_NODE=1 go test -race -count=1 -coverprofile=/private/tmp/jaws-issue-308-coverage.out ./...`
- `JAWS_REQUIRE_NODE=1 go test -count=1 ./...`
- `go build -v ./...`
- `GOOS=linux GOARCH=386 CGO_ENABLED=0 go test -count=1 -exec=/usr/bin/true ./lib/bind/... ./lib/ui/...`
- rendered `go doc` review for the package and every affected exported helper

Closes #308.
