### PR TITLE
docs: centralize nil-value conventions

### DIFF
--- a/.agents/skills/jaws/SKILL.md
+++ b/.agents/skills/jaws/SKILL.md
@@ -35,18 +35,20 @@ JaWS is an immediate-mode, server-driven UI framework, not an MVC framework.
 
 ## Hard framework constraints
 
-- Every JaWS `UI` value must be a non-nil interface, comparable at runtime, **and
-  equal to itself**, since it is used as a map key. A value that is a nil interface,
-  only statically comparable (an interface field holding a slice/map/func), or that
-  holds a `NaN` (so `v != v`) is rejected: the container widgets — the only place a raw
-  `UI` value is used as a map key — cancel the `Request` in all builds (cause matches
-  `tag.ErrNotUsableAsTag`), and `Request.NewElement` asserts runtime comparability in
-  debug builds. A typed nil (e.g. `(*Widget)(nil)`) is comparable and equal to itself,
-  so it counts as usable and JaWS dispatches render/update/event calls to it; only a
-  nil `UI` interface is a no-op. Surviving such a call is up to the concrete type, not
-  a requirement: a widget that dereferences its fields panics, and none of the
-  standard `lib/ui` widgets document nil-receiver tolerance. Do not pass a nil pointer
-  of a type that does not; use a zero value only where that type documents one.
+- Follow the module-wide nil-value convention in package `jaws`: required
+  operational collaborators and pointer receivers are non-nil unless an API
+  documents a meaning for nil. Do not treat unsupported nil use as a framework
+  defect or repeat ordinary non-nil boilerplate on individual symbols.
+- Every non-nil JaWS `UI` value must be comparable at runtime **and equal to
+  itself**. A value that is only statically comparable (an interface field holding a
+  slice/map/func), or that holds a `NaN` (so `v != v`), is rejected: the container
+  widgets — the only place a raw `UI` value is used as a map key — cancel the
+  `Request` in all builds (cause matches `tag.ErrNotUsableAsTag`), and
+  `Request.NewElement` asserts runtime comparability in debug builds. Container
+  children must also be non-nil. `Request.NewElement` tolerates a nil `UI` interface
+  as a render/update no-op. A typed nil (e.g. `(*Widget)(nil)`) is comparable and equal
+  to itself, so JaWS dispatches render/update/event calls to it; whether those calls
+  tolerate its nil receiver follows the concrete type's contract.
 - Every JaWS `UI` value is request-scoped. Once used by one Request, never use
   that value with another Request; construct fresh widgets per request. The
   widgets may still refer to shared, synchronized application state, binders,
@@ -143,11 +145,9 @@ These are the two usual building blocks for widget handlers passed to `$.Button`
   supports multiple live Elements. They remain request-scoped; construct fresh widget
   values for another Request even when those values refer to shared synchronized
   application state.
-- A nil-interface child provider is a valid part of the Go value but is not renderable:
-  zero Container/Tbody and `NewContainer`/`NewTbody` with nil providers panic when
-  render/update calls `JawsContains`. Zero Select and `NewSelect(nil)` likewise panic in
-  render/update, while `Select.JawsInput` treats the nil handler as a no-op. A typed-nil
-  provider is dispatched normally and must tolerate its nil receiver itself.
+- `Select.JawsInput` treats a nil-interface handler as a no-op. Typed-nil providers
+  and handlers are dispatched normally; nil-receiver behavior follows the concrete
+  type.
 
 ## Template-dot and tag rules
 
@@ -241,8 +241,8 @@ Implications:
   without render-time initialization. It uses the updater as a tag, attaches its event
   handlers, applies tag and handler params, and invokes `JawsUpdate` once. HTML attribute
   params are ignored; write attributes on the template-authored element.
-- The updater must be a non-nil interface whose dynamic value is comparable at runtime,
-  equal to itself, and usable as a tag. A typed nil is invoked normally and must tolerate
+- The updater's dynamic value must be comparable at runtime, equal to itself, and
+  usable as a tag. A typed nil is invoked normally and must tolerate
   its nil receiver. Reuse one updater for live Elements only when it supports that use
   without retaining Element-specific state on the shared value; it must be safe for
   concurrent use when shared across Requests.

