### PR TITLE
fix(bind): make SuccessHook a function alias

### DIFF
--- a/.agents/skills/jaws/SKILL.md
+++ b/.agents/skills/jaws/SKILL.md
@@ -98,7 +98,7 @@ These are the two usual building blocks for widget handlers passed to `$.Button`
 - Chain builders return a new `Binder[T]`:
   - `.SetLocked(fn)` / `.GetLocked(fn)` — override read/write semantics.
   - `.GetHTML(fn)` — supply a custom `JawsGetHTML` for HTML-rendering widgets (`Span`, `Div`, `A`, `Label`).
-  - `.Success(fn)` — run after a successful set. Accepted signatures: `func()`, `func() error`, `func(*Element)`, `func(*Element) error`. Non-nil errors propagate; a handler can still return `ErrValueUnchanged` to signal no change.
+  - `.Success(fn)` — run after a successful set. Accepted dynamic types: `func()`, `func() error`, `func(*Element)`, `func(*Element) error`; `SuccessHook` aliases the last form. Convert a defined function type before passing it. Non-nil errors propagate; a handler can still return `ErrValueUnchanged` to signal no change.
   - `.Clicked(fn)` / `.ContextMenu(fn)` — attach click/context handlers to the same bound variable.
   - `.InitialHTMLAttr(fn)` — attach attribute hooks.
 - Use `bind.New` for input widgets and for content whose natural key is the backing variable. Multiple widgets bound to the same pointer share a tag automatically, so `Request.Dirty(&field)` refreshes all of them.
@@ -216,7 +216,7 @@ template inclusion so the surrounding Template owns the DOM:
 
 JaWS parses template params as:
 - HTML attrs: `string`, `[]string`, `template.HTMLAttr`, `[]template.HTMLAttr`
-- Handlers: `InputFn` (the func alias `func(e *Element, val string) error`), plus anything satisfying `InputHandler`, `ClickHandler`, or `ContextMenuHandler`
+- Handlers: values whose dynamic type is exactly `InputFn` (the func alias `func(e *Element, val string) error`), plus anything satisfying `InputHandler`, `ClickHandler`, or `ContextMenuHandler`. Convert a defined function type to `InputFn` before passing it through params.
 - Tags: everything else (plus comparable handlers are auto-tagged)
 
 Implications:

