### PR TITLE
fix: clear sessions during shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,6 +843,9 @@ Session key-value pairs can be accessed using `Request.Set()` and
 do this if there is no session; `Get()` will return nil, and `Set()`
 will be a no-op.
 
+`Jaws.Close` invalidates every registered session, permanently clears its
+key-value data, and prevents new sessions from being created.
+
 Sessions are bound to the client IP JaWS sees. Attempting to access an
 existing session from a different non-loopback IP will fail. Loopback
 addresses are treated as the same client so a reverse proxy connecting to the

--- a/jaws.go
+++ b/jaws.go
@@ -206,6 +206,10 @@ func New() (jw *Jaws, err error) {
 // unclaimable but retain their identity while callers hold them. Active WebSocket
 // handlers observe cancellation and finish asynchronously.
 //
+// Registered [Session] values are invalidated and detached from their Requests,
+// and their key/value data is permanently cleared; new Sessions cannot be
+// created after shutdown begins.
+//
 // Calls to [Jaws.NewRequest] after shutdown begins return Requests with
 // already-canceled contexts that [Jaws.UseRequest] cannot claim. Broadcasts and
 // sends may be discarded after Done closes. Close stops accepting errors from
@@ -230,6 +234,7 @@ func (jw *Jaws) Close() {
 		}
 		if rq.loadState() == reqRunning {
 			rq.mu.Lock()
+			rq.killSessionLocked(true)
 			// Shutdown has no error cause. CancelCauseFunc is idempotent, so it
 			// also safely handles a Request whose context is already done.
 			rq.cancelFn(nil)
@@ -238,6 +243,7 @@ func (jw *Jaws) Close() {
 			jw.retireNonRunningRequestLocked(rq)
 		}
 	}
+	jw.closeSessionsLocked()
 	jw.mu.Unlock()
 }
 

--- a/jaws_test.go
+++ b/jaws_test.go
@@ -177,6 +177,156 @@ func TestNew_DefaultWebSocketPingInterval(t *testing.T) {
 	}
 }
 
