### PR TITLE
chore(what): pin stringer generator

### DIFF
--- a/lib/what/what.go
+++ b/lib/what/what.go
@@ -2,7 +2,7 @@ package what
 
 // What identifies a JaWS wire protocol command or event.
 //
-//go:generate go run golang.org/x/tools/cmd/stringer@latest -type=What
+//go:generate go run golang.org/x/tools/cmd/stringer@v0.49.0 -type=What
 type What uint8
 
 const (


### PR DESCRIPTION
## Summary

- pin the lib/what stringer generator to golang.org/x/tools v0.49.0
- keep generated output byte-identical across repeated generation
- avoid adding x/tools to the runtime module graph

Fixes #341

## Verification

- ran go generate ./lib/what twice; what_string.go had the same SHA-256 after both runs
- confirmed lib/what/what_string.go, go.mod, and go.sum are unchanged
- confirmed golang.org/x/tools is absent from go list -m all
- go generate ./...
- go vet ./...
- gofmt -l .
- staticcheck ./...
- golangci-lint run
- gosec -quiet ./...
- JAWS_REQUIRE_NODE=1 go test -race -count=1 -coverprofile=/private/tmp/jaws-341-coverage.out ./...
- JAWS_REQUIRE_NODE=1 go test -count=1 ./...
- go build -v ./...
- Linux/386 test binaries cross-compiled for lib/bind and lib/ui on the Darwin/arm64 development host; CI executes the 386 tests on Linux