--- a/element.go
+++ b/element.go
@@ -98,6 +98,9 @@ func (elem *Element) Freeze() {
 // be processed for it; see the package "Locking" documentation. Handlers added
 // after [Element.JawsRender] has returned (or [Element.Freeze] has been called)
 // are dropped; debug builds panic.
+//
+// Input callback functions used directly by signature are recognized according
+// to the dynamic-type rules documented by [InputFn].
 func (elem *Element) AddHandlers(h ...any) {
 	elem.appendHandlers(h...)
 }

--- a/eventhandler.go
+++ b/eventhandler.go
@@ -19,10 +19,16 @@ type InputHandler interface {
 	JawsInput(elem *Element, value string) (err error)
 }
 
-// InputFn is the signature of an input handling function. JaWS calls it for an
-// input or set message received from JavaScript over the WebSocket connection,
-// and for a hook message, which tests use to invoke the handler synchronously
-// (see [what.Hook]).
+// InputFn is the signature of an input handling function.
+//
+// JaWS calls it for an input or set message received from JavaScript over the
+// WebSocket connection, and for a hook message, which tests use to invoke the
+// handler synchronously (see [what.Hook]).
+//
+// When a function value is used directly as an input handler through an
+// any-valued API such as [ParseParams], [Element.AddHandlers] or
+// [CallEventHandlers], its dynamic type must be exactly InputFn. Convert a value
+// of a defined function type to InputFn first, or implement [InputHandler].
 type InputFn = func(elem *Element, value string) (err error)
 
 func callInputHandler(obj any, elem *Element, value string) (err error) {
@@ -77,6 +83,8 @@ func callEventHandlers(ui any, elem *Element, wht what.What, value string) (err 
 // CallEventHandlers calls the event handlers for the given [Element].
 //
 // Recovers from panics in user-provided handlers, returning them as errors.
+// Input callback functions used directly by signature are recognized according
+// to the dynamic-type rules documented by [InputFn].
 //
 // Request event dispatch calls this only after the Element is frozen, publishing
 // the completed handler slice before its lock-free read. A direct caller must not

--- a/lib/bind/bind_test.go
+++ b/lib/bind/bind_test.go
@@ -6,6 +6,7 @@ import (
 	"html/template"
 	"io"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -108,15 +109,68 @@ func testBindLockState(mu *sync.Mutex) string {
 }
 
 func TestBind_Hook_Success_panic(t *testing.T) {
-	defer func() {
-		if x := recover(); x == nil {
-			t.Fail()
-		}
-	}()
-	var mu deadlock.Mutex
-	var val string
-	New(&mu, &val).Success(func(n int) {})
-	t.Fail()
+	type definedSuccessHook func(*jaws.Element) error
+	tests := []struct {
+		name string
+		fn   any
+	}{
+		{"defined type with matching signature", definedSuccessHook(func(*jaws.Element) error { return nil })},
+		{"unsupported signature", func(int) {}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var recovered any
+			func() {
+				defer func() { recovered = recover() }()
+				var mu deadlock.Mutex
+				var val string
+				New(&mu, &val).Success(tt.fn)
+			}()
+			if recovered == nil {
+				t.Fatal("Success did not panic")
+			}
+			message, ok := recovered.(string)
+			if !ok {
+				t.Fatalf("panic = %v (%T), want string", recovered, recovered)
+			}
+			if want := fmt.Sprintf("%T", tt.fn); !strings.Contains(message, want) {
+				t.Errorf("panic = %q, want callback type %q", message, want)
+			}
+			if !strings.Contains(message, "unsupported callback type") {
+				t.Errorf("panic = %q, want unsupported callback type", message)
+			}
+			if strings.Contains(message, "[T]") {
+				t.Errorf("panic = %q, contains unsubstituted [T]", message)
+			}
+		})
+	}
+}
+
+func TestBind_Hook_SuccessHook(t *testing.T) {
+	var mu sync.Mutex
+	var value, calls int
+	var gotElem *jaws.Element
+	elem := new(jaws.Element)
+	errHook := errors.New("hook error")
+	hook := SuccessHook(func(elem *jaws.Element) error {
+		calls++
+		gotElem = elem
+		return errHook
+	})
+	binder := New(&mu, &value).Success(hook)
+
+	if err := binder.JawsSet(elem, 1); !errors.Is(err, errHook) {
+		t.Errorf("JawsSet error = %v, want %v", err, errHook)
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1", calls)
+	}
+	if gotElem != elem {
+		t.Errorf("element = %p, want %p", gotElem, elem)
+	}
+	if value != 1 {
+		t.Errorf("value = %d, want 1", value)
+	}
 }
 
 func TestBind_Hook_Success_breaksonerr(t *testing.T) {

--- a/lib/bind/binder.go
+++ b/lib/bind/binder.go
@@ -62,14 +62,17 @@ type ContextMenuHook[T comparable] func(bind Binder[T], elem *jaws.Element, clic
 // Do not lock or unlock the [Binder] within fn. Do not call [Getter.JawsGet].
 type InitialHTMLAttrHook[T comparable] func(bind Binder[T], elem *jaws.Element) (s template.HTMLAttr)
 
-// SuccessHook is a function to call when [Setter.JawsSet] returns with no error.
+// SuccessHook is called by [Setter.JawsSet] after [Binder.JawsSetLocked] succeeds.
 //
 // The [Binder] locks are not held when the function is called.
 //
 // Success hooks in a [Binder] chain are called in reverse registration order.
 // If one of them returns an error, that error is returned from [Setter.JawsSet] and
 // no more success hooks are called.
-type SuccessHook func(elem *jaws.Element) (err error)
+//
+// SuccessHook is a type alias so its values have the dynamic function type
+// accepted by [Binder.Success] through its any parameter.
+type SuccessHook = func(elem *jaws.Element) (err error)
 
 // Formatter customizes [Binder.Format] output for a value.
 type Formatter interface {
@@ -144,15 +147,21 @@ type Binder[T comparable] interface {
 	// and you probably want to call its [Binder.JawsGetLocked] first.
 	GetLocked(fn GetHook[T]) (newbind Binder[T])
 
-	// Success returns a [Binder] that will call fn after the value has been set
-	// with no errors. No locks are held when the function is called.
+	// Success returns a [Binder] that calls fn after a successful set.
+	//
+	// No locks are held when the function is called.
 	// If the function returns an error, that will be returned from [Setter.JawsSet].
 	//
-	// The function must have one of the following signatures:
+	// The dynamic type of fn must be one of the following function types:
 	//  * func()
 	//  * func() error
 	//  * func(*jaws.Element)
 	//  * func(*jaws.Element) error
+	//
+	// [SuccessHook] is an alias for the last function type.
+	// A value of a defined function type must be converted to the corresponding
+	// function type before it is passed. Success panics if fn has any other
+	// dynamic type.
 	Success(fn any) (newbind Binder[T])
 
 	// GetHTML returns a [Binder] that will call fn instead of the default
@@ -203,7 +212,8 @@ type Binder[T comparable] interface {
 type binder[T comparable] struct {
 	prev *binder[T]
 	RWLocker
-	ptr  *T
+	ptr *T
+	// The defined hook types distinguish roles whose signatures can coincide.
 	hook any
 }
 
@@ -409,5 +419,5 @@ func wrapSuccessHook(fn any) (hook SuccessHook) {
 	case func(*jaws.Element) error:
 		return fn
 	}
-	panic("Binder[T].Success(): function has wrong signature")
+	panic(fmt.Sprintf("bind.Binder.Success: unsupported callback type %T", fn))
 }

--- a/lib/ui/jsvar.go
+++ b/lib/ui/jsvar.go
@@ -106,6 +106,9 @@ var (
 
 // JsVarCheck validates a tentative browser update to a [JsVar].
 //
+// JsVarCheck is a type alias so a value of a defined function type with this
+// signature can be assigned to [JsVar.ClientCheck] without explicit conversion.
+//
 // The value contains the complete tentative state, and jsPath is the
 // browser-supplied jq path used for the update. The path is passed through
 // unchanged: jq accepts equivalent noncanonical spellings, including empty
@@ -127,7 +130,7 @@ var (
 // rejected tentative value. Any custom marshaling callback it invokes, including
 // MarshalJSON or MarshalText, has the same restrictions. The check must not
 // return or wrap [jaws.ErrEventUnhandled], which has handler-dispatch semantics.
-type JsVarCheck[T any] func(value *T, jsPath string) error
+type JsVarCheck[T any] = func(value *T, jsPath string) error
 
 // JSONSizeCheck returns a check that limits the JSON encoding of value.
 //

--- a/lib/ui/jsvar_check_test.go
+++ b/lib/ui/jsvar_check_test.go
@@ -147,6 +147,8 @@ func TestJSONSizeCheck(t *testing.T) {
 }
 
 func TestJsVarClientCheckContract(t *testing.T) {
+	type clientCheck func(*jsVarCheckedState, string) error
+
 	jw, err := jaws.New()
 	if err != nil {
 		t.Fatal(err)
@@ -167,7 +169,7 @@ func TestJsVarClientCheckContract(t *testing.T) {
 	errRejected := fmt.Errorf("blocked: %w", jaws.ErrValueUnchanged)
 	checkCalls := 0
 	checkHeldLock := true
-	jsvar.ClientCheck = func(value *jsVarCheckedState, jsPath string) error {
+	jsvar.ClientCheck = clientCheck(func(value *jsVarCheckedState, jsPath string) error {
 		checkCalls++
 		if value != &state {
 			t.Errorf("check value = %p, want %p", value, &state)
@@ -183,7 +185,7 @@ func TestJsVarClientCheckContract(t *testing.T) {
 			return errRejected
 		}
 		return nil
-	}
+	})
 
 	rw := RequestWriter{Request: tr.Request, Writer: io.Discard}
 	if err = rw.JsVar("checked", jsvar); err != nil {

--- a/lib/ui/object.go
+++ b/lib/ui/object.go
@@ -19,7 +19,11 @@ type ObjectClickedHook func(obj Object, elem *jaws.Element, click jaws.Click) (e
 type ObjectContextMenuHook func(obj Object, elem *jaws.Element, click jaws.Click) (err error)
 
 // ObjectInitialHTMLAttrHook is a function to call when a [jaws.Element] is initially rendered.
-type ObjectInitialHTMLAttrHook func(obj Object, elem *jaws.Element) (s template.HTMLAttr)
+//
+// ObjectInitialHTMLAttrHook is a type alias so a value of a defined function type
+// with this signature can be passed to [Object.InitialHTMLAttr] without explicit
+// conversion.
+type ObjectInitialHTMLAttrHook = func(obj Object, elem *jaws.Element) (s template.HTMLAttr)
 
 // Object is a chainable UI object that combines HTML rendering, tags and
 // optional event handlers.
@@ -45,7 +49,8 @@ type Object interface {
 var _ Object = &object{}
 
 type object struct {
-	prev    *object
+	prev *object
+	// The defined hook types distinguish click from context-menu callbacks.
 	handler any
 }
 

--- a/lib/ui/object_test.go
+++ b/lib/ui/object_test.go
@@ -167,17 +167,20 @@ func TestObject_InitialHTMLAttr_DefaultEmpty(t *testing.T) {
 }
 
 func TestObject_InitialHTMLAttr(t *testing.T) {
+	type initialHTMLAttrHook func(Object, *jaws.Element) template.HTMLAttr
+
 	order := []int{}
 	elem := &jaws.Element{}
+	first := initialHTMLAttrHook(func(got Object, gotElem *jaws.Element) (s template.HTMLAttr) {
+		order = append(order, 1)
+		if gotElem != elem {
+			t.Fatalf("unexpected elem %#v", gotElem)
+		}
+		return `data-first="1"`
+	})
 
 	obj := New("x").
-		InitialHTMLAttr(func(got Object, gotElem *jaws.Element) (s template.HTMLAttr) {
-			order = append(order, 1)
-			if gotElem != elem {
-				t.Fatalf("unexpected elem %#v", gotElem)
-			}
-			return `data-first="1"`
-		}).
+		InitialHTMLAttr(first).
 		InitialHTMLAttr(func(Object, *jaws.Element) (s template.HTMLAttr) {
 			order = append(order, 2)
 			s = `data-second="2"`

--- a/parseparams.go
+++ b/parseparams.go
@@ -22,8 +22,9 @@ func usableAsTag(t any) (ok bool) {
 // ParseParams parses the parameters passed to UI helpers when creating a new
 // [Element], returning UI tags, event handlers and HTML attributes.
 //
-// ParseParams recognizes [InputFn], [InputHandler], [ClickHandler] and
-// [ContextMenuHandler] as event handlers. It does not invoke
+// ParseParams recognizes values whose dynamic type is exactly [InputFn], and
+// values implementing [InputHandler], [ClickHandler] or [ContextMenuHandler],
+// as event handlers. It does not invoke
 // [InitialHTMLAttrHandler.JawsInitialHTMLAttr]; implementing that interface does
 // not affect parameter classification.
 //

--- a/setup.go
+++ b/setup.go
@@ -39,8 +39,11 @@ func makeAbsPath(prefix string, u *url.URL) *url.URL {
 // Setup configures [Jaws] with extra functionality and resources.
 //
 // The list of extras can be strings, [*url.URL], [*staticserve.StaticServe] or
-// []*staticserve.StaticServe URL resources, or a setup function matching
-// [SetupFunc] such as jawsboot.Setup.
+// []*staticserve.StaticServe URL resources, or a [SetupFunc] such as
+// jawsboot.Setup.
+//
+// A value of a defined function type must be converted to [SetupFunc] before it
+// is passed as an extra.
 //
 // A nil [SetupFunc] extra is ignored.
 //


### PR DESCRIPTION
## Summary

- make bind.SuccessHook an alias for the supported element-aware callback signature, so it naturally passes through Binder.Success without reflection
- use aliases for the other callback types whose roles do not require nominal identity: ui.ObjectInitialHTMLAttrHook and ui.JsVarCheck
- retain defined types for binder and Object click/context callbacks because identical signatures are used to distinguish their roles
- report the actual dynamic callback type when Binder.Success rejects a callback
- document why the aliases are load-bearing and clarify exact dynamic-type conversion requirements at the Binder.Success, Jaws.Setup, and InputFn any-valued boundaries
- cover alias assignability through the real Binder, Object, and JsVar dispatch paths

## Verification

- go generate ./...
- go vet ./...
- gofmt -l .
- gofumpt -l .
- staticcheck ./...
- golangci-lint run
- gosec ./...
- JAWS_REQUIRE_NODE=1 go test -race -coverprofile=/private/tmp/jaws-issue-325-final-coverage.out ./...
- JAWS_REQUIRE_NODE=1 go test ./...
- go build -v ./...
- GOOS=linux GOARCH=386 CGO_ENABLED=0 go test -exec=/usr/bin/true ./lib/bind/... ./lib/ui/...
- go mod verify
- go mod tidy -diff
- rendered go doc review for all affected exported symbols

Fixes #325