### PR TITLE
fix(tag): expand acyclic noncomparable getter nodes

### DIFF
--- a/lib/tag/tag.go
+++ b/lib/tag/tag.go
@@ -73,11 +73,13 @@ func sameActiveNode(a, b any) bool {
 	if ta != reflect.TypeOf(b) {
 		return false
 	}
-	if ta.Comparable() {
-		return a == b
-	}
 	va := reflect.ValueOf(a)
 	vb := reflect.ValueOf(b)
+	// Value.Comparable also checks the dynamic values held by interface fields;
+	// Type.Comparable alone does not make interface equality safe.
+	if va.Comparable() && vb.Comparable() {
+		return a == b
+	}
 	switch va.Kind() {
 	case reflect.Func:
 		// Value.Pointer identifies shared function code, not closure identity, so it

--- a/lib/tag/taggetter_test.go
+++ b/lib/tag/taggetter_test.go
@@ -1,6 +1,7 @@
 package tag
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -17,6 +18,33 @@ func (g *freshSliceTagger) JawsGetTag() any {
 		out = append(out, k)
 	}
 	return out
+}
+
+type getterWithMetadata struct {
+	metadata any
+	next     any
+}
+
+func (g getterWithMetadata) JawsGetTag() any { return g.next }
+
+func TestTagGetter_AcyclicRuntimeNonComparableWrappersExpand(t *testing.T) {
+	leaf := getterWithMetadata{
+		metadata: []string{"leaf"},
+		next:     Tag("expected"),
+	}
+	root := getterWithMetadata{
+		metadata: []string{"root"},
+		next:     leaf,
+	}
+
+	got, err := TagExpand(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []any{Tag("expected")}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("TagExpand() = %#v, want %#v", got, want)
+	}
 }
 
 func TestTagGetter_FreshContainersExpandToTheSameKeySet(t *testing.T) {

--- a/tagexpand_test.go
+++ b/tagexpand_test.go
@@ -8,6 +8,13 @@ import (
 	"github.com/linkdata/jaws/lib/tag"
 )
 
+type getterWithMetadata struct {
+	metadata any
+	next     any
+}
+
+func (g getterWithMetadata) JawsGetTag() any { return g.next }
+
 func TestJaws_MustTagExpand(t *testing.T) {
 	jw, err := New()
 	if err != nil {
@@ -23,6 +30,29 @@ func TestJaws_MustTagExpand(t *testing.T) {
 	awaitTestLoggerQueue(t, jw)
 	if logged := logger.snapshot(); len(logged) != 0 {
 		t.Fatalf("successful expansion logged %v, want nothing", logged)
+	}
+}
+
+func TestJaws_MustTagExpandAcyclicRuntimeNonComparableGetter(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jw.Close()
+
+	leaf := getterWithMetadata{
+		metadata: []string{"leaf"},
+		next:     tag.Tag("expected"),
+	}
+	root := getterWithMetadata{
+		metadata: []string{"root"},
+		next:     leaf,
+	}
+
+	got := jw.MustTagExpand(root)
+	want := []any{tag.Tag("expected")}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("MustTagExpand() = %#v, want %#v", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- check active `TagGetter` values for dynamic comparability before cycle-detection equality
- allow acyclic value-receiver getter wrappers with noncomparable interface metadata to reach their valid tag leaf
- cover both `tag.TagExpand` and default-logger `Jaws.MustTagExpand`

The existing diagnostic already says a value is not usable as a tag; changing that text alone would still discard the valid expansion and make `MustTagExpand` panic. This change keeps the diagnostic unchanged for genuinely unusable emitted keys.

## Verification

- go generate ./...
- go vet ./...
- gofumpt -l .
- staticcheck ./...
- golangci-lint run
- gosec ./...
- JAWS_REQUIRE_NODE=1 go test -race -coverprofile=coverage.out ./...
- JAWS_REQUIRE_NODE=1 go test ./...
- go build ./...
- Linux/386 test binaries cross-compiled for lib/bind and lib/ui

Closes #327
