### PR TITLE
ui: preserve render failures after empty writes

### DIFF
--- a/lib/ui/handler.go
+++ b/lib/ui/handler.go
@@ -62,7 +62,7 @@ func (pt *pageTemplate) JawsRender(elem *jaws.Element, w io.Writer, params []any
 }
 
 // statusRecorder wraps an [http.ResponseWriter] to apply the page handler's
-// default HTML content type and record whether any response bytes have been
+// default HTML content type and record whether a final response has been
 // committed, so [uiHandler.ServeHTTP] can still send a 500 for a render failure
 // that occurred before any output was written.
 type statusRecorder struct {
@@ -71,6 +71,9 @@ type statusRecorder struct {
 }
 
 func (sr *statusRecorder) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
 	if sr.Header().Get("Content-Type") == "" {
 		sr.Header().Set("Content-Type", "text/html; charset=utf-8")
 	}
@@ -79,7 +82,9 @@ func (sr *statusRecorder) Write(p []byte) (int, error) {
 }
 
 func (sr *statusRecorder) WriteHeader(code int) {
-	sr.wrote = true
+	if code == http.StatusSwitchingProtocols || code >= 200 {
+		sr.wrote = true
+	}
 	sr.ResponseWriter.WriteHeader(code)
 }
 

--- a/lib/ui/handler_content_type_test.go
+++ b/lib/ui/handler_content_type_test.go
@@ -1,9 +1,11 @@
 package ui
 
 import (
+	"errors"
 	"html/template"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 
 	"github.com/linkdata/jaws"
@@ -76,5 +78,105 @@ func TestHandler_RenderFailureBeforeOutputUsesTextContentType(t *testing.T) {
 	}
 	if got, want := rr.Header().Get("Content-Type"), "text/plain; charset=utf-8"; got != want {
 		t.Fatalf("Content-Type = %q, want %q", got, want)
+	}
+}
+
+func TestHandler_EmptyWriteBeforeErrorReturns500(t *testing.T) {
+	renderErr := errors.New("boom")
+	tmpl := template.Must(template.New("page").Funcs(template.FuncMap{
+		"fail": func() (string, error) { return "", renderErr },
+	}).Parse(`{{.Dot}}{{fail}}`))
+
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		t.Run(method, func(t *testing.T) {
+			jw, err := jaws.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(jw.Close)
+			if err = jw.AddTemplateLookuper(tmpl); err != nil {
+				t.Fatal(err)
+			}
+
+			rr := httptest.NewRecorder()
+			Handler(jw, "page", "").ServeHTTP(rr, httptest.NewRequest(method, "/", nil))
+
+			if got, want := rr.Code, http.StatusInternalServerError; got != want {
+				t.Fatalf("status = %d, want %d", got, want)
+			}
+			if got, want := rr.Header().Get("Content-Type"), "text/plain; charset=utf-8"; got != want {
+				t.Fatalf("Content-Type = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+type recordingResponseWriter struct {
+	header      http.Header
+	headerCodes []int
+	writes      int
+}
+
+func (rw *recordingResponseWriter) Header() http.Header {
+	return rw.header
+}
+
+func (rw *recordingResponseWriter) Write(p []byte) (int, error) {
+	rw.writes++
+	return len(p), nil
+}
+
+func (rw *recordingResponseWriter) WriteHeader(code int) {
+	rw.headerCodes = append(rw.headerCodes, code)
+}
+
+func TestStatusRecorder_EmptyWriteDoesNotCommit(t *testing.T) {
+	rw := &recordingResponseWriter{header: make(http.Header)}
+	sr := statusRecorder{ResponseWriter: rw}
+
+	n, err := sr.Write(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("Write returned %d bytes, want 0", n)
+	}
+	if sr.wrote {
+		t.Fatal("empty Write marked the response committed")
+	}
+	if rw.writes != 0 {
+		t.Fatalf("underlying Write calls = %d, want 0", rw.writes)
+	}
+	if got := rw.header.Get("Content-Type"); got != "" {
+		t.Fatalf("Content-Type = %q, want empty", got)
+	}
+}
+
+func TestStatusRecorder_InformationalHeaderCommitState(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		code  int
+		wrote bool
+	}{
+		{"continue", http.StatusContinue, false},
+		{"processing", http.StatusProcessing, false},
+		{"early hints", http.StatusEarlyHints, false},
+		{"last informational", 199, false},
+		{"switching protocols", http.StatusSwitchingProtocols, true},
+		{"success", http.StatusOK, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rw := &recordingResponseWriter{header: make(http.Header)}
+			sr := statusRecorder{ResponseWriter: rw}
+
+			sr.WriteHeader(tc.code)
+
+			if sr.wrote != tc.wrote {
+				t.Fatalf("wrote = %t, want %t", sr.wrote, tc.wrote)
+			}
+			if want := []int{tc.code}; !slices.Equal(rw.headerCodes, want) {
+				t.Fatalf("underlying WriteHeader calls = %v, want %v", rw.headerCodes, want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #321.

## Summary

- ignore zero-length template writes without committing headers or response state
- preserve the default HTML content type on the first non-empty write
- keep informational 1xx responses non-final except for 101 Switching Protocols
- cover GET and HEAD render failures plus recorder boundary behavior

## Verification

- reproduced the regression before the fix for GET and HEAD
- `go generate ./...`
- `go vet ./...`
- `gofmt -l .` and `gofumpt -l .`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`
- `JAWS_REQUIRE_NODE=1 go test -race -coverprofile=/private/tmp/jaws-issue-321-coverage.out ./...`
- `JAWS_REQUIRE_NODE=1 go test ./...`
- `go build -v ./...`
- `go mod verify` and `go mod tidy -diff`
- Linux/386 test packages cross-compiled for `lib/bind` and `lib/ui`
- rendered `go doc github.com/linkdata/jaws/lib/ui Handler` reviewed