--- a/README.md
+++ b/README.md
@@ -863,10 +863,11 @@ The reason is that there is no unbroken call chain from the time the Request
 object is created when the initial HTTP request comes in and when it is
 requested during the JavaScript WebSocket HTTP request.
 
-`Request.SetContext` must return a non-nil context derived from the current
-context passed to it. If the returned context is canceled or its deadline
-expires, a running Request's WebSocket loop wakes promptly even while idle; no
-browser event or broadcast is needed.
+`Request.SetContext` transforms the Request's current context. Return a context
+derived from the value passed to the callback so cancellation and deadlines
+continue to propagate. If the returned context is canceled or its deadline expires,
+a running Request's WebSocket loop wakes promptly even while idle; no browser event
+or broadcast is needed.
 
 Background work that must cancel the Request should retain its own derived
 context and cancellation function, not the Request pointer:

--- a/contracts.go
+++ b/contracts.go
@@ -94,9 +94,7 @@ type TemplateLookuper interface {
 // property of the concrete type rather than a requirement of this contract: a type
 // may document that it tolerates one, and a type that does not will panic when
 // dereferencing its fields. Passing a nil pointer of such a type is therefore a
-// caller error, not a framework-handled case. The pointer-valued widgets in
-// [github.com/linkdata/jaws/lib/ui] dereference their fields, and no widget there
-// documents nil-receiver tolerance.
+// caller error, not a framework-handled case.
 type UI interface {
 	Renderer
 	Updater

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,27 @@
+// Package jaws creates dynamic server-driven webpages over WebSockets.
+//
+// It integrates with [html/template] and any router that supports [http.Handler].
+//
+// This package holds the core engine and the [UI] interfaces. The standard
+// widgets (Span, Button, Select, Text, and so on) and the RequestWriter helper
+// methods live in [github.com/linkdata/jaws/lib/ui], and value binding lives in
+// [github.com/linkdata/jaws/lib/bind].
+//
+// # Nil values
+//
+// Throughout this module, including its subpackages, nil is unsupported for pointer
+// receivers and for values used as required operational collaborators, such as
+// callbacks, handlers, providers, lockers, writers, file systems, contexts, and
+// pointers to mutable values, unless the relevant API documents a meaning for nil.
+// Passing an unsupported nil is a caller error and may panic immediately or when
+// used later. Nil slices, maps, data values, and results otherwise follow ordinary
+// Go semantics and the relevant API. An interface containing a typed nil is non-nil;
+// its behavior follows the relevant interface, API, and concrete type.
+//
+// # Tags
+//
+// Tags associate [Element] values with application data or logical signals for
+// targeted dirtying, broadcasts, and lookup. See
+// [github.com/linkdata/jaws/lib/tag] for tag selection, expansion, registration,
+// and lifetime.
+package jaws

--- a/element.go
+++ b/element.go
@@ -54,7 +54,7 @@ type Element struct {
 // their types (and a pointer's address when readable; see [tag.TagStringRelease]),
 // while debug and -race builds render them in full — more informative, but able
 // to crash on a self-referential or oversized tag. String tolerates an Element
-// whose Request is not yet set, but not a nil *Element.
+// whose Request is not yet set.
 func (elem *Element) String() string {
 	// Guard elem.Request like Request.String()/JawsKeyString guard a nil
 	// receiver, so String() stays safe on a not-fully-constructed Element.

--- a/elementstate.go
+++ b/elementstate.go
@@ -22,8 +22,8 @@ var ErrElementStateNil = errors.New("jaws: element state must not be nil")
 // synchronized: whatever the stored value contains is guarded by that value's own
 // synchronization, not by this call.
 //
-// elem must be a non-nil Element obtained from [Request.NewElement]. ElementState does
-// not verify that provenance. It panics if elem or elem.Request is nil.
+// elem must be obtained from [Request.NewElement]. ElementState does not verify
+// that provenance.
 func ElementState(elem *Element) (state any) {
 	rq := elem.Request
 	rq.mu.RLock()
@@ -51,9 +51,8 @@ func ElementState(elem *Element) (state any) {
 // the claim is synchronized; mutating the stored value afterwards is guarded by that
 // value's own synchronization, not by this call.
 //
-// When state is non-nil, elem must be a non-nil Element obtained from
-// [Request.NewElement]. SetElementState does not verify that provenance. It panics if
-// elem or elem.Request is nil; a nil state is rejected before elem is examined.
+// When state is non-nil, elem must be obtained from [Request.NewElement].
+// SetElementState does not verify that provenance.
 func SetElementState(elem *Element, state any) error {
 	// The two functions are package-level rather than methods on Element because
 	// ui.With embeds both *Element and ui.RequestWriter, so any method returning a value

--- a/jaws.go
+++ b/jaws.go
@@ -1,18 +1,3 @@
-// Package jaws creates dynamic server-driven webpages over WebSockets.
-//
-// It integrates with [html/template] and any router that supports [http.Handler].
-//
-// This package holds the core engine and the [UI] interfaces. The standard
-// widgets (Span, Button, Select, Text, and so on) and the RequestWriter helper
-// methods live in [github.com/linkdata/jaws/lib/ui], and value binding lives in
-// [github.com/linkdata/jaws/lib/bind].
-//
-// # Tags
-//
-// Tags associate [Element] values with application data or logical signals for
-// targeted dirtying, broadcasts, and lookup. See
-// [github.com/linkdata/jaws/lib/tag] for tag selection, expansion, registration,
-// and lifetime.
 package jaws
 
 // Maintainer locking notes:
@@ -120,7 +105,7 @@ type Jaws struct {
 	Logger                Logger     // Optional logger; [Jaws.Log] dispatches Error calls asynchronously and serially
 	Debug                 bool       // Set to true to enable debug info in generated HTML code. Call GenerateHeadHTML after changing it.
 	MakeAuth              MakeAuthFn // Function to create ui.With.Auth for Templates. If nil, templates get the fail-open DefaultAuth (IsAdmin()==true for everyone); set it to enforce authorization. See DefaultAuth.
-	// BaseContext is the non-nil parent context for Requests.
+	// BaseContext is the parent context for Requests.
 	//
 	// New uses [context.Background]. If a custom context implements the optional
 	// method recognized by [context.AfterFunc], that method and its returned stop
@@ -412,7 +397,6 @@ func (jw *Jaws) ContentSecurityPolicy() (s string) {
 // The returned middleware does not trust forwarded HTTPS headers. Note that the
 // session cookie Secure flag is governed separately by [Jaws.TrustForwardedHeaders]
 // (also false by default), so the two stay consistent unless you opt in.
-// The next handler must be non-nil.
 func (jw *Jaws) SecureHeadersMiddleware(next http.Handler) http.Handler {
 	hdrs := secureheaders.DefaultHeaders()
 	delete(hdrs, "Content-Security-Policy")

--- a/jawsboot/doc.go
+++ b/jawsboot/doc.go
@@ -5,4 +5,7 @@
 // stored gzip-compressed under assets/static). When bumping the vendored files,
 // update this version note and README.md's provenance table so the shipped
 // release stays auditable against upstream security advisories.
+//
+// Nil values follow the module-wide convention documented by
+// [github.com/linkdata/jaws].
 package jawsboot

--- a/jawsboot/jawsboot.go
+++ b/jawsboot/jawsboot.go
@@ -30,9 +30,6 @@ var assetsFS embed.FS
 // bundled bootstrap *.map sourcemap paths, quietly answering devtools probes for
 // "bootstrap.bundle.min.js.map" and "bootstrap.min.css.map".
 //
-// handleFn must not be nil when calling Setup directly; it is invoked once per
-// asset. Reaching it through [jaws.Jaws.Setup] is always safe, since that
-// substitutes a no-op handler when its own handleFn is nil (see [jaws.SetupFunc]).
 // The returned URLs are always valid: they are built from clean, slash-rooted
 // paths over content-hashed embedded asset names, so err only ever reflects a
 // failure to walk the embedded filesystem.

--- a/jawstest/jawstest.go
+++ b/jawstest/jawstest.go
@@ -25,6 +25,8 @@ import (
 
 // TestRequest is a request harness intended for tests.
 //
+// Values must be created with [NewTestRequest]; the zero value is not usable.
+//
 // The embedded [jaws.Request] provides the usual request methods (NewElement,
 // JawsKeyString, and so on). The channels expose the loop's wiring: send incoming
 // WebSocket messages on InCh, read outbound messages from OutCh, and inject

--- a/lib/bind/bind.go
+++ b/lib/bind/bind.go
@@ -14,9 +14,6 @@ import (
 //
 // If l implements [RWLocker], reads use its read lock. Otherwise reads and
 // writes both use l. The pointer p is also exposed as the UI tag.
-//
-// Both l and p must be non-nil; a Binder created with a nil locker or nil
-// pointer panics on first use.
 func New[T comparable](l sync.Locker, p *T) Binder[T] {
 	return &binder[T]{RWLocker: AsRWLocker(l), ptr: p}
 }

--- a/lib/bind/doc.go
+++ b/lib/bind/doc.go
@@ -13,4 +13,7 @@
 // widgets. They panic when called with a value whose dynamic type does not match
 // the requested adapter type, so use them at trusted construction points rather
 // than on unvalidated external input.
+//
+// Nil values follow the module-wide convention documented by
+// [github.com/linkdata/jaws].
 package bind

--- a/lib/bind/rwlocker.go
+++ b/lib/bind/rwlocker.go
@@ -12,8 +12,7 @@ type RWLocker interface {
 // AsRWLocker returns an [RWLocker] backed by l.
 //
 // If l already implements [RWLocker] it is returned unchanged; otherwise its
-// Lock and Unlock are used for both read and write locking. A nil l yields an
-// RWLocker that panics when locked.
+// Lock and Unlock are used for both read and write locking.
 func AsRWLocker(l sync.Locker) RWLocker {
 	if rl, ok := l.(RWLocker); ok {
 		return rl

--- a/lib/templatereloader/doc.go
+++ b/lib/templatereloader/doc.go
@@ -1,3 +1,6 @@
 // Package templatereloader provides a jaws.TemplateLookuper that reparses
 // templates from disk while running in debug or race builds.
+//
+// Nil values follow the module-wide convention documented by
+// [github.com/linkdata/jaws].
 package templatereloader

--- a/lib/templatereloader/templatereloader.go
+++ b/lib/templatereloader/templatereloader.go
@@ -80,7 +80,7 @@ func create(debug bool, fsys fs.FS, fpath, relpath string) (tl jaws.TemplateLook
 // and retains the last successful templates. It does not retry until another
 // interval elapses.
 //
-// The zero value returns nil. A nil receiver panics.
+// The zero value returns nil.
 func (tr *TemplateReloader) Lookup(name string) *template.Template {
 	tr.mu.RLock()
 	curr := tr.curr

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -103,10 +103,8 @@ preserves their Elements and nested subtrees; changed nested containers need the
 update. Child Element identity is parent-scoped, so moving a child definition between
 parents does not preserve its Element.
 
-The zero Container and Tbody, and values constructed with a nil-interface child
-provider, panic when rendering or updating calls the missing provider. A zero
-Select behaves the same for render and update, while its `JawsInput` is a no-op.
-A typed-nil provider is called normally and must tolerate its nil receiver itself.
+`Select.JawsInput` treats a nil-interface handler as a no-op. Typed-nil providers
+and handlers are called normally; nil-receiver behavior follows the concrete type.
 
 You can also use explicit constructors through:
 

--- a/lib/ui/container.go
+++ b/lib/ui/container.go
@@ -25,7 +25,6 @@ import (
 // those Elements supports multiple live Elements. Use Container as a value;
 // taking its address changes identity and is unsupported.
 //
-// A nil-interface provider panics when rendering or updating requests children.
 // A typed-nil provider is called normally and must tolerate its nil receiver.
 type Container struct {
 	outerHTMLTag string

--- a/lib/ui/doc.go
+++ b/lib/ui/doc.go
@@ -18,8 +18,10 @@
 // equality to pointer identity.
 //
 // See [jaws.UI] and each concrete widget for comparability, typed-nil, and
-// zero-value behavior. No pointer widget in this package documents nil-receiver
-// tolerance.
+// zero-value behavior.
+//
+// Nil values follow the module-wide convention documented by
+// [github.com/linkdata/jaws].
 //
 // Within one request, a widget normally backs one live [jaws.Element]. The
 // HTML-inner widgets, [Img], [Option], [Template], [Container], [Tbody], and

--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -564,7 +564,7 @@ func (jsvar *JsVar[T]) JawsInput(elem *jaws.Element, value string) (err error) {
 
 // NewJsVar creates a JsVar over v protected by l.
 //
-// The locker l must be non-nil and must remain valid for the lifetime of the JsVar.
+// The locker l must remain valid for the lifetime of the JsVar.
 // The pointer v may be nil; reads then return the zero value, rendering omits the
 // initial data, and writes return [github.com/linkdata/jq.ErrInvalidReceiver].
 // Create a fresh JsVar for each live [jaws.Element]; l and v may be shared by

--- a/lib/ui/register.go
+++ b/lib/ui/register.go
@@ -37,7 +37,7 @@ func (registerUI) JawsRender(*jaws.Element, io.Writer, []any) error {
 // [jaws.ErrEventUnhandled]. HTML attribute params have no effect; write
 // attributes in the template.
 //
-// The updater must be non-nil, comparable at runtime, equal to itself, and usable
+// The updater must be comparable at runtime, equal to itself, and usable
 // as a tag. A typed nil is invoked normally and must tolerate its nil receiver.
 // The same updater may back multiple live Elements only when it supports that use
 // without retaining Element-specific state on the shared value. If shared across

--- a/lib/ui/select.go
+++ b/lib/ui/select.go
@@ -20,9 +20,7 @@ import (
 // reused across those Elements supports multiple live Elements. Use Select as a
 // value; taking its address changes identity and is unsupported.
 //
-// A nil-interface handler makes [Select.JawsInput] a no-op and panics when
-// rendering or updating requests options. A typed-nil handler is called normally
-// and must tolerate its nil receiver.
+// A typed-nil handler is called normally and must tolerate its nil receiver.
 //
 // Select supports one selected option; a multiple select is unsupported.
 // A completed native form reset changes browser state without an input/change

--- a/lib/ui/tbody.go
+++ b/lib/ui/tbody.go
@@ -6,7 +6,7 @@ import "github.com/linkdata/jaws"
 //
 // [NewTbody] configures its embedded [Container] for tbody. Replacing that
 // Container is unsupported. Tbody otherwise follows Container's identity,
-// reconciliation, multiplicity, and nil-provider contracts. Treat it as
+// reconciliation, multiplicity, and typed-nil-provider behavior. Treat it as
 // immutable after use and use it as a value; taking its address changes identity
 // and is unsupported.
 type Tbody struct {

--- a/parseparams.go
+++ b/parseparams.go
@@ -27,6 +27,8 @@ func usableAsTag(t any) (ok bool) {
 // [InitialHTMLAttrHandler.JawsInitialHTMLAttr]; implementing that interface does
 // not affect parameter classification.
 //
+// A nil [InputFn] is ignored.
+//
 // A recognized event handler that is also usable as a tag is returned in both tags
 // and handlers.
 func ParseParams(params []any) (tags []any, handlers []any, attrs []string) {

--- a/request.go
+++ b/request.go
@@ -82,8 +82,6 @@ type requestBuffers struct {
 // [Jaws.UseRequest] claims it. The Request finishes when WebSocket handling ends or a
 // non-running Request is retired. It then remains cancelled and unregistered. Its
 // pointer identity is never reused for another connection.
-//
-// Request methods require a non-nil receiver unless the method documents otherwise.
 type Request struct {
 	Jaws             *Jaws                   // (read-only) the JaWS instance the Request belongs to
 	JawsKey          key.Key                 // (read-only) random key assigned to this Request; routes JaWS URLs and request-targeted broadcasts only while registered
@@ -184,6 +182,8 @@ func (rq *Request) finishLocked() {
 }
 
 // JawsKeyString returns the request key in the text form used by JaWS URLs.
+//
+// It tolerates a nil receiver for diagnostics only.
 func (rq *Request) JawsKeyString() string {
 	jawsKey := key.Key(0)
 	if rq != nil {
@@ -464,7 +464,7 @@ func (rq *Request) HeadHTML(w io.Writer) (err error) {
 	return
 }
 
-// GetConnectFn returns the currently set [ConnectFn].
+// GetConnectFn returns the currently set [ConnectFn], or nil if none is set.
 func (rq *Request) GetConnectFn() (fn ConnectFn) {
 	rq.mu.RLock()
 	fn = rq.connectFn
@@ -473,6 +473,8 @@ func (rq *Request) GetConnectFn() (fn ConnectFn) {
 }
 
 // SetConnectFn sets the function called after the WebSocket is accepted.
+//
+// A nil fn clears the callback.
 //
 // See [ConnectFn] for the callback lifecycle and permitted operations.
 func (rq *Request) SetConnectFn(fn ConnectFn) {
@@ -541,8 +543,7 @@ func (rq *Request) Context() (ctx context.Context) {
 //
 // fn runs while the Request lock is held. It must not call methods on the same
 // Request, call code that may do so, or block on work that needs the same
-// Request. SetContext panics if fn is nil. If fn panics, SetContext releases the
-// lock and propagates the panic.
+// Request. If fn panics, SetContext releases the lock and propagates the panic.
 //
 // If a custom context implements the optional method recognized by
 // [context.AfterFunc], that method and its returned stop function must return

--- a/session.go
+++ b/session.go
@@ -18,8 +18,8 @@ import (
 // Session stores server-side per-user state shared by one or more requests.
 //
 // A Session is bound to the remote IP that created it. Its exported methods are
-// safe to call on a nil *Session; those calls return the documented zero value
-// or do nothing.
+// safe to call on a nil *Session; methods with results return the result type's
+// zero value, and the others do nothing.
 type Session struct {
 	jw        *Jaws
 	sessionID key.Key
@@ -99,7 +99,6 @@ func (sess *Session) delRequest(rq *Request, wasClaimed bool) {
 }
 
 // Jaws returns the [Jaws] instance of the [Session], or nil.
-// It is safe to call on a nil [Session].
 func (sess *Session) Jaws() (jw *Jaws) {
 	if sess != nil {
 		jw = sess.jw
@@ -108,7 +107,6 @@ func (sess *Session) Jaws() (jw *Jaws) {
 }
 
 // Get returns the value associated with the key, or nil.
-// It is safe to call on a nil [Session].
 func (sess *Session) Get(key string) (value any) {
 	if sess != nil {
 		sess.mu.RLock()
@@ -120,7 +118,6 @@ func (sess *Session) Get(key string) (value any) {
 
 // Set sets a value to be associated with the key.
 // If value is nil, the key is removed from the session.
-// It is safe to call on a nil [Session].
 func (sess *Session) Set(key string, value any) {
 	if sess != nil {
 		sess.mu.Lock()
@@ -134,7 +131,6 @@ func (sess *Session) Set(key string, value any) {
 }
 
 // ID returns the session ID, a 64-bit random value.
-// It is safe to call on a nil [Session], in which case it returns zero.
 func (sess *Session) ID() (id uint64) {
 	if sess != nil {
 		id = uint64(sess.sessionID)
@@ -143,7 +139,6 @@ func (sess *Session) ID() (id uint64) {
 }
 
 // CookieValue returns the session cookie value.
-// It is safe to call on a nil [Session], in which case it returns an empty string.
 func (sess *Session) CookieValue() (s string) {
 	if sess != nil {
 		s = sess.cookie.Value
@@ -152,7 +147,6 @@ func (sess *Session) CookieValue() (s string) {
 }
 
 // IP returns the remote IP the session is bound to, or the zero [netip.Addr] if unset.
-// It is safe to call on a nil [Session], in which case it returns the zero [netip.Addr].
 func (sess *Session) IP() (ip netip.Addr) {
 	if sess != nil {
 		ip = sess.remoteIP
@@ -161,7 +155,6 @@ func (sess *Session) IP() (ip netip.Addr) {
 }
 
 // Cookie returns a cookie for the [Session]. Returns a delete cookie if the [Session] is expired.
-// It is safe to call on a nil [Session], in which case it returns nil.
 func (sess *Session) Cookie() (cookie *http.Cookie) {
 	if sess != nil {
 		cookie = &http.Cookie{} // #nosec G124 -- copied from sess.cookie before returning.
@@ -216,9 +209,7 @@ func (sess *Session) addCookie(w http.ResponseWriter, r *http.Request) {
 // It must not be called before the JaWS processing loop ([Jaws.Serve] or
 // [Jaws.ServeWithTimeout]) is running, because the wake-up broadcasts may block.
 //
-// Returns a cookie to be sent to the client browser that will delete the browser cookie.
-// It is safe to call on a nil [Session], in which case it returns nil; for any
-// non-nil [Session] it returns a non-nil deletion cookie.
+// Close returns a non-nil deletion cookie for a non-nil [Session].
 func (sess *Session) Close() (cookie *http.Cookie) {
 	if sess != nil {
 		sess.jw.deleteSessionIfCurrent(sess)
@@ -249,13 +240,11 @@ func (sess *Session) Close() (cookie *http.Cookie) {
 
 // Reload calls [Session.Broadcast] with a message asking browsers to reload the page.
 // See [Session.Broadcast] for the processing-loop requirement.
-// It is safe to call on a nil [Session].
 func (sess *Session) Reload() {
 	sess.Broadcast(wire.Message{What: what.Reload})
 }
 
 // Clear removes all key/value pairs from the session.
-// It is safe to call on a nil [Session].
 func (sess *Session) Clear() {
 	if sess != nil {
 		sess.mu.Lock()
@@ -268,7 +257,6 @@ func (sess *Session) Clear() {
 //
 // The returned slice is a snapshot. Its Request pointers are not pinned and may
 // become stale immediately; see [Request].
-// It is safe to call on a nil [Session].
 func (sess *Session) Requests() (requests []*Request) {
 	if sess != nil {
 		sess.mu.RLock()
@@ -282,7 +270,6 @@ func (sess *Session) Requests() (requests []*Request) {
 //
 // It must not be called before the JaWS processing loop ([Jaws.Serve] or
 // [Jaws.ServeWithTimeout]) is running. Otherwise this call may block.
-// It is safe to call on a nil [Session].
 func (sess *Session) Broadcast(msg wire.Message) {
 	if sess != nil {
 		// Snapshot the requests under the lock (via Requests), then broadcast

--- a/testserve.go
+++ b/testserve.go
@@ -24,11 +24,11 @@ import (
 // production use; it does not import any testing-only packages, so it does not
 // pull net/http/httptest into the production build.
 //
-// onPanic must be non-nil; it is called with the recovered value (nil if the loop
-// exited normally) when the loop goroutine stops, before doneCh is closed, so a
-// harness can publish captured panic state before any <-doneCh waiter observes
-// it. A harness that does not expect panics should re-panic when the value is
-// non-nil so unexpected loop panics still surface.
+// onPanic is called with the recovered value (nil if the loop exited normally)
+// when the loop goroutine stops, before doneCh is closed, so a harness can publish
+// captured panic state before any <-doneCh waiter observes it. A harness that does
+// not expect panics should re-panic when the value is non-nil so unexpected loop
+// panics still surface.
 func (jw *Jaws) TestServe(rq *Request, onPanic func(recovered any)) (inCh chan wire.WsMsg, outCh chan wire.WsMsg, bcastCh chan wire.Message, readyCh, doneCh chan struct{}) {
 	bcastCh = make(chan wire.Message, 64)
 	// Subscribe and then rendezvous with the Serve loop so the subscription is


### PR DESCRIPTION
Closes #322.

## Summary

- define one module-wide convention for unsupported nil receivers and required operational collaborators
- remove repetitive non-nil preconditions while retaining supported and non-standard nil semantics
- align package guides and the JaWS skill with the centralized contract
- document the `jawstest.TestRequest` zero-value requirement

## Issue #322

This resolves the two documentation gaps in #322 without adding symbol-by-symbol boilerplate. The downstream handler passed to `Jaws.SessionMiddleware` and the normal-build filesystem passed to `templatereloader.New` are required operational collaborators, so unsupported nil values fall under the module-wide rule. The `templatereloader` package documentation links to that rule, while `New` continues to state that `fsys` is unused in debug and race builds.

## Verification

- `go generate ./...`
- `go vet ./...`
- `gofmt -l .`
- `staticcheck ./...`
- `golangci-lint run ./...`
- `gosec ./...`
- `JAWS_REQUIRE_NODE=1 go test -race -coverprofile=coverage.out ./...`
- `JAWS_REQUIRE_NODE=1 go test ./...`
- `go build -v ./...`
- Linux/386 test packages cross-compiled for `lib/bind` and `lib/ui`
- rendered `go doc` reviewed for every affected exported symbol and package