### PR TITLE
docs: correct API edge-case contracts

### DIFF
--- a/.agents/skills/jaws/SKILL.md
+++ b/.agents/skills/jaws/SKILL.md
@@ -179,12 +179,10 @@ These are the two usual building blocks for widget handlers passed to `$.Button`
   `tag.TagGetter` implementations are unsupported.
 - JaWS does not serialize `JawsGetTag` calls. A getter used concurrently must synchronize its
   state and safely publish any returned containers.
-- `ui.JsVar` is the one in-tree initialization case: `JawsGetTag` returns nil before its first
-  render initializes the dirty tag, and that nil is not a dirty target. A getter in its nil phase
-  is therefore not usable as a tag: passing a not-yet-rendered `JsVar` as a tag to another widget
-  expands to no keys, so that widget registers under nothing and a later dirty of the JsVar never
-  reaches it. Render the JsVar first, or tag the other widget with an independent value. `ui.Object`
-  propagates the phase of any chained getter that has one.
+- `ui.JsVar.JawsGetTag` returns nil until `JawsRender` resolves a usable dirty tag; a failed
+  render may resolve it. While it is nil, using the JsVar as a tag registers no keys, and later
+  resolution is not retroactive. Render it first or use an independent tag. `ui.Object` propagates
+  the phase of any chained getter that has one.
 - `tag.TagExpand` rejects exactly these as tags: `string`, `bool`, `int`/`int8`/`int16`/`int32`/`int64`,
   `uint`/`uint8`/`uint16`/`uint32`/`uint64`, `float32`/`float64`, `template.HTML`, `template.HTMLAttr`,
   `jid.Jid` and `key.Key`. It is a switch on exact types, so aliases of a rejected type are rejected,

--- a/README.md
+++ b/README.md
@@ -536,8 +536,9 @@ JaWS can periodically ping active WebSocket connections to detect peers
 that disappeared without a close handshake.
 
 Set `Jaws.WebSocketPingInterval` to control this. The default is
-`jaws.DefaultWebSocketPingInterval` (1 minute). Set it to `0` or a
-negative value to disable keepalive pings.
+`jaws.DefaultWebSocketPingInterval` (1 minute). A non-positive value disables
+pings; the application must then detect and cancel unresponsive Requests to
+bound queued updates.
 
 ### Safe to call before `Serve()`
 

--- a/errors.go
+++ b/errors.go
@@ -9,7 +9,8 @@ import (
 	"github.com/linkdata/jaws/lib/key"
 )
 
-// ErrServeAlreadyRunning indicates the JaWS processing loop is already running.
+// ErrServeAlreadyRunning reports an overlapping [Jaws.Serve] or
+// [Jaws.ServeWithTimeout] call.
 var ErrServeAlreadyRunning = errors.New("serve loop already running")
 
 // ErrValueUnchanged reports a successful no-op set: there was no error, but the

