### PR TITLE
docs(named): define browser-safe name contract

### DIFF
--- a/lib/named/doc.go
+++ b/lib/named/doc.go
@@ -4,4 +4,7 @@
 // Labels are represented as template.HTML and are rendered as trusted HTML. When
 // labels come from user-controlled text, escape them before constructing the Bool
 // or BoolArray entry.
+//
+// Names used as browser form values must be valid UTF-8 and must not contain
+// U+0000 (NUL), so their identity survives an HTML and browser round trip.
 package named

--- a/lib/named/namedbool.go
+++ b/lib/named/namedbool.go
@@ -21,6 +21,9 @@ type Bool struct {
 
 // NewBool returns a [Bool] with the given name, HTML and checked state.
 //
+// To preserve its identity as a browser form value, name must be valid UTF-8
+// and must not contain U+0000 (NUL).
+//
 // The html argument is rendered as trusted HTML (it is the label shown in select
 // lists and checkboxes) and is not escaped. When it is derived from untrusted
 // user input it must be pre-escaped, e.g. template.HTML(template.HTMLEscapeString(s)).

--- a/lib/named/namedboolarray.go
+++ b/lib/named/namedboolarray.go
@@ -88,6 +88,9 @@ func (nba *BoolArray) JawsContains(elem *jaws.Element) (contents []jaws.UI) {
 // Add adds a [Bool] with the given name and trusted HTML text.
 // Returns itself.
 //
+// To preserve its identity as a browser form value, name must be valid UTF-8
+// and must not contain U+0000 (NUL).
+//
 // The html argument is rendered as trusted HTML and is not escaped; pre-escape it
 // (e.g. template.HTML(template.HTMLEscapeString(s))) when it is derived from
 // untrusted user input. See [NewBool].


### PR DESCRIPTION
## Summary

- document that Bool names used as browser form values must be valid UTF-8
- explicitly exclude U+0000 (NUL), which is valid UTF-8 but is normalized during HTML parsing
- publish the contract in the named package docs and both public name-entry APIs, NewBool and BoolArray.Add

This keeps the API and wire behavior unchanged while defining the supported name domain that preserves identity across HTML/browser round trips.

## Verification

- go generate ./...
- go vet ./...
- gofmt -l .
- gofumpt -l .
- staticcheck ./...
- golangci-lint run
- gosec ./...
- JAWS_REQUIRE_NODE=1 go test -race -coverprofile=/private/tmp/jaws-issue-323-coverage.out ./...
- JAWS_REQUIRE_NODE=1 go test ./...
- go build -v ./...
- GOOS=linux GOARCH=386 CGO_ENABLED=0 go test -exec=/usr/bin/true ./lib/bind/... ./lib/ui/...
- go mod verify
- go mod tidy -diff
- rendered go doc review for the named package, NewBool, and BoolArray.Add

Fixes #323