### PR TITLE
docs(ui): document Object chain composition

### DIFF
--- a/lib/ui/object.go
+++ b/lib/ui/object.go
@@ -9,24 +9,49 @@ import (
 	"github.com/linkdata/jaws/lib/tag"
 )
 
-// ObjectClickedHook is a function to call when a click event is received.
+// ObjectClickedHook handles a click event for an [Object].
 //
-// It is named distinctly from the generic [bind.ClickedHook] to avoid confusion:
-// this one operates on an [Object], not a [bind.Binder].
+// obj is the chain node containing the hook. See [Object] for composition
+// semantics.
+//
+// Unlike [bind.ClickedHook], ObjectClickedHook receives an [Object] rather than
+// a [bind.Binder].
 type ObjectClickedHook func(obj Object, elem *jaws.Element, click jaws.Click) (err error)
 
-// ObjectContextMenuHook is a function to call when a context menu event is received.
+// ObjectContextMenuHook handles a context menu event for an [Object].
+//
+// obj is the chain node containing the hook. See [Object] for composition
+// semantics.
 type ObjectContextMenuHook func(obj Object, elem *jaws.Element, click jaws.Click) (err error)
 
-// ObjectInitialHTMLAttrHook is a function to call when a [jaws.Element] is initially rendered.
+// ObjectInitialHTMLAttrHook provides attributes when an [Object] is initially rendered.
+//
+// obj is the chain node containing the hook. See [Object] for composition
+// semantics.
 //
 // ObjectInitialHTMLAttrHook is a type alias so a value of a defined function type
 // with this signature can be passed to [Object.InitialHTMLAttr] without explicit
 // conversion.
 type ObjectInitialHTMLAttrHook = func(obj Object, elem *jaws.Element) (s template.HTMLAttr)
 