--- a/jaws.go
+++ b/jaws.go
@@ -126,8 +126,13 @@ type Jaws struct {
 	// method recognized by [context.AfterFunc], that method and its returned stop
 	// function must return promptly and must not synchronously call this Jaws or
 	// one of its Requests, or wait for work that does. See [Request.SetContext].
-	BaseContext             context.Context
-	WebSocketPingInterval   time.Duration // Interval between keepalive pings on active WebSocket connections. Defaults to DefaultWebSocketPingInterval. Set <=0 to disable keepalive pings.
+	BaseContext context.Context
+	// WebSocketPingInterval controls keepalive pings on active WebSocket connections.
+	//
+	// It defaults to [DefaultWebSocketPingInterval]. A non-positive value disables
+	// pings; the application must then detect and cancel each unresponsive
+	// [Request] to bound queued updates.
+	WebSocketPingInterval   time.Duration
 	MaxPendingRequestsPerIP int           // Maximum number of unclaimed Requests per client IP. Defaults to DefaultMaxPendingRequestsPerIP. Set <=0 to disable the cap.
 	webSocketTimeout        time.Duration // timeout duration passed to ServeWith
 	maintenanceInterval     time.Duration // Serve maintenance tick interval; set by ServeWithTimeout and read under mu, zero until Serve starts
@@ -349,15 +354,11 @@ func (jw *Jaws) Log(err error) error {
 	return err
 }
 
-// MustLog reports an error or panics when no [Jaws.Logger] is configured.
+// MustLog passes a non-nil err to [Jaws.Log], or panics if no [Jaws.Logger] is
+// configured.
 //
-// A non-nil err is passed to [Jaws.Log] when jw and the Logger are non-nil.
-// Otherwise MustLog panics synchronously with err. MustLog has no effect if err
-// is nil, including on a nil receiver.
-//
-// Some update-time paths cannot return errors to their caller and report them
-// through MustLog. Set [Jaws.Logger] when those errors should be logged instead
-// of treated as fatal programming errors.
+// A nil err has no effect, including on a nil receiver. With a configured
+// Logger, errors submitted after shutdown begins are discarded by Log.
 func (jw *Jaws) MustLog(err error) {
 	if err != nil {
 		if jw != nil && jw.Logger != nil {
@@ -368,13 +369,8 @@ func (jw *Jaws) MustLog(err error) {
 	}
 }
 
-// reportMisuse reports a violated API contract (a programming error).
-//
-// It reports err through [Jaws.MustLog] (which queues it, or panics if no Logger
-// is set) and, in debug builds, additionally panics to fail fast. So in production
-// with a Logger configured the mistake is queued and the caller continues without
-// applying the offending operation, while debug builds and unconfigured servers
-// still stop on it.
+// reportMisuse passes an API contract violation to MustLog and panics in debug
+// or race builds.
 func (jw *Jaws) reportMisuse(err error) {
 	jw.MustLog(err)
 	if deadlock.Debug {

--- a/lib/named/namedbool.go
+++ b/lib/named/namedbool.go
@@ -75,8 +75,7 @@ func (nb *Bool) JawsGet(elem *jaws.Element) (yes bool) {
 // whether nb is currently one of its members. See [BoolArray.WriteLocked] for
 // the restrictions on using a removed Bool.
 //
-// It returns [jaws.ErrValueUnchanged] if checked already matched the current
-// state.
+// It returns [jaws.ErrValueUnchanged] if no checked state changes.
 func (nb *Bool) JawsSet(elem *jaws.Element, checked bool) (err error) {
 	nba := nb.nba
 	// Lock ordering invariant: when both locks are needed, the owning BoolArray's

--- a/lib/named/namedboolarray.go
+++ b/lib/named/namedboolarray.go
@@ -49,26 +49,19 @@ func (nba *BoolArray) ReadLocked(fn func(nbl []*Bool)) {
 	fn(nba.data)
 }
 
-// WriteLocked calls fn with the [BoolArray] locked for writing and replaces
-// the array contents with the returned values.
+// WriteLocked calls fn with the [BoolArray] locked for writing and replaces its
+// contents with the values fn returns.
 //
-// Ownership of the returned slice and its backing array transfers to the
-// BoolArray when fn returns; callers must not retain or access that storage
-// afterward. Nil entries are discarded without changing the relative order of
-// non-nil entries.
+// Nil entries are removed from fn's result in place, preserving order, before
+// it is copied. The backing array passed to fn is cleared before return, so
+// retained aliases contain nil values.
 //
-// Omitting a [Bool] from the returned slice does not detach it from nba:
-// [Bool.Array] continues to return nba, and [Bool.JawsSet] continues to apply
-// nba's single-select and dirtying behavior. Structural removal is supported
-// only after every live UI element backed by the Bool has been removed and no
-// event for it can remain in flight. Do not call Bool.JawsSet while the Bool is
-// absent; reinsert it into the same array before using it as an event setter.
+// Omitting a [Bool] does not change [Bool.Array]. Removal is supported only
+// after its live UI elements are removed and no event can remain in flight.
+// Reinsert it before calling [Bool.JawsSet].
 //
-// As with [BoolArray.ReadLocked], fn must not call other [BoolArray] methods or
-// [Bool.JawsSet] (they re-acquire the same non-reentrant nba mutex and deadlock);
-// operate only on the provided slice and the *[Bool] methods that take just the
-// Bool's own mutex (see [BoolArray.ReadLocked]). The exclusive lock held here
-// serializes [Bool.Set] across concurrent WriteLocked calls.
+// fn must not call methods on nba or [Bool.JawsSet] on an associated [Bool];
+// doing so deadlocks. It may call other Bool methods, including [Bool.Set].
 func (nba *BoolArray) WriteLocked(fn func(nbl []*Bool) []*Bool) {
 	nba.mu.Lock()
 	defer nba.mu.Unlock()

--- a/lib/templatereloader/templatereloader.go
+++ b/lib/templatereloader/templatereloader.go
@@ -14,8 +14,8 @@ import (
 // [TemplateReloader.Lookup].
 const reloadInterval = time.Second
 
-// TemplateReloader reloads and reparses templates if more than one second
-// has passed since the last reload.
+// TemplateReloader reparses templates from disk at most once per second and is
+// safe for concurrent use.
 type TemplateReloader struct {
 	// path is the glob templates are reparsed from. It is set once by create and
 	// read under mu during a reload; [TemplateReloader.Path] exposes it read-only.
@@ -73,22 +73,14 @@ func create(debug bool, fsys fs.FS, fpath, relpath string) (tl jaws.TemplateLook
 	return
 }
 
-// Lookup returns the named template, reparsing the templates from disk first
-// when more than one second has passed since the last reload.
+// Lookup returns the named template, reparsing from disk when the reload
+// interval has elapsed.
 //
-// If a reload fails to parse (for example while a template file is being
-// edited), the last successfully parsed templates are retained and used, so a
-// transient parse error does not take down a running server. Lookup never
-// panics on a reload error.
+// If reparsing fails, Lookup records the error for [TemplateReloader.LastError]
+// and retains the last successful templates. It does not retry until another
+// interval elapses.
 //
-// A failed reload still advances the reload timestamp, so the next reparse is
-// deferred until the interval elapses again; the last-good templates keep being
-// served meanwhile, and a fix made within that window is not picked up until the
-// window reopens.
-//
-// On the zero value (&TemplateReloader{}), which has never parsed any templates,
-// Lookup returns nil, keeping the zero value as safe to call as [TemplateReloader.LastError]
-// and [TemplateReloader.Path].
+// The zero value returns nil. A nil receiver panics.
 func (tr *TemplateReloader) Lookup(name string) *template.Template {
 	tr.mu.RLock()
 	curr := tr.curr

--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -352,8 +352,8 @@ func (jsvar *JsVar[T]) setPathLock(elem *jaws.Element, jsPath string, value any,
 	var data []byte
 	var changed bool
 	dirtyTag, data, changed, checkRejected, pathSetter, err = jsvar.setPathAndMarshal(elem, jsPath, value, clientWrite)
-	// dirtyTag is assigned only in JawsRender, so a set before the first render leaves
-	// it nil. A what.Set with a nil Dest would target every element, and there is
+	// dirtyTag is assigned only by JawsRender, so a set before JawsRender leaves it
+	// nil. A what.Set with a nil Dest would target every element, and there is
 	// nothing to update yet because the initial render carries the value in its
 	// data-jawsdata attribute, so the broadcast is skipped in that case.
 	//
@@ -421,6 +421,10 @@ func (jsvar *JsVar[T]) setPath(elem *jaws.Element, jsPath string, value any, cli
 // destination field after assignment. Applications using an encoded
 // representation such as decimal strings must pass that representation in value.
 //
+// If marshaling a broadcast value fails, JawsSetPath returns the error after
+// applying the write. It does not roll back the value, queue a broadcast, or call
+// [SetPather.JawsPathSet].
+//
 // When a write produces a broadcast, value is marshaled while the application
 // locker is held. Custom marshaling callbacks reachable from value, including
 // MarshalJSON and MarshalText, must not acquire that locker or re-enter the
@@ -438,8 +442,9 @@ func (jsvar *JsVar[T]) JawsSet(elem *jaws.Element, value T) (err error) {
 
 // JawsRender writes the hidden element that seeds and routes the JavaScript variable.
 //
-// params[0] must be a valid JsVar name. Otherwise, JawsRender returns
-// [ErrIllegalJsVarName] without writing markup.
+// params[0] must be a valid JsVar name. An invalid name returns
+// [ErrIllegalJsVarName] without writing markup, but still applies any bound-value
+// tag and handlers, invokes its initial-attribute hook, and adds the JsVar handler.
 //
 // A name may be bound by more than one live binding; see [JsVar] for how a
 // browser write is delivered to every live binding of the name.
@@ -503,16 +508,12 @@ func (jsvar *JsVar[T]) renderSnapshot(elem *jaws.Element, params []any) (getter 
 	return
 }
 
-// JawsGetTag returns the dirty tag, or nil before the first render initializes it.
+// JawsGetTag returns the dirty tag resolved by [JsVar.JawsRender], or nil.
 //
-// That nil is not a dirty target. After initialization JawsGetTag obeys the normal
-// idempotent tag identity contract; see
-// [github.com/linkdata/jaws/lib/tag.TagGetter].
-//
-// A JsVar is therefore only usable as a tag once it has rendered. Passing one as a tag
-// to another widget beforehand expands to no keys at all, so that widget registers
-// under nothing and a later dirty of this JsVar never reaches it. Render the JsVar
-// first, or tag the other widget with a value that does not depend on this one.
+// A failed JawsRender may still resolve the tag. Once non-nil, it follows the
+// stable-identity contract of [github.com/linkdata/jaws/lib/tag.TagGetter]. Using
+// the JsVar as a tag while nil registers no keys; later resolution is not
+// retroactive.
 //
 // It is safe for concurrent use.
 func (jsvar *JsVar[T]) JawsGetTag() any {

--- a/request.go
+++ b/request.go
@@ -1103,14 +1103,9 @@ func (rq *Request) Log(err error) error {
 	return jw.Log(err)
 }
 
-// MustLog reports an error or panics when no [Jaws.Logger] is configured.
+// MustLog passes err to [Jaws.MustLog].
 //
-// On a nil Request, a non-nil err is treated as having no configured Logger and
-// panics; a nil err has no effect. See [Jaws.MustLog] for delivery behavior.
-//
-// Some update-time paths cannot return errors to their caller and report them
-// through MustLog. Set [Jaws.Logger] when those errors should be logged instead
-// of treated as fatal programming errors.
+// A nil Request behaves like a nil [Jaws].
 func (rq *Request) MustLog(err error) {
 	var jw *Jaws
 	if rq != nil {

--- a/serve.go
+++ b/serve.go
@@ -34,6 +34,11 @@ func (jw *Jaws) getWebSocketTimeout() (t time.Duration) {
 // requestTimeout must be an exact multiple of [time.Second] from [time.Second]
 // through 2,147,483,646 seconds. Other values have unspecified behavior.
 //
+// An overlapping [Jaws.Serve] or [Jaws.ServeWithTimeout] call reports
+// [ErrServeAlreadyRunning] through [Jaws.MustLog]. It panics without a Logger
+// and in debug or race builds; otherwise it returns without starting another
+// processing loop.
+//
 // Before [Request.ServeHTTP] begins WebSocket processing, timeout-based Request
 // retirement is periodic and approximate, not a hard deadline. [Jaws.NewRequest],
 // a successful [Jaws.UseRequest], and [Request.MarkWritten] mark activity using
@@ -157,8 +162,7 @@ func (jw *Jaws) ServeWithTimeout(requestTimeout time.Duration) {
 
 // Serve calls [Jaws.ServeWithTimeout] with [DefaultWebSocketTimeout].
 //
-// It is intended to run on its own goroutine. On a normal return after
-// [Jaws.Close], Serve waits for every accepted log entry to finish delivery.
+// See [Jaws.ServeWithTimeout] for lifecycle and panic behavior.
 func (jw *Jaws) Serve() {
 	jw.ServeWithTimeout(DefaultWebSocketTimeout)
 }


### PR DESCRIPTION
Fixes #317.

## Summary

- correct the documented `BoolArray` and `JsVar` mutation/render contracts
- document keepalive-disable, overlapping-serve, and shutdown logging behavior
- clarify `TemplateReloader` concurrency, zero-value, and nil-receiver behavior
- align the README and JaWS skill guidance with the corrected API docs

## Verification

- `go generate ./...`
- `go vet ./...`
- `gofmt -l .` and `gofumpt -l .`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`
- `JAWS_REQUIRE_NODE=1 go test -race -coverprofile=coverage.out ./...`
- `JAWS_REQUIRE_NODE=1 go test ./...`
- `go build -v ./...`
- rendered `go doc` review for every affected exported symbol
