### PR TITLE
docs(named): require non-empty option names

### DIFF
--- a/lib/named/doc.go
+++ b/lib/named/doc.go
@@ -5,6 +5,6 @@
 // labels come from user-controlled text, escape them before constructing the Bool
 // or BoolArray entry.
 //
-// Names used as browser form values must be valid UTF-8 and must not contain
-// U+0000 (NUL), so their identity survives an HTML and browser round trip.
+// Names used as browser form values must be non-empty, valid UTF-8 strings
+// without U+0000 (NUL).
 package named

--- a/lib/named/namedbool.go
+++ b/lib/named/namedbool.go
@@ -10,6 +10,10 @@ import (
 
 // Bool stores a named boolean value with an HTML representation.
 //
+// A Bool must have a non-empty, valid UTF-8 name without U+0000 (NUL). Its zero
+// value is therefore not ready for use; construct values with [NewBool] or
+// [BoolArray.Add].
+//
 // Bool values are safe for concurrent use.
 type Bool struct {
 	nba     *BoolArray       // (read-only) BoolArray that this is part of (may be nil)
@@ -21,8 +25,7 @@ type Bool struct {
 
 // NewBool returns a [Bool] with the given name, HTML and checked state.
 //
-// To preserve its identity as a browser form value, name must be valid UTF-8
-// and must not contain U+0000 (NUL).
+// name must be a non-empty, valid UTF-8 string without U+0000 (NUL).
 //
 // The html argument is rendered as trusted HTML (it is the label shown in select
 // lists and checkboxes) and is not escaped. When it is derived from untrusted

--- a/lib/named/namedboolarray.go
+++ b/lib/named/namedboolarray.go
@@ -85,11 +85,9 @@ func (nba *BoolArray) JawsContains(elem *jaws.Element) (contents []jaws.UI) {
 	return
 }
 
-// Add adds a [Bool] with the given name and trusted HTML text.
-// Returns itself.
+// Add adds a [Bool] with the given name and trusted HTML text and returns nba.
 //
-// To preserve its identity as a browser form value, name must be valid UTF-8
-// and must not contain U+0000 (NUL).
+// name must be a non-empty, valid UTF-8 string without U+0000 (NUL).
 //
 // The html argument is rendered as trusted HTML and is not escaped; pre-escape it
 // (e.g. template.HTML(template.HTMLEscapeString(s))) when it is derived from
@@ -154,13 +152,10 @@ func (nba *BoolArray) deselectOthersLocked(name string, deselect bool) (changed 
 	return
 }
 
-// Get returns the name of the first [Bool] in the group that
-// has its checked value set to true. Returns an empty string
-// if none are true.
+// Get returns the name of the first checked [Bool].
 //
-// In case you can have more than one selected or you need to
-// distinguish between a blank name and the fact that none are
-// set to true, use [BoolArray.ReadLocked] to inspect the data directly.
+// It returns an empty string if none are checked. Use [BoolArray.ReadLocked]
+// to inspect all checked values when multiple values may be checked.
 func (nba *BoolArray) Get() (name string) {
 	nba.mu.RLock()
 	for _, nb := range nba.data {

--- a/lib/named/selecthandler.go
+++ b/lib/named/selecthandler.go
@@ -5,8 +5,11 @@ import (
 	"github.com/linkdata/jaws/lib/bind"
 )
 
-// SelectHandler is implemented by values that can both render options and
-// store a selected option name. [BoolArray] is the standard implementation.
+// SelectHandler renders select options and stores the selection as a string.
+//
+// Rendered option values must be non-empty. A string that matches no rendered
+// option value represents no selection. [BoolArray] is the standard
+// implementation and returns an empty string when no [Bool] is checked.
 type SelectHandler interface {
 	jaws.Container
 	bind.Setter[string]

--- a/lib/ui/select.go
+++ b/lib/ui/select.go
@@ -9,7 +9,11 @@ import (
 
 // Select renders a single-selection HTML select element.
 //
-// Its handler supplies the options and reads and writes one selected option name.
+// Its handler supplies the options and represents the selection as a string.
+// Option values must be non-empty. A string that matches no option value
+// represents no selection. [named.BoolArray] is the standard handler and
+// requires non-empty [named.Bool.Name] values.
+//
 // The handler's dynamic value defines Select's identity and must be comparable
 // and equal to itself. Rebuilding with an equal handler lets a parent retain its
 // live Element. Keep application state containing a slice, map, or function
@@ -37,7 +41,7 @@ var (
 
 // NewSelect returns a single-selection Select backed by handler.
 //
-// See [Select] for native reset semantics.
+// See [Select] for handler requirements and native reset semantics.
 func NewSelect(handler named.SelectHandler) Select {
 	return Select{handler: handler}
 }
@@ -70,7 +74,7 @@ func (u Select) container() Container {
 	return NewContainer("select", u.handler)
 }
 
-// JawsInput stores one browser-side selected option name.
+// JawsInput stores one browser-side selected option value.
 //
 // A nil-interface handler is a no-op; a typed-nil handler is called normally.
 // If no render-derived dirty tag is available, Select performs no additional
@@ -85,8 +89,8 @@ func (u Select) JawsInput(elem *jaws.Element, value string) (err error) {
 // Select renders a single-selection HTML select element.
 //
 // HTML attribute params are applied to the select element, but the multiple
-// attribute is unsupported because Select stores one selected option name.
-// See [Select] for native reset semantics.
+// attribute is unsupported because Select stores one selected option value.
+// See [Select] for handler requirements and native reset semantics.
 func (rw RequestWriter) Select(handler named.SelectHandler, params ...any) error {
 	return rw.NewUI(NewSelect(handler), params...)
 }


### PR DESCRIPTION
## Summary

- require `named.Bool` names and Select option values to be non-empty
- document the unsupported `Bool` zero value and supported construction paths
- define unmatched Select handler values as the no-selection representation
- remove `BoolArray.Get`'s blank-name ambiguity from the supported contract

This is a documentation-only change; runtime behavior is unchanged.

## Verification

- `go generate ./...`
- `gofmt -l .`
- `gofumpt -l .`
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`
- `JAWS_REQUIRE_NODE=1 go test -race -coverprofile=coverage.out ./...`
- `JAWS_REQUIRE_NODE=1 go test ./...`
- `go build ./...`
- `GOOS=linux GOARCH=386 CGO_ENABLED=0 go test -exec=/usr/bin/true ./lib/bind/... ./lib/ui/...`
- `go mod verify`
- `go mod tidy -diff`

Fixes #348