-// Object is a chainable UI object that combines HTML rendering, tags and
-// optional event handlers.
+// Object is a chainable UI object.
+//
+// Each call to [Object.Clicked], [Object.ContextMenu], or
+// [Object.InitialHTMLAttr] returns a new chain node wrapping its receiver. Click
+// and context-menu hooks run from newest to oldest. Dispatch continues while the
+// result matches [jaws.ErrEventUnhandled] according to [errors.Is], including
+// when wrapped, and stops at the first other result. Each hook receives the node
+// containing it as its Object argument; that node includes the hook and all
+// older links, but no newer links.
+//
+// Initial-attribute hooks all run from newest to oldest. Their non-empty results
+// are joined in that order with one space inserted between results.
+//
+// The effective expanded tag set combines the non-nil tag contributions of every
+// link, and adding a link preserves older links' contributions. The resulting
+// Object remains subject to [tag.TagGetter]'s initialization, stability, and
+// concurrency requirements. Use [tag.TagExpand] to obtain flattened, validated
+// keys.
 type Object interface {
 	bind.HTMLGetter
 	tag.TagGetter
@@ -34,15 +59,15 @@ type Object interface {
 	jaws.ContextMenuHandler
 	jaws.InitialHTMLAttrHandler
 
-	// Clicked returns an [Object] that will call fn when [jaws.ClickHandler.JawsClick] is invoked.
+	// Clicked adds fn as the newest click hook and returns the resulting [Object].
 	Clicked(fn ObjectClickedHook) (newobj Object)
 
-	// ContextMenu returns an [Object] that will call fn when
-	// [jaws.ContextMenuHandler.JawsContextMenu] is invoked.
+	// ContextMenu adds fn as the newest context-menu hook and returns the
+	// resulting [Object].
 	ContextMenu(fn ObjectContextMenuHook) (newobj Object)
 
-	// InitialHTMLAttr returns an [Object] that will call fn when
-	// [jaws.InitialHTMLAttrHandler.JawsInitialHTMLAttr] is invoked.
+	// InitialHTMLAttr adds fn as the newest initial-attribute hook and returns the
+	// resulting [Object].
 	InitialHTMLAttr(fn ObjectInitialHTMLAttrHook) (newobj Object)
 }
 
@@ -127,12 +152,7 @@ func (obj *object) JawsInitialHTMLAttr(elem *jaws.Element) (attr template.HTMLAt
 	return
 }
 
-// JawsGetTag collects the non-nil tags of every link in the chain.
-//
-// The returned container is freshly built per call, which [tag.TagGetter] permits: only
-// the expanded key set has to stay the same. A chained getter that has its own
-// documented nil initialization phase (see [JsVar.JawsGetTag]) propagates that phase
-// here, so this object is likewise only usable as a tag once that link has initialized.
+// JawsGetTag returns the chain's non-nil tag contributions.
 func (obj *object) JawsGetTag() any {
 	var tags []any
 	for obj != nil {

--- a/lib/ui/object.go
+++ b/lib/ui/object.go
@@ -37,15 +37,19 @@ type ObjectInitialHTMLAttrHook = func(obj Object, elem *jaws.Element) (s templat
 // Object is a chainable UI object.
 //
 // Each call to [Object.Clicked], [Object.ContextMenu], or
-// [Object.InitialHTMLAttr] returns a new chain node wrapping its receiver. Click
-// and context-menu hooks run from newest to oldest. Dispatch continues while the
-// result matches [jaws.ErrEventUnhandled] according to [errors.Is], including
-// when wrapped, and stops at the first other result. Each hook receives the node
-// containing it as its Object argument; that node includes the hook and all
-// older links, but no newer links.
+// [Object.InitialHTMLAttr] returns a new chain node wrapping its receiver. Calls
+// to [jaws.ClickHandler.JawsClick] and
+// [jaws.ContextMenuHandler.JawsContextMenu] run the corresponding hooks from
+// newest to oldest. Dispatch continues while the result matches
+// [jaws.ErrEventUnhandled] according to [errors.Is], including when wrapped,
+// and stops at the first other result. If no hook handles the event, the invoked
+// method returns an error matching [jaws.ErrEventUnhandled]. Each hook receives
+// the node containing it as its Object argument; that node includes the hook and
+// all older links, but no newer links.
 //
-// Initial-attribute hooks all run from newest to oldest. Their non-empty results
-// are joined in that order with one space inserted between results.
+// [jaws.InitialHTMLAttrHandler.JawsInitialHTMLAttr] runs all initial-attribute
+// hooks from newest to oldest. Their non-empty results are joined in that order
+// with one space inserted between results.
 //
 // The effective expanded tag set combines the non-nil tag contributions of every
 // link, and adding a link preserves older links' contributions. The resulting

--- a/lib/ui/object_test.go
+++ b/lib/ui/object_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/linkdata/jaws"
+	"github.com/linkdata/jaws/lib/tag"
 )
 
 type testObjectStringer struct {
@@ -36,6 +37,22 @@ func TestObject_NewForwardsHTMLAndTag(t *testing.T) {
 	}
 	if got, want := obj.JawsGetTag(), any(inner); got != want {
 		t.Fatalf("want tag %#v got %#v", want, got)
+	}
+}
+
+func TestObject_GetTag_SurvivesChaining(t *testing.T) {
+	inner := testObjectStringer{s: "x"}
+	obj := New(inner).
+		Clicked(func(Object, *jaws.Element, jaws.Click) error { return nil }).
+		ContextMenu(func(Object, *jaws.Element, jaws.Click) error { return nil }).
+		InitialHTMLAttr(func(Object, *jaws.Element) template.HTMLAttr { return "" })
+
+	got, err := tag.TagExpand(obj)
+	if err != nil {
+		t.Fatalf("TagExpand() error = %v", err)
+	}
+	if len(got) != 1 || got[0] != inner {
+		t.Fatalf("TagExpand() = %#v, want [%#v]", got, inner)
 	}
 }
 
@@ -158,8 +175,6 @@ func TestObject_EventUnhandledCanBeWrapped(t *testing.T) {
 		})
 	if err := obj.JawsClick(nil, jaws.Click{Name: "click"}); !errors.Is(err, jaws.ErrEventUnhandled) {
 		t.Fatalf("want ErrEventUnhandled chain got %v", err)
-	} else if err != older {
-		t.Fatalf("want oldest wrapped unhandled got %v", err)
 	}
 	if len(clicked) != 2 || clicked[0] != 2 || clicked[1] != 1 {
 		t.Fatalf("unexpected wrapped click fallthrough order %v", clicked)
@@ -177,8 +192,6 @@ func TestObject_EventUnhandledCanBeWrapped(t *testing.T) {
 		})
 	if err := obj.JawsContextMenu(nil, jaws.Click{Name: "menu"}); !errors.Is(err, jaws.ErrEventUnhandled) {
 		t.Fatalf("want ErrEventUnhandled chain got %v", err)
-	} else if err != older {
-		t.Fatalf("want oldest wrapped unhandled got %v", err)
 	}
 	if len(contextMenu) != 2 || contextMenu[0] != 2 || contextMenu[1] != 1 {
 		t.Fatalf("unexpected wrapped context-menu fallthrough order %v", contextMenu)

--- a/lib/ui/object_test.go
+++ b/lib/ui/object_test.go
@@ -54,19 +54,19 @@ func TestObject_ContextMenu_DefaultUnhandled(t *testing.T) {
 }
 
 func TestObject_Clicked_FallthroughOrder(t *testing.T) {
-	obj := New("x")
 	order := []int{}
 	gotObj := []Object{}
 	gotElem := []*jaws.Element{}
 	gotClick := []jaws.Click{}
 
-	obj = obj.Clicked(func(got Object, elem *jaws.Element, click jaws.Click) error {
+	first := New("x").Clicked(func(got Object, elem *jaws.Element, click jaws.Click) error {
 		order = append(order, 1)
 		gotObj = append(gotObj, got)
 		gotElem = append(gotElem, elem)
 		gotClick = append(gotClick, click)
 		return nil
-	}).Clicked(func(got Object, elem *jaws.Element, click jaws.Click) error {
+	})
+	obj := first.Clicked(func(got Object, elem *jaws.Element, click jaws.Click) error {
 		order = append(order, 2)
 		gotObj = append(gotObj, got)
 		gotElem = append(gotElem, elem)
@@ -82,8 +82,8 @@ func TestObject_Clicked_FallthroughOrder(t *testing.T) {
 	if len(order) != 2 || order[0] != 2 || order[1] != 1 {
 		t.Fatalf("unexpected order %v", order)
 	}
-	if gotObj[0] == gotObj[1] {
-		t.Fatalf("expected distinct hook objects")
+	if gotObj[0] != obj || gotObj[1] != first {
+		t.Fatalf("want hook objects [%p %p] got [%p %p]", obj, first, gotObj[0], gotObj[1])
 	}
 	if gotElem[0] != elem || gotElem[1] != elem {
 		t.Fatalf("unexpected elem forwarding %#v", gotElem)
@@ -118,14 +118,17 @@ func TestObject_Clicked_StopsOnHandled(t *testing.T) {
 }
 
 func TestObject_ContextMenu_FallthroughOrder(t *testing.T) {
-	obj := New("x")
 	order := []int{}
+	gotObj := []Object{}
 
-	obj = obj.ContextMenu(func(Object, *jaws.Element, jaws.Click) error {
+	first := New("x").ContextMenu(func(got Object, _ *jaws.Element, _ jaws.Click) error {
 		order = append(order, 1)
+		gotObj = append(gotObj, got)
 		return nil
-	}).ContextMenu(func(Object, *jaws.Element, jaws.Click) error {
+	})
+	obj := first.ContextMenu(func(got Object, _ *jaws.Element, _ jaws.Click) error {
 		order = append(order, 2)
+		gotObj = append(gotObj, got)
 		return jaws.ErrEventUnhandled
 	})
 
@@ -135,27 +138,50 @@ func TestObject_ContextMenu_FallthroughOrder(t *testing.T) {
 	if len(order) != 2 || order[0] != 2 || order[1] != 1 {
 		t.Fatalf("unexpected order %v", order)
 	}
+	if gotObj[0] != obj || gotObj[1] != first {
+		t.Fatalf("want hook objects [%p %p] got [%p %p]", obj, first, gotObj[0], gotObj[1])
+	}
 }
 
 func TestObject_EventUnhandledCanBeWrapped(t *testing.T) {
-	wrapped := fmt.Errorf("wrapped: %w", jaws.ErrEventUnhandled)
-
-	obj := New("x").Clicked(func(Object, *jaws.Element, jaws.Click) error {
-		return wrapped
-	})
+	older := fmt.Errorf("older: %w", jaws.ErrEventUnhandled)
+	newer := fmt.Errorf("newer: %w", jaws.ErrEventUnhandled)
+	clicked := []int{}
+	obj := New("x").
+		Clicked(func(Object, *jaws.Element, jaws.Click) error {
+			clicked = append(clicked, 1)
+			return older
+		}).
+		Clicked(func(Object, *jaws.Element, jaws.Click) error {
+			clicked = append(clicked, 2)
+			return newer
+		})
 	if err := obj.JawsClick(nil, jaws.Click{Name: "click"}); !errors.Is(err, jaws.ErrEventUnhandled) {
 		t.Fatalf("want ErrEventUnhandled chain got %v", err)
-	} else if err != wrapped {
-		t.Fatalf("want wrapped unhandled got %v", err)
+	} else if err != older {
+		t.Fatalf("want oldest wrapped unhandled got %v", err)
+	}
+	if len(clicked) != 2 || clicked[0] != 2 || clicked[1] != 1 {
+		t.Fatalf("unexpected wrapped click fallthrough order %v", clicked)
 	}
 
-	obj = New("x").ContextMenu(func(Object, *jaws.Element, jaws.Click) error {
-		return wrapped
-	})
+	contextMenu := []int{}
+	obj = New("x").
+		ContextMenu(func(Object, *jaws.Element, jaws.Click) error {
+			contextMenu = append(contextMenu, 1)
+			return older
+		}).
+		ContextMenu(func(Object, *jaws.Element, jaws.Click) error {
+			contextMenu = append(contextMenu, 2)
+			return newer
+		})
 	if err := obj.JawsContextMenu(nil, jaws.Click{Name: "menu"}); !errors.Is(err, jaws.ErrEventUnhandled) {
 		t.Fatalf("want ErrEventUnhandled chain got %v", err)
-	} else if err != wrapped {
-		t.Fatalf("want wrapped unhandled got %v", err)
+	} else if err != older {
+		t.Fatalf("want oldest wrapped unhandled got %v", err)
+	}
+	if len(contextMenu) != 2 || contextMenu[0] != 2 || contextMenu[1] != 1 {
+		t.Fatalf("unexpected wrapped context-menu fallthrough order %v", contextMenu)
 	}
 }
 
@@ -170,25 +196,33 @@ func TestObject_InitialHTMLAttr(t *testing.T) {
 	type initialHTMLAttrHook func(Object, *jaws.Element) template.HTMLAttr
 
 	order := []int{}
+	gotObj := []Object{}
 	elem := &jaws.Element{}
 	first := initialHTMLAttrHook(func(got Object, gotElem *jaws.Element) (s template.HTMLAttr) {
 		order = append(order, 1)
+		gotObj = append(gotObj, got)
 		if gotElem != elem {
 			t.Fatalf("unexpected elem %#v", gotElem)
 		}
 		return `data-first="1"`
 	})
 
-	obj := New("x").
-		InitialHTMLAttr(first).
-		InitialHTMLAttr(func(Object, *jaws.Element) (s template.HTMLAttr) {
-			order = append(order, 2)
-			s = `data-second="2"`
-			return
-		})
+	firstObj := New("x").InitialHTMLAttr(first)
+	obj := firstObj.InitialHTMLAttr(func(got Object, _ *jaws.Element) (s template.HTMLAttr) {
+		order = append(order, 2)
+		gotObj = append(gotObj, got)
+		s = `data-second="2"`
+		return
+	})
 
 	if got := obj.JawsInitialHTMLAttr(elem); got != `data-second="2" data-first="1"` {
 		t.Fatalf("want %q got %q", `data-second="2" data-first="1"`, got)
+	}
+	if len(order) != 2 || order[0] != 2 || order[1] != 1 {
+		t.Fatalf("unexpected order %v", order)
+	}
+	if gotObj[0] != obj || gotObj[1] != firstObj {
+		t.Fatalf("want hook objects [%p %p] got [%p %p]", obj, firstObj, gotObj[0], gotObj[1])
 	}
 }
 


### PR DESCRIPTION
## Summary

- document exported Object chain ordering, event entry points, fallthrough classification, hook-node identity, initial attributes, and effective tag aggregation
- expose hook-node semantics on the exported hook types
- strengthen tests for wrapped ErrEventUnhandled traversal, exact chain nodes, initial-hook call order, and tag preservation through every public builder

Fixes #337

## Verification

- go generate ./...
- go vet ./...
- gofmt -l .
- staticcheck ./...
- golangci-lint run
- gosec -quiet ./...
- JAWS_REQUIRE_NODE=1 go test -race -count=1 -coverprofile=/private/tmp/jaws-342-review-coverage.out ./...
- JAWS_REQUIRE_NODE=1 go test -count=1 ./...
- go build -v ./...
- go doc github.com/linkdata/jaws/lib/ui Object
- Linux/386 test binaries cross-compiled for lib/bind and lib/ui on the Darwin/arm64 development host; CI executes the 386 tests on Linux
- mutation check confirmed TestObject_GetTag_SurvivesChaining fails when chained tag lookup is disabled