### PR TITLE
assets: throttle reconnect-triggered reloads

### DIFF
--- a/lib/assets/jaws.js
+++ b/lib/assets/jaws.js
@@ -17,6 +17,8 @@ const jawsJidRx = /^[1-9]\d*$/;
 const jawsMaxJid = '9223372036854775807';
 // Milliseconds; bounds reconnect probes that never receive a network result.
 const jawsReconnectTimeout = 10 * 1000;
+// Minimum navigation age for a reconnect-triggered page reload.
+const jawsReconnectReloadMinPageAge = 60 * 1000;
 
 function jawsIsJid(v) {
 	if (typeof v === 'string' && v.startsWith(jawsIdPrefix)) {
@@ -376,11 +378,12 @@ function jawsLost() {
 }
 
 function jawsHandleReconnect(e) {
-	if (e.currentTarget.status === 204) {
+	// Reloading resets the navigation clock, so repeated failures enter the backoff.
+	if (e.currentTarget.status === 204 && performance.now() >= jawsReconnectReloadMinPageAge) {
 		window.location.reload();
-	} else {
-		jawsLost();
+		return;
 	}
+	jawsLost();
 }
 
 function jawsReconnect() {

--- a/lib/assets/js_test.go
+++ b/lib/assets/js_test.go
@@ -1929,6 +1929,7 @@ process.stdout.write(JSON.stringify({
 
 func TestJawsJS_ReconnectXHRResultsAreHandledOnce(t *testing.T) {
 	raw := runJawsJSSnippet(t, lostIndicatorStubs+`
+global.performance = { now: function() { return 60000; } };
 function FakeSocket() {}
 WebSocket = FakeSocket;
 jaws = new FakeSocket();
@@ -2079,6 +2080,65 @@ process.stdout.write(JSON.stringify({
 	}
 	if !strings.Contains(got.LostHTML, "Server connection lost") {
 		t.Fatalf("lost indicator = %q", got.LostHTML)
+	}
+}
+
+func TestJawsJS_ReconnectReloadUsesNavigationAge(t *testing.T) {
+	raw := runJawsJSSnippet(t, lostIndicatorStubs+`
+let navigationAge = 59999;
+global.performance = { now: function() { return navigationAge; } };
+let reloads = 0;
+window.location.reload = function() { reloads++; };
+const delays = [];
+setTimeout = function(fn, ms) {
+	delays.push(ms);
+};
+
+const results = [];
+function record(name) {
+	results.push({
+		name: name,
+		reloads: reloads,
+		delays: delays.slice(),
+		prepended: lostIndicatorPrepended
+	});
+}
+
+// A page just under the minimum age backs off.
+jawsHandleReconnect({ currentTarget: { status: 204 } });
+record("before minimum age");
+
+// The exact age boundary permits a reload.
+navigationAge = 60000;
+jawsHandleReconnect({ currentTarget: { status: 204 } });
+record("at minimum age");
+
+// Simulate the fresh navigation, including its new document.
+navigationAge = 0;
+lostIndicatorElem = null;
+jawsHandleReconnect({ currentTarget: { status: 204 } });
+record("fresh navigation");
+
+process.stdout.write(JSON.stringify(results));
+`)
+
+	type result struct {
+		Name      string `json:"name"`
+		Reloads   int    `json:"reloads"`
+		Delays    []int  `json:"delays"`
+		Prepended int    `json:"prepended"`
+	}
+	var got []result
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &got); err != nil {
+		t.Fatalf("failed to parse snippet output %q: %v", raw, err)
+	}
+	want := []result{
+		{Name: "before minimum age", Delays: []int{1000}, Prepended: 1},
+		{Name: "at minimum age", Reloads: 1, Delays: []int{1000}, Prepended: 1},
+		{Name: "fresh navigation", Reloads: 1, Delays: []int{1000, 1000}, Prepended: 2},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("reconnect reload timing = %+v, want %+v", got, want)
 	}
 }
 


### PR DESCRIPTION
Fixes #316.

A successful reconnect probe reloads only after the current navigation is at least one minute old. Because a reload resets the monotonic navigation clock, persistent WebSocket handshake failures enter the existing visible reconnect backoff instead of immediately reloading again. Long-lived pages can still reload immediately when their connection later fails.

This deliberately uses no persistent browser storage: `performance.now()` provides the navigation-scoped clock needed to bound the loop without stored state or parsing.

Tests cover the 59,999 ms backoff, exact 60-second reload boundary, fresh-navigation reset, positive retry delay, and lost-connection indicator.

Verification:
- `go generate ./...`
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec -quiet ./...`
- `JAWS_REQUIRE_NODE=1 go test -race -coverprofile=... ./...`
- `JAWS_REQUIRE_NODE=1 go test ./...`
- `go build ./...`
- `gofmt -l .` / `gofumpt -l .`
- `node --check lib/assets/jaws.js`