### PR TITLE
websocket: document forwarded origin scheme requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -976,8 +976,15 @@ items explicitly:
   generic writes atomically. Configure an equivalent check and shared locker on
   every binding that exposes the same `Ptr` or reachable mutable backing state;
   server writes and `PathSetter` values bypass `ClientCheck`.
-* Enable `Jaws.TrustForwardedHeaders` only behind a single trusted reverse proxy
-  that overwrites `X-Forwarded-For`, `X-Real-IP` and `X-Forwarded-Proto`.
+* Behind a TLS-terminating proxy that forwards plain HTTP, enable
+  `Jaws.TrustForwardedHeaders`. Configure the proxy to remove client-supplied
+  forwarding headers and set `X-Forwarded-Proto` plus `X-Forwarded-For` or
+  `X-Real-IP` itself; JaWS also recognizes the scheme headers `X-Forwarded-Ssl`,
+  `Front-End-Https` and `Forwarded`, so the proxy must sanitize those too. The
+  forwarded scheme is used for WebSocket Origin validation; without it,
+  WebSocket upgrades from HTTPS pages are rejected with
+  `ErrWebsocketOriginWrongScheme`. Trust these headers only behind a single
+  reverse proxy you control.
 * Run the test suite both with and without `-race` before release: `-race`
   exercises the deadlock lock-order detector and JaWS debug-gated checks, while a
   plain `go test` exercises the crash-safe release tag renderer that `-race` and

--- a/errors.go
+++ b/errors.go
@@ -99,7 +99,8 @@ var ErrJavascriptDisabled = errors.New("javascript is disabled")
 // ErrWebsocketOriginMissing is returned when a WebSocket request has no Origin header.
 var ErrWebsocketOriginMissing = errors.New("websocket request missing Origin header")
 
-// ErrWebsocketOriginWrongScheme is returned when a WebSocket Origin is not HTTP or HTTPS.
+// ErrWebsocketOriginWrongScheme is returned when a WebSocket Origin scheme is
+// unsupported or does not match the initial request's security.
 var ErrWebsocketOriginWrongScheme = errors.New("websocket Origin not http or https")
 
 // ErrWebsocketOriginWrongHost is returned when a WebSocket Origin host does not match the initial request host.

