### PR TITLE
fix(jaws): surface TestServe loop panics

### DIFF
--- a/jawstest/jawstest.go
+++ b/jawstest/jawstest.go
@@ -25,7 +25,8 @@ import (
 
 // TestRequest is a request harness intended for tests.
 //
-// Values must be created with [NewTestRequest]; the zero value is not usable.
+// Values must be created with [NewTestRequest] or [NewTestRequestWithPanic]; the
+// zero value is not usable.
 //
 // The embedded [jaws.Request] provides the usual request methods (NewElement,
 // JawsKeyString, and so on). The channels expose the loop's wiring: send incoming
@@ -70,10 +71,24 @@ func repanic(recovered any) {
 //
 // Passing nil for r uses a GET / request with no body.
 //
+// Unexpected request-loop panics are re-raised on the loop goroutine. Use
+// [NewTestRequestWithPanic] to capture an expected panic.
+//
 // It panics if the request cannot be created or claimed. It requires the Jaws
 // processing loop ([jaws.Jaws.Serve] or [jaws.Jaws.ServeWithTimeout]) to be running;
 // if it is not, the underlying [jaws.Jaws.TestServe] panics.
 func NewTestRequest(jw *jaws.Jaws, r *http.Request) *TestRequest {
+	return NewTestRequestWithPanic(jw, r, repanic)
+}
+
+// NewTestRequestWithPanic creates and serves a [TestRequest] with explicit loop-panic handling.
+//
+// onPanic is called on the request-loop goroutine when it stops, with the
+// recovered value or nil after a normal exit. DoneCh closes after onPanic
+// returns or unwinds.
+//
+// It otherwise behaves like [NewTestRequest].
+func NewTestRequestWithPanic(jw *jaws.Jaws, r *http.Request, onPanic func(recovered any)) *TestRequest {
 	if r == nil {
 		r = httptest.NewRequest(http.MethodGet, "/", nil)
 	}
@@ -91,9 +106,7 @@ func NewTestRequest(jw *jaws.Jaws, r *http.Request) *TestRequest {
 		Request:  rq,
 		Recorder: rr,
 	}
-	// This harness does not expect loop panics, so re-raise any so they surface
-	// instead of being silently swallowed.
-	tr.InCh, tr.OutCh, tr.BcastCh, tr.ReadyCh, tr.DoneCh = jw.TestServe(rq, repanic)
+	tr.InCh, tr.OutCh, tr.BcastCh, tr.ReadyCh, tr.DoneCh = jw.TestServe(rq, onPanic)
 	return tr
 }
 

--- a/jawstest/jawstest_test.go
+++ b/jawstest/jawstest_test.go
@@ -1,12 +1,10 @@
 package jawstest_test
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"os/exec"
-	"strings"
 	"testing"
 	"time"
 
@@ -17,12 +15,10 @@ import (
 	"github.com/linkdata/jaws/lib/wire"
 )
 
-const jawstestUpdaterPanic = "jawstest updater panic sentinel"
-
-type jawstestPanickingUpdater struct{}
+type jawstestPanickingUpdater struct{ value any }
 
 func (jawstestPanickingUpdater) JawsRender(*jaws.Element, io.Writer, []any) error { return nil }
-func (jawstestPanickingUpdater) JawsUpdate(*jaws.Element)                         { panic(jawstestUpdaterPanic) }
+func (u jawstestPanickingUpdater) JawsUpdate(*jaws.Element)                       { panic(u.value) }
 
 // TestNewTestRequest_BcastChToOutCh drives a broadcast through the harness's
 // exposed channels end to end: a page-global Alert injected on BcastCh must
@@ -120,47 +116,45 @@ func TestNewTestRequest_WithExplicitRequest(t *testing.T) {
 	<-tr.ReadyCh
 }
 
-func TestNewTestRequest_ReportsUpdaterPanic(t *testing.T) {
-	const helperEnv = "JAWS_TEST_UPDATER_PANIC_HELPER"
-	if os.Getenv(helperEnv) == "1" {
-		jw, err := jaws.New()
-		if err != nil {
-			t.Fatal(err)
-		}
-		t.Cleanup(jw.Close)
-		go jw.Serve()
-
-		tr := jawstest.NewTestRequest(jw, nil)
-		select {
-		case <-tr.ReadyCh:
-		case <-time.After(2 * time.Second):
-			t.Fatal("timeout waiting for the request loop to start")
-		}
-		const updateTag = tag.Tag("jawstest-panic-update")
-		elem := tr.NewElement(jawstestPanickingUpdater{})
-		elem.Tag(updateTag)
-		elem.Freeze()
-		tr.BcastCh <- wire.Message{Dest: updateTag, What: what.Update}
-		select {
-		case <-tr.DoneCh:
-			t.Fatal("request loop returned normally after JawsUpdate panic")
-		case <-time.After(2 * time.Second):
-			t.Fatal("timeout waiting for JawsUpdate panic")
-		}
-		return
+func TestNewTestRequestWithPanic_ReportsUpdaterPanic(t *testing.T) {
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
 	}
+	t.Cleanup(jw.Close)
+	go jw.Serve()
 
-	// NewTestRequest re-panics on its request-loop goroutine, so a subprocess is
-	// required to observe the panic without terminating this test process.
-	// #nosec G204 -- os.Args[0] is the current test binary and all arguments are fixed.
-	cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run=^TestNewTestRequest_ReportsUpdaterPanic$", "-test.count=1", "-test.timeout=5s")
-	cmd.Env = append(os.Environ(), helperEnv+"=1", "GOTRACEBACK=none")
-	output, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatal("jawstest request loop returned normally after JawsUpdate panic")
+	wantPanic := errors.New("jawstest updater panic sentinel")
+	panicCh := make(chan any, 1)
+	tr := jawstest.NewTestRequestWithPanic(jw, nil, func(recovered any) {
+		panicCh <- recovered
+	})
+	defer tr.Close()
+	select {
+	case <-tr.ReadyCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for the request loop to start")
 	}
-	if !strings.Contains(string(output), "panic: "+jawstestUpdaterPanic) {
-		t.Fatalf("subprocess did not report the updater panic:\n%s", output)
+	const updateTag = tag.Tag("jawstest-panic-update")
+	elem := tr.NewElement(jawstestPanickingUpdater{value: wantPanic})
+	elem.Tag(updateTag)
+	elem.Freeze()
+	tr.BcastCh <- wire.Message{Dest: updateTag, What: what.Update}
+	select {
+	case <-tr.DoneCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for JawsUpdate panic")
+	}
+	select {
+	case recovered := <-panicCh:
+		if recovered != wantPanic {
+			t.Fatalf("onPanic recovered %#v, want original value %#v", recovered, wantPanic)
+		}
+	default:
+		t.Fatal("onPanic was not called")
+	}
+	if got := jw.RequestCount(); got != 0 {
+		t.Fatalf("RequestCount() = %d, want 0 after recycling the test request", got)
 	}
 }
 

--- a/jawstest/jawstest_test.go
+++ b/jawstest/jawstest_test.go
@@ -1,16 +1,28 @@
 package jawstest_test
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/linkdata/jaws"
 	"github.com/linkdata/jaws/jawstest"
+	"github.com/linkdata/jaws/lib/tag"
 	"github.com/linkdata/jaws/lib/what"
 	"github.com/linkdata/jaws/lib/wire"
 )
+
+const jawstestUpdaterPanic = "jawstest updater panic sentinel"
+
+type jawstestPanickingUpdater struct{}
+
+func (jawstestPanickingUpdater) JawsRender(*jaws.Element, io.Writer, []any) error { return nil }
+func (jawstestPanickingUpdater) JawsUpdate(*jaws.Element)                         { panic(jawstestUpdaterPanic) }
 
 // TestNewTestRequest_BcastChToOutCh drives a broadcast through the harness's
 // exposed channels end to end: a page-global Alert injected on BcastCh must
@@ -106,6 +118,50 @@ func TestNewTestRequest_WithExplicitRequest(t *testing.T) {
 	}
 	defer tr.Close()
 	<-tr.ReadyCh
+}
+
+func TestNewTestRequest_ReportsUpdaterPanic(t *testing.T) {
+	const helperEnv = "JAWS_TEST_UPDATER_PANIC_HELPER"
+	if os.Getenv(helperEnv) == "1" {
+		jw, err := jaws.New()
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(jw.Close)
+		go jw.Serve()
+
+		tr := jawstest.NewTestRequest(jw, nil)
+		select {
+		case <-tr.ReadyCh:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout waiting for the request loop to start")
+		}
+		const updateTag = tag.Tag("jawstest-panic-update")
+		elem := tr.NewElement(jawstestPanickingUpdater{})
+		elem.Tag(updateTag)
+		elem.Freeze()
+		tr.BcastCh <- wire.Message{Dest: updateTag, What: what.Update}
+		select {
+		case <-tr.DoneCh:
+			t.Fatal("request loop returned normally after JawsUpdate panic")
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout waiting for JawsUpdate panic")
+		}
+		return
+	}
+
+	// NewTestRequest re-panics on its request-loop goroutine, so a subprocess is
+	// required to observe the panic without terminating this test process.
+	// #nosec G204 -- os.Args[0] is the current test binary and all arguments are fixed.
+	cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run=^TestNewTestRequest_ReportsUpdaterPanic$", "-test.count=1", "-test.timeout=5s")
+	cmd.Env = append(os.Environ(), helperEnv+"=1", "GOTRACEBACK=none")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("jawstest request loop returned normally after JawsUpdate panic")
+	}
+	if !strings.Contains(string(output), "panic: "+jawstestUpdaterPanic) {
+		t.Fatalf("subprocess did not report the updater panic:\n%s", output)
+	}
 }
 
 // TestClose_SecondCallIsSafe pins that [jawstest.TestRequest.Close] is idempotent:

--- a/lib/ui/template_register_test.go
+++ b/lib/ui/template_register_test.go
@@ -118,60 +118,102 @@ func TestRegister_TemplateUpdaterReportsUnclaimed(t *testing.T) {
 // request loop, which RequestWriter.Register cannot do because it updates immediately: a
 // registerUI child is rendered with a tag, then that tag is dirtied.
 func TestRegister_TemplateUpdaterOnTheRequestLoop(t *testing.T) {
-	jw, err := jaws.New()
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(jw.Close)
-	logger := new(templateLogger)
-	jw.Logger = logger
-	if err = jw.AddTemplateLookuper(template.Must(template.New("reg-plain").Parse(`plain`))); err != nil {
-		t.Fatal(err)
-	}
-	go jw.Serve()
+	for _, tt := range []struct {
+		name      string
+		withLog   bool
+		wantAlive bool // does the request loop survive?
+	}{
+		{"with logger the loop continues", true, true},
+		{"without logger the request is torn down", false, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			jw, err := jaws.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(jw.Close)
+			logger := new(templateLogger)
+			if tt.withLog {
+				jw.Logger = logger
+			}
+			if err = jw.AddTemplateLookuper(template.Must(template.New("reg-plain").Parse(`plain`))); err != nil {
+				t.Fatal(err)
+			}
+			go jw.Serve()
 
-	tr := jawstest.NewTestRequest(jw, nil)
-	t.Cleanup(func() {
-		tr.Close()
-		<-tr.DoneCh
-	})
-	<-tr.ReadyCh
+			panicCh := make(chan any, 1)
+			tr := jawstest.NewTestRequestWithPanic(jw, nil, func(recovered any) {
+				panicCh <- recovered
+			})
+			t.Cleanup(func() {
+				tr.Close()
+				<-tr.DoneCh
+			})
+			<-tr.ReadyCh
 
-	dirty := tag.Tag("registered")
-	tmpl := NewTemplate("div", "reg-plain", tag.Tag("dot"))
-	// Build the registered Element by hand: RequestWriter.Register would run the
-	// failing update immediately, and registerUI.JawsRender ignores params, so
-	// NewUI would not apply the tag. This leaves the first failing update to the
-	// request loop.
-	regElem := tr.NewElement(registerUI{Updater: tmpl})
-	regElem.Tag(dirty)
-	regElem.Freeze()
+			dirty := tag.Tag("registered")
+			tmpl := NewTemplate("div", "reg-plain", tag.Tag("dot"))
+			// Build the registered Element by hand: RequestWriter.Register would run the
+			// failing update immediately, and registerUI.JawsRender ignores params, so
+			// NewUI would not apply the tag. This leaves the first failing update to the
+			// request loop.
+			regElem := tr.NewElement(registerUI{Updater: tmpl})
+			regElem.Tag(dirty)
+			regElem.Freeze()
 
-	tr.BcastCh <- wire.Message{Dest: dirty, What: what.Update}
+			tr.BcastCh <- wire.Message{Dest: dirty, What: what.Update}
 
-	// BcastCh preserves send order. Receiving this Alert proves the loop processed
-	// the preceding failing update and kept serving because a logger was configured.
-	const probe = "still alive"
-	tr.BcastCh <- wire.Message{What: what.Alert, Data: probe}
-	select {
-	case msg, ok := <-tr.OutCh:
-		if !ok {
-			t.Fatal("the request loop stopped although a logger was configured")
-		}
-		if msg.Jid != 0 || msg.What != what.Alert || msg.Data != probe {
-			t.Fatalf("liveness probe = %+v, want Alert %q", msg, probe)
-		}
-	case <-tr.DoneCh:
-		t.Fatal("the request loop stopped although a logger was configured")
-	case <-time.After(2 * time.Second):
-		t.Fatal("timeout waiting for the request-loop liveness probe")
-	}
+			if tt.wantAlive {
+				// BcastCh preserves send order. Receiving this Alert proves the loop
+				// processed the preceding failing update and kept serving afterwards.
+				const probe = "still alive"
+				tr.BcastCh <- wire.Message{What: what.Alert, Data: probe}
+				select {
+				case msg, ok := <-tr.OutCh:
+					if !ok {
+						t.Fatal("the request loop stopped although a logger was configured")
+					}
+					if msg.Jid != 0 || msg.What != what.Alert || msg.Data != probe {
+						t.Fatalf("liveness probe = %+v, want Alert %q", msg, probe)
+					}
+				case <-tr.DoneCh:
+					t.Fatal("the request loop stopped although a logger was configured")
+				case <-time.After(2 * time.Second):
+					t.Fatal("timeout waiting for the request-loop liveness probe")
+				}
 
-	// Join the request-loop goroutine, then drain the asynchronous logger.
-	tr.Close()
-	<-tr.DoneCh
-	logged := logger.sync(t, jw)
-	if len(logged) != 1 || !errors.Is(logged[0], ErrElementStateUnclaimed) {
-		t.Fatalf("logged errors = %v, want one %v", logged, ErrElementStateUnclaimed)
+				// Join the request-loop goroutine, then drain the asynchronous logger.
+				tr.Close()
+				<-tr.DoneCh
+				select {
+				case recovered := <-panicCh:
+					if recovered != nil {
+						t.Fatalf("onPanic recovered = %v, want nil", recovered)
+					}
+				default:
+					t.Fatal("onPanic was not called")
+				}
+				logged := logger.sync(t, jw)
+				if len(logged) != 1 || !errors.Is(logged[0], ErrElementStateUnclaimed) {
+					t.Fatalf("logged errors = %v, want one %v", logged, ErrElementStateUnclaimed)
+				}
+				return
+			}
+
+			select {
+			case <-tr.DoneCh:
+			case <-time.After(2 * time.Second):
+				t.Fatal("timeout waiting for the request loop to tear down")
+			}
+			select {
+			case recovered := <-panicCh:
+				err, ok := recovered.(error)
+				if !ok || !errors.Is(err, ErrElementStateUnclaimed) {
+					t.Fatalf("onPanic recovered = %v, want an error wrapping %v", recovered, ErrElementStateUnclaimed)
+				}
+			default:
+				t.Fatal("onPanic was not called")
+			}
+		})
 	}
 }

--- a/lib/ui/template_register_test.go
+++ b/lib/ui/template_register_test.go
@@ -118,83 +118,60 @@ func TestRegister_TemplateUpdaterReportsUnclaimed(t *testing.T) {
 // request loop, which RequestWriter.Register cannot do because it updates immediately: a
 // registerUI child is rendered with a tag, then that tag is dirtied.
 func TestRegister_TemplateUpdaterOnTheRequestLoop(t *testing.T) {
-	for _, tt := range []struct {
-		name      string
-		withLog   bool
-		wantAlive bool // does the request loop survive?
-	}{
-		{"with logger the loop continues", true, true},
-		// Request.process recovers the panic and tears the request down; its follow-up Log
-		// emits nothing and TestServe's callback sees nil, because process consumed it.
-		{"without logger the request is torn down", false, false},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			jw, err := jaws.New()
-			if err != nil {
-				t.Fatal(err)
-			}
-			t.Cleanup(jw.Close)
-			logger := new(templateLogger)
-			if tt.withLog {
-				jw.Logger = logger
-			}
-			if err = jw.AddTemplateLookuper(template.Must(template.New("reg-plain").Parse(`plain`))); err != nil {
-				t.Fatal(err)
-			}
-			go jw.Serve()
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+	logger := new(templateLogger)
+	jw.Logger = logger
+	if err = jw.AddTemplateLookuper(template.Must(template.New("reg-plain").Parse(`plain`))); err != nil {
+		t.Fatal(err)
+	}
+	go jw.Serve()
 
-			tr := jawstest.NewTestRequest(jw, nil)
-			t.Cleanup(func() {
-				tr.Close()
-				<-tr.DoneCh
-			})
-			<-tr.ReadyCh
+	tr := jawstest.NewTestRequest(jw, nil)
+	t.Cleanup(func() {
+		tr.Close()
+		<-tr.DoneCh
+	})
+	<-tr.ReadyCh
 
-			dirty := tag.Tag("registered")
-			tmpl := NewTemplate("div", "reg-plain", tag.Tag("dot"))
-			// Build the registered Element by hand: RequestWriter.Register would run the
-			// failing update immediately, and registerUI.JawsRender ignores params, so
-			// NewUI would not apply the tag. This leaves the first failing update to the
-			// request loop.
-			regElem := tr.NewElement(registerUI{Updater: tmpl})
-			regElem.Tag(dirty)
-			regElem.Freeze()
+	dirty := tag.Tag("registered")
+	tmpl := NewTemplate("div", "reg-plain", tag.Tag("dot"))
+	// Build the registered Element by hand: RequestWriter.Register would run the
+	// failing update immediately, and registerUI.JawsRender ignores params, so
+	// NewUI would not apply the tag. This leaves the first failing update to the
+	// request loop.
+	regElem := tr.NewElement(registerUI{Updater: tmpl})
+	regElem.Tag(dirty)
+	regElem.Freeze()
 
-			tr.BcastCh <- wire.Message{Dest: dirty, What: what.Update}
+	tr.BcastCh <- wire.Message{Dest: dirty, What: what.Update}
 
-			if tt.wantAlive {
-				// BcastCh preserves send order. Receiving this Alert proves the loop
-				// processed the preceding failing update and kept serving afterwards.
-				const probe = "still alive"
-				tr.BcastCh <- wire.Message{What: what.Alert, Data: probe}
-				select {
-				case msg, ok := <-tr.OutCh:
-					if !ok {
-						t.Fatal("the request loop stopped although a logger was configured")
-					}
-					if msg.Jid != 0 || msg.What != what.Alert || msg.Data != probe {
-						t.Fatalf("liveness probe = %+v, want Alert %q", msg, probe)
-					}
-				case <-tr.DoneCh:
-					t.Fatal("the request loop stopped although a logger was configured")
-				case <-time.After(2 * time.Second):
-					t.Fatal("timeout waiting for the request-loop liveness probe")
-				}
+	// BcastCh preserves send order. Receiving this Alert proves the loop processed
+	// the preceding failing update and kept serving because a logger was configured.
+	const probe = "still alive"
+	tr.BcastCh <- wire.Message{What: what.Alert, Data: probe}
+	select {
+	case msg, ok := <-tr.OutCh:
+		if !ok {
+			t.Fatal("the request loop stopped although a logger was configured")
+		}
+		if msg.Jid != 0 || msg.What != what.Alert || msg.Data != probe {
+			t.Fatalf("liveness probe = %+v, want Alert %q", msg, probe)
+		}
+	case <-tr.DoneCh:
+		t.Fatal("the request loop stopped although a logger was configured")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for the request-loop liveness probe")
+	}
 
-				// Join the request-loop goroutine, then drain the asynchronous logger.
-				tr.Close()
-				<-tr.DoneCh
-				logged := logger.sync(t, jw)
-				if len(logged) != 1 || !errors.Is(logged[0], ErrElementStateUnclaimed) {
-					t.Fatalf("logged errors = %v, want one %v", logged, ErrElementStateUnclaimed)
-				}
-				return
-			}
-			select {
-			case <-tr.DoneCh:
-			case <-time.After(2 * time.Second):
-				t.Fatal("timeout waiting for the request loop to tear down")
-			}
-		})
+	// Join the request-loop goroutine, then drain the asynchronous logger.
+	tr.Close()
+	<-tr.DoneCh
+	logged := logger.sync(t, jw)
+	if len(logged) != 1 || !errors.Is(logged[0], ErrElementStateUnclaimed) {
+		t.Fatalf("logged errors = %v, want one %v", logged, ErrElementStateUnclaimed)
 	}
 }

--- a/request.go
+++ b/request.go
@@ -1181,6 +1181,8 @@ func (rq *Request) runWebSocket(ws *websocket.Conn, pingInterval, wsTimeout time
 		go wire.PingLoop(ctx, cancelRequest, rq.Jaws.Done(), pingInterval, wsTimeout, ws)
 		broadcastMsgCh := pendingSubscription
 		pendingSubscription = nil
+		// Production deliberately discards the recovered value so a loop panic stays
+		// contained to the failed Request while its connection is torn down.
 		rq.process(broadcastMsgCh, incomingMsgCh, outboundMsgCh) // unsubscribes broadcastMsgCh, closes outboundMsgCh
 	}
 	return

--- a/request_test.go
+++ b/request_test.go
@@ -1909,12 +1909,16 @@ func TestRequest_UpdatePanicLogs(t *testing.T) {
 			panic("wildpanic")
 		},
 	}
+	rq.ExpectPanic = true
 	th.NoErr(rq.UI(tss))
 	rq.Dirty(tss)
 	select {
 	case <-th.C:
 		th.Timeout()
 	case <-rq.DoneCh:
+	}
+	if !rq.Panicked || rq.PanicVal != "wildpanic" {
+		t.Fatalf("request-loop panic = %#v, want %q", rq.PanicVal, "wildpanic")
 	}
 	loggedErr := logger.next(t)
 	if !strings.Contains(loggedErr.Error(), "wildpanic") {

--- a/requestloop.go
+++ b/requestloop.go
@@ -24,9 +24,9 @@ import (
 
 // process runs the main message-processing loop.
 //
-// It unsubscribes broadcastMsgCh and closes outboundMsgCh before returning. If
-// the loop panics, process completes that cleanup, logs it non-fatally and returns
-// the original recovered value.
+// It unsubscribes broadcastMsgCh and closes outboundMsgCh before returning. A
+// loop panic is contained, a diagnostic is passed to [Jaws.Log], and the
+// recovered value is returned unchanged for the caller to handle.
 func (rq *Request) process(broadcastMsgCh chan wire.Message, incomingMsgCh <-chan wire.WsMsg, outboundMsgCh chan<- wire.WsMsg) (panicValue any) {
 	jawsDoneCh := rq.Jaws.Done()
 	// Snapshot cancelFn under rq.mu, the same way ServeHTTP does: its only writers

--- a/requestloop.go
+++ b/requestloop.go
@@ -22,8 +22,12 @@ import (
 	"github.com/linkdata/jaws/lib/wire"
 )
 
-// process is the main message processing loop. Will unsubscribe broadcastMsgCh and close outboundMsgCh on exit.
-func (rq *Request) process(broadcastMsgCh chan wire.Message, incomingMsgCh <-chan wire.WsMsg, outboundMsgCh chan<- wire.WsMsg) {
+// process runs the main message-processing loop.
+//
+// It unsubscribes broadcastMsgCh and closes outboundMsgCh before returning. If
+// the loop panics, process completes that cleanup, logs it non-fatally and returns
+// the original recovered value.
+func (rq *Request) process(broadcastMsgCh chan wire.Message, incomingMsgCh <-chan wire.WsMsg, outboundMsgCh chan<- wire.WsMsg) (panicValue any) {
 	jawsDoneCh := rq.Jaws.Done()
 	// Snapshot cancelFn under rq.mu, the same way ServeHTTP does: its only writers
 	// (claim, getRequestLocked, releaseBuffersLocked) run strictly before or after
@@ -38,6 +42,7 @@ func (rq *Request) process(broadcastMsgCh chan wire.Message, incomingMsgCh <-cha
 	go rq.eventCaller(eventCallCh, outboundMsgCh, eventDoneCh)
 
 	defer func() {
+		panicValue = recover()
 		rq.Jaws.unsubscribe(broadcastMsgCh)
 		// process runs only for a running (hence claimed) Request, so its WebSocket
 		// earns the session grace window.
@@ -52,15 +57,15 @@ func (rq *Request) process(broadcastMsgCh chan wire.Message, incomingMsgCh <-cha
 				}
 			case <-eventDoneCh:
 				close(outboundMsgCh)
-				if x := recover(); x != nil {
+				if panicValue != nil {
 					var err error
 					var ok bool
-					if err, ok = x.(error); !ok {
-						err = fmt.Errorf("jaws: %v panic: %v", rq, x)
+					if err, ok = panicValue.(error); !ok {
+						err = fmt.Errorf("jaws: %v panic: %v", rq, panicValue)
 					}
 					// Log non-fatally rather than MustLog: this runs in the cleanup
-					// defer with no surrounding recover, and the panic is already
-					// contained, so the request is torn down regardless.
+					// defer with no surrounding recover, and the request is torn down
+					// regardless.
 					_ = rq.Jaws.Log(err)
 				}
 				return

--- a/testserve.go
+++ b/testserve.go
@@ -28,7 +28,8 @@ import (
 // when the loop goroutine stops, before doneCh is closed, so a harness can publish
 // captured panic state before any <-doneCh waiter observes it. A harness that does
 // not expect panics should re-panic when the value is non-nil so unexpected loop
-// panics still surface.
+// panics still surface. doneCh is closed even if onPanic panics or calls
+// runtime.Goexit.
 func (jw *Jaws) TestServe(rq *Request, onPanic func(recovered any)) (inCh chan wire.WsMsg, outCh chan wire.WsMsg, bcastCh chan wire.Message, readyCh, doneCh chan struct{}) {
 	bcastCh = make(chan wire.Message, 64)
 	// Subscribe and then rendezvous with the Serve loop so the subscription is
@@ -70,14 +71,10 @@ func (jw *Jaws) TestServe(rq *Request, onPanic func(recovered any)) (inCh chan w
 	doneCh = make(chan struct{})
 
 	go func() {
-		// onPanic runs before doneCh closes so a harness can publish its captured
-		// panic state before any <-doneCh waiter observes it. onPanic may re-panic
-		// to propagate an unexpected panic; that skips the close, which is moot
-		// since the goroutine is then crashing the test anyway.
-		defer func() {
-			onPanic(recover())
-			close(doneCh)
-		}()
+		// Registered first so it runs last: onPanic is invoked before doneCh closes,
+		// while the close still runs if onPanic panics or calls runtime.Goexit.
+		defer close(doneCh)
+		defer func() { onPanic(recover()) }()
 		close(readyCh)
 		panicValue := rq.process(bcastCh, inCh, outCh)
 		// Recycle before re-panicking: the outer defer reports the loop panic, so

--- a/testserve.go
+++ b/testserve.go
@@ -79,8 +79,13 @@ func (jw *Jaws) TestServe(rq *Request, onPanic func(recovered any)) (inCh chan w
 			close(doneCh)
 		}()
 		close(readyCh)
-		rq.process(bcastCh, inCh, outCh)
+		panicValue := rq.process(bcastCh, inCh, outCh)
+		// Recycle before re-panicking: the outer defer reports the loop panic, so
+		// propagating it first would skip the Request's lifecycle cleanup.
 		jw.recycle(rq)
+		if panicValue != nil {
+			panic(panicValue)
+		}
 	}()
 	return
 }

--- a/testserve_panic_external_test.go
+++ b/testserve_panic_external_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"testing"
 	"time"
 
@@ -19,7 +20,8 @@ type panickingUpdater struct{ value any }
 func (panickingUpdater) JawsRender(*jaws.Element, io.Writer, []any) error { return nil }
 func (u panickingUpdater) JawsUpdate(*jaws.Element)                       { panic(u.value) }
 
-func TestTestServeReportsUpdaterPanic(t *testing.T) {
+func startPanickingTestServe(t *testing.T, onPanic func(recovered any)) (jw *jaws.Jaws, doneCh chan struct{}, wantPanic error) {
+	t.Helper()
 	jw, err := jaws.New()
 	if err != nil {
 		t.Fatal(err)
@@ -29,7 +31,7 @@ func TestTestServeReportsUpdaterPanic(t *testing.T) {
 
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
 	rq := jw.NewRequest(r)
-	wantPanic := errors.New("update boom")
+	wantPanic = errors.New("update boom")
 	elem := rq.NewElement(panickingUpdater{value: wantPanic})
 	const updateTag = tag.Tag("panic-update")
 	elem.Tag(updateTag)
@@ -38,22 +40,52 @@ func TestTestServeReportsUpdaterPanic(t *testing.T) {
 		t.Fatal("could not claim request")
 	}
 
-	panicCh := make(chan any, 1)
-	_, _, bcastCh, readyCh, doneCh := jw.TestServe(rq, func(recovered any) {
-		panicCh <- recovered
-	})
+	_, _, bcastCh, readyCh, doneCh := jw.TestServe(rq, onPanic)
 	select {
 	case <-readyCh:
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for TestServe to start")
 	}
 	bcastCh <- wire.Message{Dest: updateTag, What: what.Update}
+	return
+}
+
+func waitForTestServeDone(t *testing.T, doneCh <-chan struct{}) {
+	t.Helper()
 	select {
 	case <-doneCh:
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for TestServe to stop")
 	}
+}
 
+func TestTestServeReportsUpdaterPanic(t *testing.T) {
+	panicCh := make(chan any, 1)
+	jw, doneCh, wantPanic := startPanickingTestServe(t, func(recovered any) {
+		panicCh <- recovered
+	})
+	waitForTestServeDone(t, doneCh)
+
+	select {
+	case recovered := <-panicCh:
+		if recovered != wantPanic {
+			t.Fatalf("onPanic recovered %#v, want original value %#v", recovered, wantPanic)
+		}
+	default:
+		t.Fatal("onPanic was not called")
+	}
+	if got := jw.RequestCount(); got != 0 {
+		t.Fatalf("RequestCount() = %d, want 0 after TestServe recycled the request", got)
+	}
+}
+
+func TestTestServeClosesDoneWhenOnPanicGoexits(t *testing.T) {
+	panicCh := make(chan any, 1)
+	jw, doneCh, wantPanic := startPanickingTestServe(t, func(recovered any) {
+		panicCh <- recovered
+		runtime.Goexit()
+	})
+	waitForTestServeDone(t, doneCh)
 	select {
 	case recovered := <-panicCh:
 		if recovered != wantPanic {

--- a/testserve_panic_external_test.go
+++ b/testserve_panic_external_test.go
@@ -1,0 +1,68 @@
+package jaws_test
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/linkdata/jaws"
+	"github.com/linkdata/jaws/lib/tag"
+	"github.com/linkdata/jaws/lib/what"
+	"github.com/linkdata/jaws/lib/wire"
+)
+
+type panickingUpdater struct{ value any }
+
+func (panickingUpdater) JawsRender(*jaws.Element, io.Writer, []any) error { return nil }
+func (u panickingUpdater) JawsUpdate(*jaws.Element)                       { panic(u.value) }
+
+func TestTestServeReportsUpdaterPanic(t *testing.T) {
+	jw, err := jaws.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+	go jw.Serve()
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	rq := jw.NewRequest(r)
+	wantPanic := errors.New("update boom")
+	elem := rq.NewElement(panickingUpdater{value: wantPanic})
+	const updateTag = tag.Tag("panic-update")
+	elem.Tag(updateTag)
+	elem.Freeze()
+	if got := jw.UseRequest(rq.JawsKey, r); got != rq {
+		t.Fatal("could not claim request")
+	}
+
+	panicCh := make(chan any, 1)
+	_, _, bcastCh, readyCh, doneCh := jw.TestServe(rq, func(recovered any) {
+		panicCh <- recovered
+	})
+	select {
+	case <-readyCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for TestServe to start")
+	}
+	bcastCh <- wire.Message{Dest: updateTag, What: what.Update}
+	select {
+	case <-doneCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for TestServe to stop")
+	}
+
+	select {
+	case recovered := <-panicCh:
+		if recovered != wantPanic {
+			t.Fatalf("onPanic recovered %#v, want original value %#v", recovered, wantPanic)
+		}
+	default:
+		t.Fatal("onPanic was not called")
+	}
+	if got := jw.RequestCount(); got != 0 {
+		t.Fatalf("RequestCount() = %d, want 0 after TestServe recycled the request", got)
+	}
+}


### PR DESCRIPTION
## Summary

- preserve the original request-loop panic through existing cleanup and logging
- recycle TestServe requests before forwarding the panic, and always close doneCh after the callback unwinds
- add jawstest.NewTestRequestWithPanic for tests that expect a contained loop panic
- restore the logger/no-logger Template request-loop regression without a subprocess

Production serving keeps its existing log-and-contain behavior.

## Verification

- go generate ./...
- go vet ./...
- gofumpt -l .
- staticcheck ./...
- golangci-lint run
- gosec ./...
- JAWS_REQUIRE_NODE=1 go test -race -coverprofile=coverage.out ./...
- JAWS_REQUIRE_NODE=1 go test ./...
- go build ./...
- Linux/386 test binaries cross-compiled for lib/bind and lib/ui

Closes #326
