### PR TITLE
Remove dismissed Bootstrap alert wrappers

### DIFF
--- a/lib/assets/jaws.js
+++ b/lib/assets/jaws.js
@@ -271,7 +271,7 @@ function jawsAlert(data) {
 			const wrapper = document.createElement('div');
 			wrapper.innerHTML = '<div class="alert alert-' + type + ' alert-dismissible" role="alert">' + message +
 				'<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>';
-			alertsElem.append(wrapper);
+			alertsElem.append(wrapper.firstElementChild);
 			return;
 		}
 	}

--- a/lib/assets/js_test.go
+++ b/lib/assets/js_test.go
@@ -1895,14 +1895,15 @@ process.stdout.write(JSON.stringify({
 	}
 }
 
-func TestJawsJS_AlertUsesDataAttributeHook(t *testing.T) {
+func TestJawsJS_AlertAppendsDismissibleElementDirectly(t *testing.T) {
 	raw := runJawsJSSnippet(t, `
 global.bootstrap = {};
 const selectors = [];
 const appended = [];
 const alertsElem = {
-	append: function(elem) { appended.push(elem.innerHTML); }
+	append: function(elem) { appended.push(elem); }
 };
+let wrapper;
 document.querySelector = function(selector) {
 	selectors.push(selector);
 	return selector === "[data-jaws-alerts]" ? alertsElem : null;
@@ -1910,15 +1911,29 @@ document.querySelector = function(selector) {
 document.getElementById = function(id) {
 	throw new Error("unexpected id lookup: " + id);
 };
-document.createElement = function() { return { innerHTML: "" }; };
+document.createElement = function() {
+	wrapper = {};
+	Object.defineProperty(wrapper, "innerHTML", {
+		set: function(html) { this.firstElementChild = { outerHTML: html }; }
+	});
+	return wrapper;
+};
 
 jawsAlert("success\nSaved");
-process.stdout.write(JSON.stringify({ selectors: selectors, appended: appended }));
+// Bootstrap dismissal removes the alert itself, so it must be the container child.
+process.stdout.write(JSON.stringify({
+	selectors: selectors,
+	appended: appended.length,
+	appendedWrapper: appended[0] === wrapper,
+	alertHTML: appended[0] && appended[0].outerHTML
+}));
 `)
 
 	var got struct {
-		Selectors []string `json:"selectors"`
-		Appended  []string `json:"appended"`
+		Selectors       []string `json:"selectors"`
+		Appended        int      `json:"appended"`
+		AppendedWrapper bool     `json:"appendedWrapper"`
+		AlertHTML       string   `json:"alertHTML"`
 	}
 	if err := json.Unmarshal([]byte(raw), &got); err != nil {
 		t.Fatalf("failed to parse snippet output %q: %v", raw, err)
@@ -1926,8 +1941,11 @@ process.stdout.write(JSON.stringify({ selectors: selectors, appended: appended }
 	if !reflect.DeepEqual(got.Selectors, []string{"[data-jaws-alerts]"}) {
 		t.Fatalf("alert selectors = %v", got.Selectors)
 	}
-	if len(got.Appended) != 1 || !strings.Contains(got.Appended[0], "Saved") {
-		t.Fatalf("appended alerts = %v", got.Appended)
+	if got.Appended != 1 || got.AppendedWrapper {
+		t.Fatalf("appended %d elements, wrapper appended = %t", got.Appended, got.AppendedWrapper)
+	}
+	if !strings.Contains(got.AlertHTML, "Saved") || !strings.Contains(got.AlertHTML, `data-bs-dismiss="alert"`) {
+		t.Fatalf("alert HTML = %q", got.AlertHTML)
 	}
 }
 


### PR DESCRIPTION
## Summary

- append the generated Bootstrap alert directly to the alert container
- let Bootstrap dismissal remove the complete JaWS-created alert node
- add a JavaScript regression test for the direct-child lifecycle invariant

Closes #335

## Verification

- `go generate ./...`
- `go vet ./...`
- `gofmt -l .`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`
- `JAWS_REQUIRE_NODE=1 go test -race -coverprofile=coverage.out ./...`
- `JAWS_REQUIRE_NODE=1 go test ./...`
- `go build ./...`
- `node --check lib/assets/jaws.js`