### PR TITLE
what: classify Set as element-bound

### DIFF
--- a/lib/assets/js_test.go
+++ b/lib/assets/js_test.go
@@ -1242,6 +1242,68 @@ process.stdout.write(JSON.stringify({ called: called, lookedUp: lookedUp, thrown
 	}
 }
 
+func TestJawsJS_IsCommandRoutesElementBoundSet(t *testing.T) {
+	set := wire.WsMsg{What: what.Set, Data: "state=2"}
+	if !set.What.IsCommand() {
+		set.Jid = 1
+	}
+	call := wire.WsMsg{What: what.Call, Data: "app.notify=3"}
+	if !call.What.IsCommand() {
+		call.Jid = 1
+	}
+	frame, err := json.Marshal(set.Format() + call.Format())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	raw := runJawsJSSnippet(t, `
+let notified = 0;
+let errors = [];
+let lookups = [];
+window.app = {
+	state: 0,
+	notify: function(value) { notified = value; }
+};
+const elem = { id: "Jid.1", dataset: { jawsname: "app" } };
+document.getElementById = function(id) {
+	lookups.push(id);
+	return id === elem.id ? elem : null;
+};
+console.error = function(message) { errors.push(String(message)); };
+
+jawsMessage({ data: `+string(frame)+` });
+
+process.stdout.write(JSON.stringify({
+	state: window.app.state,
+	notified: notified,
+	errors: errors,
+	lookups: lookups,
+}));
+`)
+
+	var got struct {
+		State    int      `json:"state"`
+		Notified int      `json:"notified"`
+		Errors   []string `json:"errors"`
+		Lookups  []string `json:"lookups"`
+	}
+	if err = json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unexpected JSON output %q: %v", raw, err)
+	}
+	if got.State != 2 {
+		t.Errorf("Set value = %d, want 2", got.State)
+	}
+	if got.Notified != 3 {
+		t.Errorf("Call argument = %d, want 3", got.Notified)
+	}
+	if len(got.Errors) != 0 {
+		t.Errorf("client errors = %q, want none", got.Errors)
+	}
+	if want := []string{"Jid.1"}; !reflect.DeepEqual(got.Lookups, want) {
+		t.Errorf("element lookups = %q, want %q", got.Lookups, want)
+	}
+}
+
 func TestJawsJS_ElementScopedCallStillRequiresElement(t *testing.T) {
 	raw := runJawsJSSnippet(t, `
 let calls = 0;

--- a/lib/what/what.go
+++ b/lib/what/what.go
@@ -25,13 +25,15 @@ const (
 	Order
 	// Call calls a JavaScript function.
 	Call
-	// Set sets a JavaScript variable as path=json.
-	Set
 
 	separator
 
-	// Element manipulation
+	// Commands associated with an Element
 
+	// Set updates a JavaScript variable bound to the target element.
+	//
+	// Data uses the form path=json.
+	Set
 	// Inner sets the element's inner HTML.
 	Inner
 	// Delete deletes the element.

--- a/lib/what/what_string.go
+++ b/lib/what/what_string.go
@@ -15,8 +15,8 @@ func _() {
 	_ = x[Alert-4]
 	_ = x[Order-5]
 	_ = x[Call-6]
-	_ = x[Set-7]
-	_ = x[separator-8]
+	_ = x[separator-7]
+	_ = x[Set-8]
 	_ = x[Inner-9]
 	_ = x[Delete-10]
 	_ = x[Replace-11]
@@ -34,9 +34,9 @@ func _() {
 	_ = x[Hook-23]
 }
 
-const _What_name = "InvalidUpdateReloadRedirectAlertOrderCallSetseparatorInnerDeleteReplaceRemoveInsertAppendSAttrRAttrSClassRClassValueInputClickContextMenuHook"
+const _What_name = "InvalidUpdateReloadRedirectAlertOrderCallseparatorSetInnerDeleteReplaceRemoveInsertAppendSAttrRAttrSClassRClassValueInputClickContextMenuHook"
 
-var _What_index = [...]uint8{0, 7, 13, 19, 27, 32, 37, 41, 44, 53, 58, 64, 71, 77, 83, 89, 94, 99, 105, 111, 116, 121, 126, 137, 141}
+var _What_index = [...]uint8{0, 7, 13, 19, 27, 32, 37, 41, 50, 53, 58, 64, 71, 77, 83, 89, 94, 99, 105, 111, 116, 121, 126, 137, 141}
 
 func (i What) String() string {
 	idx := int(i) - 0

--- a/lib/what/what_test.go
+++ b/lib/what/what_test.go
@@ -58,9 +58,10 @@ func TestIsCommandAndValid(t *testing.T) {
 		{"Reload", Reload, true, true},
 		{"Redirect", Redirect, true, true},
 		{"Alert", Alert, true, true},
-		{"Set", Set, true, true},               // last command, just below separator
+		{"Call", Call, true, true},             // last command, just below separator
 		{"separator", separator, false, false}, // internal boundary marker, not a command or event
-		{"Inner", Inner, true, false},          // first element value, just above separator
+		{"Set", Set, true, false},              // first element value, just above separator
+		{"Inner", Inner, true, false},
 		{"Hook", Hook, true, false},            // last defined value, must stay valid
 		{"above Hook", Hook + 1, false, false}, // first undefined value above Hook
 		{"max uint8", What(255), false, false}, // top of the uint8 range, undefined


### PR DESCRIPTION
Fixes #324.

## Summary

- move `Set` across the private enum separator so `Set.IsCommand()` reports false
- renumber only `Set` from 7 to 8; the name-based wire protocol remains unchanged
- document that `Set` targets an element-bound JavaScript variable
- add direct predicate coverage and a bundled-client regression proving predicate-driven `Set` gets a Jid while request-scoped `Call` remains Jid-less

## Compatibility

JaWS is pre-release, so the numeric `Set` value changes from 7 to 8. `Inner` and all later public values retain their existing numbers. `What.String`, `what.Parse`, and WebSocket frames continue to use the `Set` name and remain unchanged.

## Verification

- reproduced both predicate and bundled-client regressions before the fix
- repeated focused regressions 20 times under the race detector
- `go generate ./...`
- `go vet ./...`
- `gofmt -l .` and `gofumpt -l .`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`
- `JAWS_REQUIRE_NODE=1 go test -race -coverprofile=/private/tmp/jaws-issue-324-coverage.out ./...`
- `JAWS_REQUIRE_NODE=1 go test ./...`
- `go build -v ./...`
- `go mod verify` and `go mod tidy -diff`
- Linux/386 test packages cross-compiled for `lib/bind` and `lib/ui`
- rendered `go doc` reviewed for `what.What.IsCommand` and `what.Set`