+func TestJaws_CloseClearsSessions(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+
+	type sessionFixture struct {
+		request *http.Request
+		session *Session
+		jawsReq *Request
+		value   string
+	}
+	fixtures := make([]sessionFixture, 2)
+	for i := range fixtures {
+		r := httptest.NewRequest(http.MethodGet, "http://example.test/", nil)
+		r.RemoteAddr = "192.0.2." + strconv.Itoa(i+1) + ":1234"
+		sess := jw.NewSession(nil, r)
+		if sess == nil {
+			t.Fatal("NewSession returned nil")
+		}
+		value := "value-" + strconv.Itoa(i)
+		sess.Set("key", value)
+		rq := jw.NewRequest(r)
+		if got := rq.Session(); got != sess {
+			t.Fatalf("Request.Session() = %p, want %p", got, sess)
+		}
+		if got := rq.Get("key"); got != value {
+			t.Fatalf("Request.Get() = %v, want %q", got, value)
+		}
+		fixtures[i] = sessionFixture{request: r, session: sess, jawsReq: rq, value: value}
+	}
+
+	if got := jw.SessionCount(); got != len(fixtures) {
+		t.Fatalf("SessionCount() = %d, want %d", got, len(fixtures))
+	}
+	registered := make(map[*Session]bool)
+	for _, sess := range jw.Sessions() {
+		registered[sess] = true
+	}
+	for _, fixture := range fixtures {
+		if !registered[fixture.session] {
+			t.Fatalf("Sessions() does not contain %p", fixture.session)
+		}
+		if got := jw.GetSession(fixture.request); got != fixture.session {
+			t.Fatalf("GetSession() = %p, want %p", got, fixture.session)
+		}
+	}
+
+	jw.Close()
+
+	if got := jw.SessionCount(); got != 0 {
+		t.Fatalf("SessionCount() after Close = %d, want 0", got)
+	}
+	if sessions := jw.Sessions(); len(sessions) != 0 {
+		t.Fatalf("Sessions() after Close = %v, want none", sessions)
+	}
+	jw.mu.RLock()
+	sessionsReleased := jw.sessions == nil
+	jw.mu.RUnlock()
+	if !sessionsReleased {
+		t.Fatal("Close retained the session registry allocation")
+	}
+	for _, fixture := range fixtures {
+		if got := jw.GetSession(fixture.request); got != nil {
+			t.Errorf("GetSession() after Close = %v, want nil", got)
+		}
+		if got := fixture.session.Get("key"); got != nil {
+			t.Errorf("Session.Get() after Close = %v, want nil", got)
+		}
+		fixture.session.Set("after", fixture.value)
+		if got := fixture.session.Get("after"); got != nil {
+			t.Errorf("Session.Set() stored %v after Close", got)
+		}
+		if cookie := fixture.session.Cookie(); cookie == nil || cookie.MaxAge >= 0 {
+			t.Errorf("Session.Cookie() after Close = %#v, want deletion cookie", cookie)
+		}
+		if requests := fixture.session.Requests(); len(requests) != 0 {
+			t.Errorf("Session.Requests() after Close = %v, want none", requests)
+		}
+		if got := fixture.jawsReq.Session(); got != nil {
+			t.Errorf("Request.Session() after Close = %v, want nil", got)
+		}
+		if got := fixture.jawsReq.Get("key"); got != nil {
+			t.Errorf("Request.Get() after Close = %v, want nil", got)
+		}
+	}
+}
+
+func TestJaws_CloseClearsRunningSession(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(jw.Close)
+	serveDone := make(chan struct{})
+	go func() {
+		jw.Serve()
+		close(serveDone)
+	}()
+
+	hr := httptest.NewRequest(http.MethodGet, "http://example.test/", nil)
+	sess := jw.NewSession(nil, hr)
+	if sess == nil {
+		t.Fatal("NewSession returned nil")
+	}
+	sess.Set("key", "value")
+	active := NewTestRequest(jw, hr)
+	if active == nil {
+		t.Fatal("NewTestRequest returned nil")
+	}
+	select {
+	case <-active.ReadyCh:
+	case <-time.After(testTimeout):
+		t.Fatal("Request did not become ready")
+	}
+	if got := active.Session(); got != sess {
+		t.Fatalf("Request.Session() = %p, want %p", got, sess)
+	}
+	if requests := sess.Requests(); len(requests) != 1 || requests[0] != active.Request {
+		t.Fatalf("Session.Requests() = %v, want the active Request", requests)
+	}
+
+	jw.Close()
+
+	if got := active.Session(); got != nil {
+		t.Errorf("Request.Session() after Close = %v, want nil", got)
+	}
+	if got := sess.Get("key"); got != nil {
+		t.Errorf("Session.Get() after Close = %v, want nil", got)
+	}
+	if requests := sess.Requests(); len(requests) != 0 {
+		t.Errorf("Session.Requests() after Close = %v, want none", requests)
+	}
+	if cookie := sess.Cookie(); cookie == nil || cookie.MaxAge >= 0 {
+		t.Errorf("Session.Cookie() after Close = %#v, want deletion cookie", cookie)
+	}
+	select {
+	case <-active.DoneCh:
+	case <-time.After(testTimeout):
+		t.Fatal("Request did not finish after Close")
+	}
+	select {
+	case <-serveDone:
+	case <-time.After(testTimeout):
+		t.Fatal("Serve did not finish after Close")
+	}
+	active.Close()
+}
+
 // TestJaws_CloseCancelsPendingHTTPWork drives a normal HTTP handler that starts
 // request-scoped work before the WebSocket connects. Close must synchronously
 // cancel that pending Request so the handler's work can stop.

--- a/request.go
+++ b/request.go
@@ -368,10 +368,11 @@ func (rq *Request) newAutoSession(r *http.Request) (sess *Session) {
 	rq.mu.Lock()
 	defer rq.mu.Unlock()
 	if rq.session == nil {
-		sess = jw.newSessionLocked(remoteIP, secure)
-		sess.addRequest(rq)
-		rq.session = sess
-		jw.sessions[sess.sessionID] = sess
+		if sess = jw.newSessionLocked(remoteIP, secure); sess != nil {
+			sess.addRequest(rq)
+			rq.session = sess
+			jw.sessions[sess.sessionID] = sess
+		}
 	}
 	return
 }

--- a/request_test.go
+++ b/request_test.go
@@ -3581,6 +3581,49 @@ func TestWS_AutoSessionCreatesSession(t *testing.T) {
 	}
 }
 
