### PR TITLE
docs(session): require a valid cookie name

### DIFF
--- a/README.md
+++ b/README.md
@@ -850,9 +850,10 @@ backend over loopback does not break binding; in deployments where every
 request reaches JaWS from loopback, IP binding is effectively disabled unless
 `Jaws.TrustForwardedHeaders` is enabled behind a single trusted reverse proxy.
 
-No data is stored in the client browser except the randomly generated 
-session cookie. You can set the cookie name in `Jaws.CookieName`, the
-default is derived from the executable name and falls back to `jaws`.
+No data is stored in the client browser except the randomly generated
+session cookie. Set its name with `Jaws.CookieName`, which must be a valid,
+non-empty HTTP cookie name. The default is derived from the executable name
+and falls back to `jaws`.
 
 ### A note on the Context
 

--- a/jaws.go
+++ b/jaws.go
@@ -89,8 +89,13 @@ type Jid = jid.Jid // convenience alias
 // unsynchronized write and is not supported. Methods document their own
 // concurrency behavior and may be called concurrently when stated.
 type Jaws struct {
-	CookieName  string // Name for session cookies; defaults to a name derived from the executable ([assets.DefaultCookieName]), falling back to "jaws"
-	AutoSession bool   // Create and associate a session during a successful WebSocket upgrade when a Request has none. Defaults to false.
+	// CookieName is the name used for session cookies.
+	//
+	// It defaults to [assets.DefaultCookieName], which is derived from the
+	// executable and falls back to "jaws". CookieName must be a valid, non-empty
+	// HTTP cookie name; see [http.Cookie.Valid].
+	CookieName  string
+	AutoSession bool // Create and associate a session during a successful WebSocket upgrade when a Request has none. Defaults to false.
 	// TrustForwardedHeaders enables trusted proxy header processing.
 	//
 	// It governs the session cookie Secure flag and WebSocket Origin scheme


### PR DESCRIPTION
## Summary

- document that `Jaws.CookieName` must be a valid, non-empty HTTP cookie name
- clarify the executable-derived default in the API documentation and README
- link callers to `http.Cookie.Valid` for the standard-library validity contract

## Rationale

An empty string is not a valid HTTP cookie name. This change makes that configuration precondition explicit instead of assigning a separate fallback meaning to the empty value.

## Verification

- `go generate ./...`
- `gofmt -l .`
- `gofumpt -l .`
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`
- `JAWS_REQUIRE_NODE=1 go test -race -coverprofile=coverage.out ./...`
- `JAWS_REQUIRE_NODE=1 go test ./...`
- `go build ./...`

Fixes #347