--- a/jaws.go
+++ b/jaws.go
@@ -104,9 +104,19 @@ type Jid = jid.Jid // convenience alias
 // unsynchronized write and is not supported. Methods document their own
 // concurrency behavior and may be called concurrently when stated.
 type Jaws struct {
-	CookieName            string     // Name for session cookies; defaults to a name derived from the executable ([assets.DefaultCookieName]), falling back to "jaws"
-	AutoSession           bool       // Create and associate a session during a successful WebSocket upgrade when a Request has none. Defaults to false.
-	TrustForwardedHeaders bool       // Trust X-Forwarded-* headers: governs the session cookie Secure flag (X-Forwarded-Proto) and the client IP used for session/request binding (X-Forwarded-For/X-Real-IP). Defaults to false; only enable behind a single reverse proxy you control that sets these headers.
+	CookieName  string // Name for session cookies; defaults to a name derived from the executable ([assets.DefaultCookieName]), falling back to "jaws"
+	AutoSession bool   // Create and associate a session during a successful WebSocket upgrade when a Request has none. Defaults to false.
+	// TrustForwardedHeaders enables trusted proxy header processing.
+	//
+	// It governs the session cookie Secure flag and WebSocket Origin scheme
+	// validation through the forwarding headers recognized by
+	// [secureheaders.RequestIsSecure], and the client IP used for session and
+	// request binding through X-Forwarded-For and X-Real-IP. Behind a proxy that
+	// terminates TLS and forwards plain HTTP, enable it and have the proxy sanitize
+	// forwarding headers and set the scheme and client IP itself, or HTTPS-page
+	// WebSocket upgrades are rejected. Defaults to false; enable only behind a
+	// single reverse proxy you control.
+	TrustForwardedHeaders bool
 	Logger                Logger     // Optional logger; [Jaws.Log] dispatches Error calls asynchronously and serially
 	Debug                 bool       // Set to true to enable debug info in generated HTML code. Call GenerateHeadHTML after changing it.
 	MakeAuth              MakeAuthFn // Function to create ui.With.Auth for Templates. If nil, templates get the fail-open DefaultAuth (IsAdmin()==true for everyone); set it to enforce authorization. See DefaultAuth.

--- a/request_test.go
+++ b/request_test.go
@@ -1581,10 +1581,12 @@ func TestRequest_ConnectFn(t *testing.T) {
 
 func TestRequest_validateWebSocketOrigin_MatchesInitialRequestOrigin(t *testing.T) {
 	tests := []struct {
-		name       string
-		initialURL string
-		origin     string
-		wantErr    error
+		name                  string
+		initialURL            string
+		forwardedProto        string
+		trustForwardedHeaders bool
+		origin                string
+		wantErr               error
 	}{
 		{
 			name:       "same origin http accepted",
@@ -1623,6 +1625,30 @@ func TestRequest_validateWebSocketOrigin_MatchesInitialRequestOrigin(t *testing.
 			wantErr:    ErrWebsocketOriginWrongScheme,
 		},
 		{
+			// A TLS-terminating proxy delivers a plain HTTP request. Its
+			// forwarded scheme is ignored until the caller opts in to trusting it.
+			name:           "untrusted forwarded HTTPS scheme rejected",
+			initialURL:     "http://example.test/page",
+			forwardedProto: "https",
+			origin:         "https://example.test",
+			wantErr:        ErrWebsocketOriginWrongScheme,
+		},
+		{
+			name:                  "trusted forwarded HTTPS scheme accepted",
+			initialURL:            "http://example.test/page",
+			forwardedProto:        "https",
+			trustForwardedHeaders: true,
+			origin:                "https://example.test",
+			wantErr:               nil,
+		},
+		{
+			name:                  "trusted proxy without forwarded HTTPS scheme rejected",
+			initialURL:            "http://example.test/page",
+			trustForwardedHeaders: true,
+			origin:                "https://example.test",
+			wantErr:               ErrWebsocketOriginWrongScheme,
+		},
+		{
 			name:       "missing origin rejected",
 			initialURL: "http://example.test/page",
 			origin:     "",
@@ -1652,6 +1678,7 @@ func TestRequest_validateWebSocketOrigin_MatchesInitialRequestOrigin(t *testing.
 				t.Fatal(err)
 			}
 			defer jw.Close()
+			jw.TrustForwardedHeaders = tt.trustForwardedHeaders
 
 			initialURL, err := url.Parse(tt.initialURL)
 			if err != nil {
@@ -1664,6 +1691,9 @@ func TestRequest_validateWebSocketOrigin_MatchesInitialRequestOrigin(t *testing.
 			// Server requests don't populate URL.Scheme/URL.Host, only Host.
 			initial := httptest.NewRequest(http.MethodGet, path, nil)
 			initial.Host = initialURL.Host
+			if tt.forwardedProto != "" {
+				initial.Header.Set("X-Forwarded-Proto", tt.forwardedProto)
+			}
 			if strings.EqualFold(initialURL.Scheme, "https") {
 				initial.TLS = &tls.ConnectionState{}
 			}


### PR DESCRIPTION
## Summary

- document that TrustForwardedHeaders governs WebSocket Origin scheme validation as well as cookies and client-IP binding
- explain the required TLS-terminating proxy configuration and forwarding-header sanitization
- pin rejection without trusted scheme information and acceptance with trusted X-Forwarded-Proto
- clarify that ErrWebsocketOriginWrongScheme also covers a mismatch with the initial request security

## Security

This keeps the strict fail-closed Origin scheme check. JaWS continues to ignore forwarded headers by default and only uses them when the application explicitly trusts a controlled reverse proxy.

## Verification

- go generate ./...
- go vet ./...
- gofmt and gofumpt clean
- staticcheck ./...
- golangci-lint run
- gosec ./...
- JAWS_REQUIRE_NODE=1 go test -race -coverprofile=/private/tmp/jaws-315.cover ./...
- JAWS_REQUIRE_NODE=1 go test ./...
- go build -v ./...
- go mod verify
- go mod tidy -diff
- Linux/386 cross-compilation for lib/bind and lib/ui tests

Closes #315.