+func TestWS_AutoSessionDoesNotCreateAfterJawsClose(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	jw.AutoSession = true
+	request := httptest.NewRequest(http.MethodGet, "http://example.test/jaws/", nil)
+	rq := jw.NewRequest(request)
+	if got := jw.UseRequest(rq.JawsKey, request); got != rq {
+		t.Fatalf("UseRequest() = %p, want %p", got, rq)
+	}
+	if !rq.startServe() {
+		t.Fatal("startServe returned false")
+	}
+	stopped := false
+	defer func() {
+		if !stopped {
+			rq.stopServe()
+		}
+	}()
+
+	jw.Close()
+	recorder := httptest.NewRecorder()
+	writer := &autoSessionWriter{ResponseWriter: recorder, rq: rq, r: request}
+	writer.WriteHeader(http.StatusSwitchingProtocols)
+
+	if recorder.Code != http.StatusSwitchingProtocols {
+		t.Errorf("status = %d, want %d", recorder.Code, http.StatusSwitchingProtocols)
+	}
+	if cookies := recorder.Result().Cookies(); len(cookies) != 0 {
+		t.Errorf("response cookies after Close = %v, want none", cookies)
+	}
+	if got := rq.Session(); got != nil {
+		t.Errorf("Request.Session() after Close = %v, want nil", got)
+	}
+	if got := jw.SessionCount(); got != 0 {
+		t.Errorf("SessionCount() after Close = %d, want 0", got)
+	}
+
+	rq.stopServe()
+	stopped = true
+}
+
 type autoSessionCloseResponseWriter struct {
 	http.ResponseWriter
 	jw     *Jaws

--- a/session.go
+++ b/session.go
@@ -116,15 +116,18 @@ func (sess *Session) Get(key string) (value any) {
 	return
 }
 
-// Set sets a value to be associated with the key.
-// If value is nil, the key is removed from the session.
+// Set associates value with key.
+//
+// A nil value removes key.
 func (sess *Session) Set(key string, value any) {
 	if sess != nil {
 		sess.mu.Lock()
-		if value == nil {
-			delete(sess.data, key)
-		} else {
-			sess.data[key] = value
+		if sess.data != nil {
+			if value == nil {
+				delete(sess.data, key)
+			} else {
+				sess.data[key] = value
+			}
 		}
 		sess.mu.Unlock()
 	}
@@ -198,6 +201,7 @@ func (sess *Session) addCookie(w http.ResponseWriter, r *http.Request) {
 }
 
 // Close invalidates and expires the [Session].
+//
 // Future [Request] values won't be able to associate with it, and [Session.Cookie] will return a deletion cookie.
 //
 // Existing [Request] values already associated with the [Session] will ask the
@@ -387,7 +391,8 @@ func (jw *Jaws) GetSession(r *http.Request) (sess *Session) {
 // of the same HTTP request. If a concurrent [Session.Close] wins first, neither
 // w nor r receives its live cookie.
 //
-// It returns nil and has no effect if r is nil; w may be nil.
+// It returns nil and has no effect if r is nil or shutdown has begun; w may be
+// nil.
 //
 // It panics if the [crypto/rand.Reader] captured by [New] returns an error while
 // generating the session ID. Go's default reader does not return errors.
@@ -417,16 +422,27 @@ func (jw *Jaws) newSession(w http.ResponseWriter, r *http.Request) (sess *Sessio
 		jw.mu.Lock()
 		defer jw.mu.Unlock()
 		sess = jw.newSessionLocked(remoteIP, secure)
-		jw.sessions[sess.sessionID] = sess
+		if sess != nil {
+			jw.sessions[sess.sessionID] = sess
+		}
 	}()
-	sess.addCookie(w, r)
+	if sess != nil {
+		sess.addCookie(w, r)
+	}
 	return
 }
 
-// newSessionLocked allocates a Session whose ID is absent from jw.sessions.
+// newSessionLocked allocates a Session whose ID is absent from jw.sessions, or
+// returns nil after shutdown begins.
 //
-// The caller must hold jw.mu and publish the Session before releasing it.
+// The caller must hold jw.mu and publish any returned Session before releasing
+// it.
 func (jw *Jaws) newSessionLocked(remoteIP netip.Addr, secure bool) (sess *Session) {
+	select {
+	case <-jw.closeCh:
+		return
+	default:
+	}
 	// Retired IDs deliberately remain eligible for reuse. A natural 64-bit random
 	// collision can therefore make a stale cookie name a later Session. Preventing
 	// every reuse would require unbounded tombstones; if this probability/space
@@ -440,6 +456,19 @@ func (jw *Jaws) newSessionLocked(remoteIP netip.Addr, secure bool) (sess *Sessio
 		}
 	}
 	return
+}
+
+// closeSessionsLocked invalidates and releases every registered Session.
+// The caller must hold jw.mu after detaching all current Requests.
+func (jw *Jaws) closeSessionsLocked() {
+	for _, sess := range jw.sessions {
+		sess.mu.Lock()
+		sess.cookie.MaxAge = -1 // #nosec G124 -- marks the already initialized session cookie for deletion.
+		sess.requests = nil
+		sess.data = nil
+		sess.mu.Unlock()
+	}
+	jw.sessions = nil
 }
 
 // deleteSessionIfCurrent unregisters sess only while it still owns its ID.

--- a/session_test.go
+++ b/session_test.go
@@ -180,6 +180,35 @@ func TestSession_NewSessionWithoutRequest(t *testing.T) {
 	}
 }
 
+func TestSession_NewSessionAfterJawsClose(t *testing.T) {
+	jw, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	jw.Close()
+
+	rw := httptest.NewRecorder()
+	hr := httptest.NewRequest(http.MethodGet, "http://example.test/", nil)
+	if sess := jw.NewSession(rw, hr); sess != nil {
+		t.Fatalf("NewSession() after Close = %v, want nil", sess)
+	}
+	if cookies := rw.Result().Cookies(); len(cookies) != 0 {
+		t.Errorf("response cookies after Close = %v, want none", cookies)
+	}
+	if cookies := hr.Cookies(); len(cookies) != 0 {
+		t.Errorf("request cookies after Close = %v, want none", cookies)
+	}
+	if got := jw.SessionCount(); got != 0 {
+		t.Errorf("SessionCount() after Close = %d, want 0", got)
+	}
+	if sessions := jw.Sessions(); len(sessions) != 0 {
+		t.Errorf("Sessions() after Close = %v, want none", sessions)
+	}
+	if got := jw.GetSession(hr); got != nil {
+		t.Errorf("GetSession() after Close = %v, want nil", got)
+	}
+}
+
 func TestSession_NewSessionUnlocksAfterInjectedRandomReaderPanic(t *testing.T) {
 	jw, err := New()
 	if err != nil {
@@ -1749,6 +1778,13 @@ func TestSession_CloseDetachesRequestSession(t *testing.T) {
 	cookie := sess.Close()
 	if cookie == nil || cookie.MaxAge != -1 {
 		t.Fatalf("expected delete cookie, got %#v", cookie)
+	}
+	if got := sess.Get("foo"); got != "bar" {
+		t.Fatalf("Session.Get() after Session.Close = %v, want %q", got, "bar")
+	}
+	sess.Set("after", "close")
+	if got := sess.Get("after"); got != "close" {
+		t.Fatalf("Session.Set() after Session.Close stored %v, want %q", got, "close")
 	}
 	if got := rq.Session(); got != nil {
 		t.Fatalf("expected closed session to detach from request, got %v", got)


### PR DESCRIPTION
## Summary

- invalidate registered sessions and release their key/value data during `Jaws.Close`
- detach pending and running requests from sessions before shutdown returns
- prevent explicit and automatic session creation after shutdown begins
- preserve ordinary `Session.Close` data retention

## Verification

- `go generate ./...`
- `gofmt -l .`
- `gofumpt -l .`
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec ./...`
- `JAWS_REQUIRE_NODE=1 go test -race -coverprofile=coverage.out ./...`
- `JAWS_REQUIRE_NODE=1 go test ./...`
- `go test -race -tags debug -count=1 .`
- `go build ./...`
- `GOOS=linux GOARCH=386 CGO_ENABLED=0 go test -exec=/usr/bin/true ./lib/bind/... ./lib/ui/...`
- `go mod verify`
- `go mod tidy -diff`

Fixes #350
