### PR TITLE
test(key): fuzz parsing and encoding

### DIFF
--- a/lib/key/key_test.go
+++ b/lib/key/key_test.go
@@ -1,7 +1,10 @@
 package key
 
 import (
+	"bytes"
 	"math"
+	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -88,6 +91,73 @@ func TestParse(t *testing.T) {
 	}
 }
 
+func FuzzParse(f *testing.F) {
+	maxKey := strconv.FormatUint(math.MaxUint64, 32)
+	for _, seed := range []string{
+		"",
+		"0",
+		"1",
+		"01",
+		"10",
+		"1A",
+		"-1",
+		"1Z",
+		"/tail",
+		"2/",
+		"2/tail/more",
+		"1A/tail",
+		"1/\xff\x00",
+		"\xff/tail",
+		"1∕tail",
+		maxKey,
+		maxKey + "/tail",
+		maxKey + "0",
+		maxKey + "0/tail",
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, s string) {
+		prefix := s
+		wantTail := ""
+		if slashIdx := strings.IndexByte(s, '/'); slashIdx >= 0 {
+			prefix = s[:slashIdx]
+			wantTail = s[slashIdx:]
+		}
+
+		got, tail := Parse(s)
+		if tail != wantTail {
+			t.Fatalf("Parse(%q) tail = %q, want %q", s, tail, wantTail)
+		}
+
+		parsed, err := strconv.ParseUint(prefix, 32, 64)
+		want := Key(0)
+		if err == nil {
+			want = Key(parsed)
+		}
+		if got != want {
+			t.Fatalf("Parse(%q) key = %d, want %d (prefix %q, ParseUint error %v)", s, uint64(got), uint64(want), prefix, err)
+		}
+		if got == 0 {
+			return
+		}
+
+		canonical := got.String()
+		if wantCanonical := strconv.FormatUint(uint64(got), 32); canonical != wantCanonical {
+			t.Fatalf("Key(%d).String() = %q, want canonical base-32 %q", uint64(got), canonical, wantCanonical)
+		}
+		if canonical != strings.ToLower(canonical) {
+			t.Fatalf("Key(%d).String() = %q, want lowercase base-32", uint64(got), canonical)
+		}
+		if appended := string(Append(nil, got)); appended != canonical {
+			t.Fatalf("Append(nil, %d) = %q, String() = %q; want equal", uint64(got), appended, canonical)
+		}
+		if reparsed, reparsedTail := Parse(canonical); reparsed != got || reparsedTail != "" {
+			t.Fatalf("Parse(%q) = %d, %q; want %d, empty tail", canonical, uint64(reparsed), reparsedTail, uint64(got))
+		}
+	})
+}
+
 func TestAppend(t *testing.T) {
 	for _, tt := range []struct {
 		name string
@@ -105,4 +175,50 @@ func TestAppend(t *testing.T) {
 			}
 		})
 	}
+}
+
+func FuzzKeyEncodingRoundTrip(f *testing.F) {
+	f.Add(uint64(0), []byte(nil))
+	f.Add(uint64(1), []byte{})
+	f.Add(uint64(32), []byte("jaws/"))
+	f.Add(uint64(math.MaxUint64), []byte{0, '/', 0xff})
+
+	f.Fuzz(func(t *testing.T, raw uint64, prefix []byte) {
+		key := Key(raw)
+		canonical := key.String()
+		if appended := string(Append(nil, key)); appended != canonical {
+			t.Fatalf("Append(nil, %d) = %q, String() = %q; want equal", raw, appended, canonical)
+		}
+
+		wantCanonical := ""
+		if key != 0 {
+			wantCanonical = strconv.FormatUint(raw, 32)
+		}
+		if canonical != wantCanonical {
+			t.Fatalf("Key(%d).String() = %q, want %q", raw, canonical, wantCanonical)
+		}
+
+		want := make([]byte, 0, len(prefix)+len(canonical))
+		want = append(want, prefix...)
+		want = append(want, canonical...)
+		dst := make([]byte, len(prefix), len(prefix)+len(canonical))
+		copy(dst, prefix)
+		got := Append(dst, key)
+		if len(got) != len(want) {
+			t.Fatalf("len(Append(%q, %d)) = %d, want %d", prefix, raw, len(got), len(want))
+		}
+		if !bytes.Equal(got[:len(prefix)], prefix) {
+			t.Fatalf("Append(%q, %d) prefix = %q, want preserved prefix %q", prefix, raw, got[:len(prefix)], prefix)
+		}
+		if suffix := string(got[len(prefix):]); suffix != canonical {
+			t.Fatalf("Append(%q, %d) suffix = %q, want %q", prefix, raw, suffix, canonical)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("Append(%q, %d) = %q, want %q", prefix, raw, got, want)
+		}
+
+		if reparsed, tail := Parse(canonical); reparsed != key || tail != "" {
+			t.Fatalf("Parse(%q) = %d, %q; want %d, empty tail", canonical, uint64(reparsed), tail, raw)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- fuzz arbitrary key text against a base-32 parser oracle while preserving first-slash tails byte-for-byte
- verify canonical lowercase String and Append output reparses for every nonzero parsed key
- fuzz every uint64 key with arbitrary binary destination prefixes, including zero and MaxUint64 behavior

Fixes #339

## Verification

- go generate ./...
- go vet ./...
- gofmt -l .
- staticcheck ./...
- golangci-lint run
- gosec -quiet ./...
- JAWS_REQUIRE_NODE=1 go test -race -count=1 -coverprofile=/private/tmp/jaws-339-coverage.out ./...
- JAWS_REQUIRE_NODE=1 go test -count=1 ./...
- go build -v ./...
- go test -count=1 -run ^$ -fuzz ^FuzzParse$ -fuzztime=5s ./lib/key
- go test -count=1 -run ^$ -fuzz ^FuzzKeyEncodingRoundTrip$ -fuzztime=5s ./lib/key
- Linux/386 test binaries cross-compiled for lib/bind and lib/ui on the Darwin/arm64 development host; CI executes the 386 tests on Linux